### PR TITLE
RFC: inputUnion type

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -139,7 +139,7 @@ type __Type {
   # OBJECT only
   interfaces: [__Type!]
 
-  # INTERFACE and UNION only
+  # INTERFACE, UNION, and INPUT_UNION only
   possibleTypes: [__Type!]
 
   # ENUM only
@@ -182,6 +182,7 @@ enum __TypeKind {
   UNION
   ENUM
   INPUT_OBJECT
+  INPUT_UNION
   LIST
   NON_NULL
 }
@@ -268,6 +269,21 @@ Fields
   union. They must be object types.
 * All other fields must return {null}.
 
+#### Input Union
+
+Input Unions are an abstract type containing possible a list of possible valid
+input values. The possible inputs of an input union are explicitly listed out
+in `possibleTypes`. Input types can be made parts of input unions without
+modification of that type.
+
+Fields
+
+* `kind` must return `__TypeKind.INPUT_UNION`.
+* `name` must return a String.
+* `description` may return a String or {null}.
+* `possibleTypes` returns the list of types that can be represented within this
+  union. They must be input object types.
+* All other fields must return {null}.
 
 #### Interface
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1507,7 +1507,7 @@ query houseTrainedQuery($atOtherHomes: Boolean! = true) {
 
 **Explanatory Text**
 
-Variables can only be scalars, enums, input objects, or lists and non-null
+Variables can only be scalars, enums, input objects, input unions, or lists and non-null
 variants of those types. These are known as input types. Objects, unions,
 and interfaces cannot be used as inputs.
 
@@ -1516,8 +1516,13 @@ For these examples, consider the following typesystem additions:
 ```graphql example
 input ComplexInput { name: String, owner: String }
 
+input AlternateComplexInput { breed: String }
+
+inputUnion ComplexInputUnion = ComplexInput | AlternateComplexInput
+
 extend type QueryRoot {
   findDog(complex: ComplexInput): Dog
+  findDogs(complexUnion: ComplexInputUnion): [Dog]
   booleanList(booleanListArg: [Boolean!]): Boolean
 }
 ```
@@ -1539,6 +1544,12 @@ query takesComplexInput($complexInput: ComplexInput) {
 
 query TakesListOfBooleanBang($booleans: [Boolean!]) {
   booleanList(booleanListArg: $booleans)
+}
+
+query fulfillsComplexInputUnion($complexUnion: ComplexInputUnion) {
+  findDogs(complexUnion: $complexUnion) {
+    name
+  }
 }
 ```
 
@@ -1806,6 +1817,10 @@ an extraneous variable.
   * AreTypesCompatible({argumentType}, {variableType}, {hasDefault}):
     * If {hasDefault} is true, treat the {variableType} as non-null.
     * If inner type of {argumentType} and {variableType} are different, return false
+    * If {variableType} is an input union
+      * Let {inputName} be the value of the `__inputname` property of {argumentType}
+      * Let {possibleTypes} be a set of possible types of {variableType}
+      * If {inputName} is not a member of {possibleTypes}, return false
     * If {argumentType} and {variableType} have different list dimensions, return false
     * If any list level of {variableType} is not non-null, and the corresponding level
       in {argument} is non-null, the types are not compatible.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -528,8 +528,8 @@ ExecuteField(objectType, objectValue, fieldType, fields, variableValues):
 
 Fields may include arguments which are provided to the underlying runtime in
 order to correctly produce a value. These arguments are defined by the field in
-the type system to have a specific input type: Scalars, Enum, Input Object, or
-List or Non-Null wrapped variations of these three.
+the type system to have a specific input type: Scalars, Enum, Input Object, Input Union, or
+List or Non-Null wrapped variations of these four.
 
 At each argument position in a query may be a literal value or a variable to be
 provided at runtime.


### PR DESCRIPTION
Related graphql-js PR: graphql/graphql-js#1196

This is an RFC for a new type: `inputUnion`. 

An `inputUnion` is a union of one or more `input` types. It may be used in any location where an `input` is currently valid. When fulfilling an `inputUnion` an additional field `__inputname` must be specified in the map/object fulfilling the input, where the value of `__inputname` is the name of a single member of the `inputUnion` being fulfilled.

Example:

```graphql
input PostInput {
  title: String!
  body: String!
}
input ImageInput {
  photo: String!
  caption: String
}

inputUnion MediaBlock = PostInput | ImageInput

type Mutation {
   addContent(content: [MediaBlock]!): Post   
}

mutation AddContent($content: [MediaBlock]!) {
   addContent(content: $content) {
      id
   }
}
```

Valid `$content` value:

```
[
  {__inputname: "PostInput", title: "Hello", content: "World"},
  {__inputname: "ImageInput", photo: "http://graphql.org/img/logo.svg", caption: "Logo"}
]
```
Invalid Value Examples:
```
{__inputname: "PostInput", title: "Invalid, missing 'content'"}
```
```
{title: "Invalid, missing __inputname", content: "World"}
```
```
{
  __inputname: "PostInput", 
  title: "Invalid, photo is not defined on PostInput", 
  content: "World", 
  photo: "http://graphql.org/img/logo.svg"
}
```

### Checklist:

#### Are we solving a real problem.

Yes. Many of these problems or use cases are laid out in graphql/graphql-js#207 but to summarize:

When creating input objects, both in mutations and queries you face a tradeoff when creating complex input structs, with one of two options:

1. Enforce a well typed structure of the input via required fields `!`. Create multiple endpoints (mutation or query) utilizing these various strict, special case input types.
1. Loosen the input type requirements and rely on runtime/server-side validation to determine the intended uses.

This solution aims to offer a third path, where more complex combinations of strict input combinations may be utilized, while still keeping the input types fulfillment unambiguous via the `__inputname` field requirement.

#### Does this enable new use cases.

Yes. Many of the use cases are detailed in graphql/graphql-js#207. I think the biggest thing this unlocks is the list of heterogeneous inputs, which can be used to define an ordered set of instructions. This also reduces the need for many individual mutations while being able to maintain strictly typed inputs. In my experience tools like [apollo-codegen](https://github.com/apollographql/apollo-codegen) and [graphql-code-generator](https://github.com/dotansimha/graphql-code-generator) have proven invaluable in creating Flow/TypeScript definitions for validating queries. This change will work well in combination with those tools, making complex input semantics simpler to statically check.

#### How common is this use case.

Very common. This is the most commented issue in graphql-js, and I personally have run into the tradeoff of creating many highly restrictive mutations vs loosening them up and creating an ad-hoc server implementation. This sort of concept feels like the missing corollary to the expressiveness of the graphql Query execution (single "smart" entry point rather than many ad-hoc endpoints).

#### Can we enable it without a change to GraphQL.

No, at least not without pushing any type-checking semantics to the execution layer.

### Additional thoughts

What about `interfaces`? There are several comments in related tickets expressing a desire for interfaces in addition to input unions. While it sounds nice for symmetry with querying, I don't see these as being useful or necessary in practice at the input layer. Interfaces are most useful when you wish to query for a _generic partial representation_ of a more specific type. This same requirement does not exist for inputs and it is my opinion that `inputInterface` would not add enough additional value to justify its addition.

### Open questions:

- Is the use of `__inputname` a valid option based on spec (__ is reserved for introspection, not sure if we can mirror this for execution)
- Does `__inputname` make sense as the name for this?
