### PR TITLE
[RFC] "Directive order is significant" section

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1094,3 +1094,21 @@ and operations.
 
 As future versions of GraphQL adopt new configurable execution capabilities,
 they may be exposed via directives.
+
+**Directive order is significant**
+
+Directives may be provided in a specific syntactic order which may have semantic interpretation.
+
+These two type definitions may have different semantic meaning:
+
+```graphql example
+type Person @addExternalFields(source: "profiles") @excludeField(name: "photo") {
+  name: String
+}
+```
+
+```graphql example
+type Person @excludeField(name: "photo") @addExternalFields(source: "profiles") {
+  name: String
+}
+```


### PR DESCRIPTION
I would like to add a note on the directive ordering to make it more explicit. It is similar to the notes:

* [Argument are unordered. ](http://facebook.github.io/graphql/June2018/#example-7eba7)
* [Input object fields are unordered.](http://facebook.github.io/graphql/June2018/#example-09646)

But it instead states that directive order is significant and may have specific semantic interpretation.