### PR TITLE
[RFC] Limit uniqueness to `@skip`, `@include` and `@deprecated` directives

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -165,7 +165,6 @@ adds additional operation types, or additional directives to an existing schema.
 Schema extensions have the potential to be invalid if incorrectly defined.
 
 1. The Schema must already be defined.
-2. Any directives provided must not already apply to the original Schema.
 
 
 ## Descriptions
@@ -544,7 +543,6 @@ GraphQL tool or service which adds directives to an existing scalar.
 Scalar type extensions have the potential to be invalid if incorrectly defined.
 
 1. The named type must already be defined and must be a Scalar type.
-2. Any directives provided must not already apply to the original Scalar type.
 
 
 ## Objects
@@ -934,10 +932,9 @@ Object type extensions have the potential to be invalid if incorrectly defined.
    may share the same name.
 3. Any fields of an Object type extension must not be already defined on the
    original Object type.
-4. Any directives provided must not already apply to the original Object type.
-5. Any interfaces provided must not be already implemented by the original
+4. Any interfaces provided must not be already implemented by the original
    Object type.
-6. The resulting extended object type must be a super-set of all interfaces it
+5. The resulting extended object type must be a super-set of all interfaces it
    implements.
 
 
@@ -1116,7 +1113,6 @@ Interface type extensions have the potential to be invalid if incorrectly define
 4. Any Object type which implemented the original Interface type must also be a
    super-set of the fields of the Interface type extension (which may be due to
    Object type extension).
-5. Any directives provided must not already apply to the original Interface type.
 
 
 ## Unions
@@ -1239,7 +1235,6 @@ Union type extensions have the potential to be invalid if incorrectly defined.
 3. All member types of a Union type extension must be unique.
 4. All member types of a Union type extension must not already be a member of
    the original Union type.
-5. Any directives provided must not already apply to the original Union type.
 
 ## Enums
 
@@ -1308,7 +1303,6 @@ Enum type extensions have the potential to be invalid if incorrectly defined.
 2. All values of an Enum type extension must be unique.
 3. All values of an Enum type extension must not already be a value of
    the original Enum.
-4. Any directives provided must not already apply to the original Enum type.
 
 
 ## Input Objects
@@ -1437,7 +1431,6 @@ Input object type extensions have the potential to be invalid if incorrectly def
 3. All fields of an Input Object type extension must have unique names.
 4. All fields of an Input Object type extension must not already be a field of
    the original Input Object.
-5. Any directives provided must not already apply to the original Input Object type.
 
 
 ## List

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1435,13 +1435,13 @@ query @skip(if: $foo) {
 ```
 
 
-### @skip And @include Directives Are Unique Per Location
+### @skip, @include And @deprecated Directives Are Unique Per Location
 
 **Formal Specification**
 
   * For every {location} in the document for which Directives can apply:
     * Let {directives} be the set of Directives which apply to {location}.
-    * For each {directive} with name `"skip"` or `"include"` in {directives}:
+    * For each {directive} with name `"skip"`, `"include"` or `"deprecated"` in {directives}:
       * Let {directiveName} be the name of {directive}.
       * Let {namedDirectives} be the set of all Directives named {directiveName}
         in {directives}.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1435,13 +1435,13 @@ query @skip(if: $foo) {
 ```
 
 
-### Directives Are Unique Per Location
+### @skip And @include Directives Are Unique Per Location
 
 **Formal Specification**
 
   * For every {location} in the document for which Directives can apply:
     * Let {directives} be the set of Directives which apply to {location}.
-    * For each {directive} in {directives}:
+    * For each {directive} with name `"skip"` or `"include"` in {directives}:
       * Let {directiveName} be the name of {directive}.
       * Let {namedDirectives} be the set of all Directives named {directiveName}
         in {directives}.


### PR DESCRIPTION
This proposal directly relates to a discussion in https://github.com/facebook/graphql/issues/429. As was discussed at the latest WG meeting, I'm creating several alternative proposals. This one implements [proposed solution](https://github.com/facebook/graphql/issues/429#issuecomment-392946579) `3. Limit the validation to only @skip and @include directives`.

It limits the scope of "Directives Are Unique Per Location" to `@skip` and `@include` directives only.

This proposal is mutually exclusive with other alternative proposals:

* [RFC] Limit uniqueness to `@skip`, `@include` and `@deprecated` directives (#471, this one)
* [RFC] Limit directive uniqueness to explicitly marked directives (#472)

@leebyron @IvanGoncharov @jjergus I would appreciate your reviews.

Closes #429