### PR TITLE
[RFC] Repeatable directives

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -278,7 +278,7 @@ InputObjectTypeExtension :
   - extend input Name Directives[Const]? InputFieldsDefinition
   - extend input Name Directives[Const]
 
-DirectiveDefinition : Description? directive @ Name ArgumentsDefinition? on DirectiveLocations
+DirectiveDefinition : Description? `unique`? directive @ Name ArgumentsDefinition? on DirectiveLocations
 
 DirectiveLocations :
   - `|`? DirectiveLocation

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -278,7 +278,7 @@ InputObjectTypeExtension :
   - extend input Name Directives[Const]? InputFieldsDefinition
   - extend input Name Directives[Const]
 
-DirectiveDefinition : Description? `unique`? directive @ Name ArgumentsDefinition? on DirectiveLocations
+DirectiveDefinition : Description? directive @ Name ArgumentsDefinition? `repeatable`? on DirectiveLocations
 
 DirectiveLocations :
   - `|`? DirectiveLocation

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1663,7 +1663,13 @@ fragment SomeFragment on SomeType {
 Directive may be defined as repeatable per location with the `repeatable` keyword:
 
 ```graphql example
-directive @example repeatable on OBJECT | INTERFACE
+directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
+
+type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
+  id: ID!
+}
+
+extend type Book @delegateField(name: "index")
 ```
 
 Directive locations may be defined with an optional leading `|` character to aid

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -165,7 +165,7 @@ adds additional operation types, or additional directives to an existing schema.
 Schema extensions have the potential to be invalid if incorrectly defined.
 
 1. The Schema must already be defined.
-2. Any unique directives provided must not already apply to the original Schema.
+2. Any non-`repeatable` directives provided must not already apply to the original Schema.
 
 
 ## Descriptions
@@ -544,7 +544,7 @@ GraphQL tool or service which adds directives to an existing scalar.
 Scalar type extensions have the potential to be invalid if incorrectly defined.
 
 1. The named type must already be defined and must be a Scalar type.
-2. Any unique directives provided must not already apply to the original Scalar type.
+2. Any non-`repeatable` directives provided must not already apply to the original Scalar type.
 
 
 ## Objects
@@ -934,7 +934,7 @@ Object type extensions have the potential to be invalid if incorrectly defined.
    may share the same name.
 3. Any fields of an Object type extension must not be already defined on the
    original Object type.
-4. Any unique directives provided must not already apply to the original Object type.
+4. Any non-`repeatable` directives provided must not already apply to the original Object type.
 5. Any interfaces provided must not be already implemented by the original
    Object type.
 6. The resulting extended object type must be a super-set of all interfaces it
@@ -1116,7 +1116,7 @@ Interface type extensions have the potential to be invalid if incorrectly define
 4. Any Object type which implemented the original Interface type must also be a
    super-set of the fields of the Interface type extension (which may be due to
    Object type extension).
-5. Any unique directives provided must not already apply to the original Interface type.
+5. Any non-`repeatable` directives provided must not already apply to the original Interface type.
 
 
 ## Unions
@@ -1239,7 +1239,7 @@ Union type extensions have the potential to be invalid if incorrectly defined.
 3. All member types of a Union type extension must be unique.
 4. All member types of a Union type extension must not already be a member of
    the original Union type.
-5. Any unique directives provided must not already apply to the original Union type.
+5. Any non-`repeatable` directives provided must not already apply to the original Union type.
 
 ## Enums
 
@@ -1308,7 +1308,7 @@ Enum type extensions have the potential to be invalid if incorrectly defined.
 2. All values of an Enum type extension must be unique.
 3. All values of an Enum type extension must not already be a value of
    the original Enum.
-4. Any unique directives provided must not already apply to the original Enum type.
+4. Any non-`repeatable` directives provided must not already apply to the original Enum type.
 
 
 ## Input Objects
@@ -1437,7 +1437,7 @@ Input object type extensions have the potential to be invalid if incorrectly def
 3. All fields of an Input Object type extension must have unique names.
 4. All fields of an Input Object type extension must not already be a field of
    the original Input Object.
-5. Any unique directives provided must not already apply to the original Input Object type.
+5. Any non-`repeatable` directives provided must not already apply to the original Input Object type.
 
 
 ## List
@@ -1606,7 +1606,7 @@ Expected Type | Internal Value   | Coerced Result
 
 ## Directives
 
-DirectiveDefinition : Description? `unique`? directive @ Name ArgumentsDefinition? on DirectiveLocations
+DirectiveDefinition : Description? directive @ Name ArgumentsDefinition? `repeatable`? on DirectiveLocations
 
 DirectiveLocations :
   - `|`? DirectiveLocation
@@ -1660,10 +1660,10 @@ fragment SomeFragment on SomeType {
 }
 ```
 
-Directive may be defined as unique per location with the `unique` keyword:
+Directive may be defined as repeatable per location with the `repeatable` keyword:
 
 ```graphql example
-unique directive @example on OBJECT | INTERFACE
+directive @example repeatable on OBJECT | INTERFACE
 ```
 
 Directive locations may be defined with an optional leading `|` character to aid
@@ -1715,7 +1715,7 @@ directive @invalidExample(arg: String @invalidExample) on ARGUMENT_DEFINITION
 ### @skip
 
 ```graphql
-unique directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 ```
 
 The `@skip` directive may be provided for fields, fragment spreads, and
@@ -1735,7 +1735,7 @@ query myQuery($someTest: Boolean) {
 ### @include
 
 ```graphql
-unique directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 ```
 
 The `@include` directive may be provided for fields, fragment spreads, and
@@ -1762,7 +1762,7 @@ must *not* be queried if either the `@skip` condition is true *or* the
 ### @deprecated
 
 ```graphql
-unique directive @deprecated(
+directive @deprecated(
   reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ENUM_VALUE
 ```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1660,7 +1660,10 @@ fragment SomeFragment on SomeType {
 }
 ```
 
-Directive may be defined as repeatable per location with the `repeatable` keyword:
+A directive may be defined as repeatable per location with the `repeatable` keyword. 
+Repeatable directives often useful when the same directive should be used with 
+different arguments at the one location, especially in cases where additional information 
+need to be provided in a form of directive via a type or a schema extension:
 
 ```graphql example
 directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -165,7 +165,8 @@ adds additional operation types, or additional directives to an existing schema.
 Schema extensions have the potential to be invalid if incorrectly defined.
 
 1. The Schema must already be defined.
-2. Any non-`repeatable` directives provided must not already apply to the original Schema.
+2. Any non-repeatable directives provided must not already apply to the
+   original Schema.
 
 
 ## Descriptions
@@ -544,7 +545,8 @@ GraphQL tool or service which adds directives to an existing scalar.
 Scalar type extensions have the potential to be invalid if incorrectly defined.
 
 1. The named type must already be defined and must be a Scalar type.
-2. Any non-`repeatable` directives provided must not already apply to the original Scalar type.
+2. Any non-repeatable directives provided must not already apply to the
+   original Scalar type.
 
 
 ## Objects
@@ -934,7 +936,8 @@ Object type extensions have the potential to be invalid if incorrectly defined.
    may share the same name.
 3. Any fields of an Object type extension must not be already defined on the
    original Object type.
-4. Any non-`repeatable` directives provided must not already apply to the original Object type.
+4. Any non-repeatable directives provided must not already apply to the
+   original Object type.
 5. Any interfaces provided must not be already implemented by the original
    Object type.
 6. The resulting extended object type must be a super-set of all interfaces it
@@ -1116,7 +1119,8 @@ Interface type extensions have the potential to be invalid if incorrectly define
 4. Any Object type which implemented the original Interface type must also be a
    super-set of the fields of the Interface type extension (which may be due to
    Object type extension).
-5. Any non-`repeatable` directives provided must not already apply to the original Interface type.
+5. Any non-repeatable directives provided must not already apply to the
+   original Interface type.
 
 
 ## Unions
@@ -1239,7 +1243,8 @@ Union type extensions have the potential to be invalid if incorrectly defined.
 3. All member types of a Union type extension must be unique.
 4. All member types of a Union type extension must not already be a member of
    the original Union type.
-5. Any non-`repeatable` directives provided must not already apply to the original Union type.
+5. Any non-repeatable directives provided must not already apply to the
+   original Union type.
 
 ## Enums
 
@@ -1308,7 +1313,8 @@ Enum type extensions have the potential to be invalid if incorrectly defined.
 2. All values of an Enum type extension must be unique.
 3. All values of an Enum type extension must not already be a value of
    the original Enum.
-4. Any non-`repeatable` directives provided must not already apply to the original Enum type.
+4. Any non-repeatable directives provided must not already apply to the
+   original Enum type.
 
 
 ## Input Objects
@@ -1437,7 +1443,8 @@ Input object type extensions have the potential to be invalid if incorrectly def
 3. All fields of an Input Object type extension must have unique names.
 4. All fields of an Input Object type extension must not already be a field of
    the original Input Object.
-5. Any non-`repeatable` directives provided must not already apply to the original Input Object type.
+5. Any non-repeatable directives provided must not already apply to the
+   original Input Object type.
 
 
 ## List
@@ -1660,21 +1667,6 @@ fragment SomeFragment on SomeType {
 }
 ```
 
-A directive may be defined as repeatable at any permitted location with the `repeatable`
-keyword. Repeatable directives are often useful when the same directive should be used with
-different arguments at a single location, especially in cases where additional information
-needs to be provided to a type or schema extension via a directive:
-
-```graphql example
-directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
-
-type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
-  id: ID!
-}
-
-extend type Book @delegateField(name: "index")
-```
-
 Directive locations may be defined with an optional leading `|` character to aid
 formatting when representing a longer list of possible locations:
 
@@ -1700,11 +1692,30 @@ type SomeType {
 }
 ```
 
+A directive may be defined as repeatable by including the "repeatable" keyword.
+Repeatable directives are often useful when the same directive should be used
+with different arguments at a single location, especially in cases where
+additional information needs to be provided to a type or schema extension via
+a directive:
+
+```graphql example
+directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE
+
+type Book @delegateField(name: "pageCount") @delegateField(name: "author") {
+  id: ID!
+}
+
+extend type Book @delegateField(name: "index")
+```
+
 While defining a directive, it must not reference itself directly or indirectly:
 
 ```graphql counter-example
 directive @invalidExample(arg: String @invalidExample) on ARGUMENT_DEFINITION
 ```
+
+Note: The order in which directives appear may be significant, including
+repeatable directives.
 
 **Validation**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1660,8 +1660,8 @@ fragment SomeFragment on SomeType {
 }
 ```
 
-A directive may be defined as repeatable per location with the `repeatable` keyword. 
-Repeatable directives often useful when the same directive should be used with 
+A directive may be defined as repeatable at any permitted location with the `repeatable` 
+keyword. Repeatable directives often useful when the same directive should be used with 
 different arguments at the one location, especially in cases where additional information 
 need to be provided in a form of directive via a type or a schema extension:
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1715,7 +1715,7 @@ directive @invalidExample(arg: String @invalidExample) on ARGUMENT_DEFINITION
 ### @skip
 
 ```graphql
-directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+unique directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 ```
 
 The `@skip` directive may be provided for fields, fragment spreads, and
@@ -1735,7 +1735,7 @@ query myQuery($someTest: Boolean) {
 ### @include
 
 ```graphql
-directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+unique directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 ```
 
 The `@include` directive may be provided for fields, fragment spreads, and
@@ -1762,7 +1762,7 @@ must *not* be queried if either the `@skip` condition is true *or* the
 ### @deprecated
 
 ```graphql
-directive @deprecated(
+unique directive @deprecated(
   reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ENUM_VALUE
 ```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -165,7 +165,7 @@ adds additional operation types, or additional directives to an existing schema.
 Schema extensions have the potential to be invalid if incorrectly defined.
 
 1. The Schema must already be defined.
-2. Any directives provided must not already apply to the original Schema.
+2. Any unique directives provided must not already apply to the original Schema.
 
 
 ## Descriptions
@@ -544,7 +544,7 @@ GraphQL tool or service which adds directives to an existing scalar.
 Scalar type extensions have the potential to be invalid if incorrectly defined.
 
 1. The named type must already be defined and must be a Scalar type.
-2. Any directives provided must not already apply to the original Scalar type.
+2. Any unique directives provided must not already apply to the original Scalar type.
 
 
 ## Objects
@@ -934,7 +934,7 @@ Object type extensions have the potential to be invalid if incorrectly defined.
    may share the same name.
 3. Any fields of an Object type extension must not be already defined on the
    original Object type.
-4. Any directives provided must not already apply to the original Object type.
+4. Any unique directives provided must not already apply to the original Object type.
 5. Any interfaces provided must not be already implemented by the original
    Object type.
 6. The resulting extended object type must be a super-set of all interfaces it
@@ -1116,7 +1116,7 @@ Interface type extensions have the potential to be invalid if incorrectly define
 4. Any Object type which implemented the original Interface type must also be a
    super-set of the fields of the Interface type extension (which may be due to
    Object type extension).
-5. Any directives provided must not already apply to the original Interface type.
+5. Any unique directives provided must not already apply to the original Interface type.
 
 
 ## Unions
@@ -1239,7 +1239,7 @@ Union type extensions have the potential to be invalid if incorrectly defined.
 3. All member types of a Union type extension must be unique.
 4. All member types of a Union type extension must not already be a member of
    the original Union type.
-5. Any directives provided must not already apply to the original Union type.
+5. Any unique directives provided must not already apply to the original Union type.
 
 ## Enums
 
@@ -1308,7 +1308,7 @@ Enum type extensions have the potential to be invalid if incorrectly defined.
 2. All values of an Enum type extension must be unique.
 3. All values of an Enum type extension must not already be a value of
    the original Enum.
-4. Any directives provided must not already apply to the original Enum type.
+4. Any unique directives provided must not already apply to the original Enum type.
 
 
 ## Input Objects
@@ -1437,7 +1437,7 @@ Input object type extensions have the potential to be invalid if incorrectly def
 3. All fields of an Input Object type extension must have unique names.
 4. All fields of an Input Object type extension must not already be a field of
    the original Input Object.
-5. Any directives provided must not already apply to the original Input Object type.
+5. Any unique directives provided must not already apply to the original Input Object type.
 
 
 ## List
@@ -1606,7 +1606,7 @@ Expected Type | Internal Value   | Coerced Result
 
 ## Directives
 
-DirectiveDefinition : Description? directive @ Name ArgumentsDefinition? on DirectiveLocations
+DirectiveDefinition : Description? `unique`? directive @ Name ArgumentsDefinition? on DirectiveLocations
 
 DirectiveLocations :
   - `|`? DirectiveLocation
@@ -1658,6 +1658,12 @@ directive @example on FIELD
 fragment SomeFragment on SomeType {
   field @example
 }
+```
+
+Directive may be defined as unique per location with the `unique` keyword:
+
+```graphql example
+unique directive @example on OBJECT | INTERFACE
 ```
 
 Directive locations may be defined with an optional leading `|` character to aid

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1660,10 +1660,10 @@ fragment SomeFragment on SomeType {
 }
 ```
 
-A directive may be defined as repeatable at any permitted location with the `repeatable` 
-keyword. Repeatable directives often useful when the same directive should be used with 
-different arguments at the one location, especially in cases where additional information 
-need to be provided in a form of directive via a type or a schema extension:
+A directive may be defined as repeatable at any permitted location with the `repeatable`
+keyword. Repeatable directives are often useful when the same directive should be used with
+different arguments at a single location, especially in cases where additional information
+needs to be provided to a type or schema extension via a directive:
 
 ```graphql example
 directive @delegateField(name: String!) repeatable on OBJECT | INTERFACE

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -187,6 +187,7 @@ type __Directive {
   description: String
   locations: [__DirectiveLocation!]!
   args: [__InputValue!]!
+  unique: Boolean!
 }
 
 enum __DirectiveLocation {
@@ -417,3 +418,4 @@ Fields
   locations this directive may be placed.
 * `args` returns a List of `__InputValue` representing the arguments this
   directive accepts.
+* `unique` must return a Boolean which identifies the directive as unique per location.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -187,7 +187,7 @@ type __Directive {
   description: String
   locations: [__DirectiveLocation!]!
   args: [__InputValue!]!
-  unique: Boolean!
+  isRepeatable: Boolean!
 }
 
 enum __DirectiveLocation {
@@ -418,4 +418,4 @@ Fields
   locations this directive may be placed.
 * `args` returns a List of `__InputValue` representing the arguments this
   directive accepts.
-* `repeatable` must return a Boolean which permits using the directive multiple times at the same location.
+* `isRepeatable` must return a Boolean which permits using the directive multiple times at the same location.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -418,4 +418,4 @@ Fields
   locations this directive may be placed.
 * `args` returns a List of `__InputValue` representing the arguments this
   directive accepts.
-* `isRepeatable` must return a Boolean which permits using the directive multiple times at the same location.
+* `isRepeatable` must return a Boolean that indicates if the directive may be used repeatedly at a single location.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -418,4 +418,5 @@ Fields
   locations this directive may be placed.
 * `args` returns a List of `__InputValue` representing the arguments this
   directive accepts.
-* `isRepeatable` must return a Boolean that indicates if the directive may be used repeatedly at a single location.
+* `isRepeatable` must return a Boolean that indicates if the directive may be
+  used repeatedly at a single location.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -418,4 +418,4 @@ Fields
   locations this directive may be placed.
 * `args` returns a List of `__InputValue` representing the arguments this
   directive accepts.
-* `unique` must return a Boolean which identifies the directive as unique per location.
+* `repeatable` must return a Boolean which permits using the directive multiple times at the same location.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1440,7 +1440,7 @@ query @skip(if: $foo) {
 **Formal Specification**
 
   * For every {location} in the document for which Directives can apply:
-    * Let {directives} be the set of Directives which apply to {location}.
+    * Let {directives} be the set of Directives which apply to {location} and marked as `unique`.
     * For each {directive} in {directives}:
       * Let {directiveName} be the name of {directive}.
       * Let {namedDirectives} be the set of all Directives named {directiveName}

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1440,7 +1440,7 @@ query @skip(if: $foo) {
 **Formal Specification**
 
   * For every {location} in the document for which Directives can apply:
-    * Let {directives} be the set of Directives which apply to {location} and marked as `unique`.
+    * Let {directives} be the set of Directives which apply to {location} and not marked as `repeatable`.
     * For each {directive} in {directives}:
       * Let {directiveName} be the name of {directive}.
       * Let {namedDirectives} be the set of all Directives named {directiveName}

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1440,7 +1440,7 @@ query @skip(if: $foo) {
 **Formal Specification**
 
   * For every {location} in the document for which Directives can apply:
-    * Let {directives} be the set of Directives which apply to {location} and not marked as `repeatable`.
+    * Let {directives} be the set of Directives which apply to {location} and are not `repeatable`.
     * For each {directive} in {directives}:
       * Let {directiveName} be the name of {directive}.
       * Let {namedDirectives} be the set of all Directives named {directiveName}

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1440,7 +1440,8 @@ query @skip(if: $foo) {
 **Formal Specification**
 
   * For every {location} in the document for which Directives can apply:
-    * Let {directives} be the set of Directives which apply to {location} and are not `repeatable`.
+    * Let {directives} be the set of Directives which apply to {location} and
+      are not repeatable.
     * For each {directive} in {directives}:
       * Let {directiveName} be the name of {directive}.
       * Let {namedDirectives} be the set of all Directives named {directiveName}


### PR DESCRIPTION
This proposal directly relates to a discussion in https://github.com/facebook/graphql/issues/429. As was discussed at the latest WG meeting, I'm creating several alternative proposals. This one implements [proposed solution](https://github.com/facebook/graphql/issues/429#issuecomment-392946579) `4. Limit the validation to only these directives that are explicitly marked as "unique". This implies that we need to introduce a new option in the directive definition`.

It limits the scope of "Directives Are Unique Per Location" to directives that are explicitly marked as `unique`.

This proposal is mutually exclusive with other alternative proposals:

* [RFC] Limit uniqueness to `@skip`, `@include` and `@deprecated` directives (#471)
* [RFC] Limit directive uniqueness to explicitly marked directives (#472, this one)

@leebyron @IvanGoncharov @jjergus I would appreciate your reviews.

Closes #429
Closes #471