### PR TITLE
[RFC] Allow singular variables in list locations

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1857,7 +1857,10 @@ AreTypesCompatible(variableType, locationType):
     * Let {nullableVariableType} be the nullable type of {variableType}.
     * Return {AreTypesCompatible(nullableVariableType, locationType)}.
   * Otherwise, if {locationType} is a list type:
-    * If {variableType} is NOT a list type, return {false}.
+    * If {variableType} is NOT a list type:
+      * Let {itemLocationType} be the unwrapped item type of {locationType}.
+      * Let {nullableItemLocationType} be the unwrapped nullable type of {itemLocationType} if {itemLocationType} is non-null, or {itemLocationType} if {itemLocationType} is nullable.
+      * Return {AreTypesCompatible(variableType, nullableItemLocationType)}.
     * Let {itemLocationType} be the unwrapped item type of {locationType}.
     * Let {itemVariableType} be the unwrapped item type of {variableType}.
     * Return {AreTypesCompatible(itemVariableType, itemLocationType)}.
@@ -1884,13 +1887,24 @@ query intCannotGoIntoBoolean($intArg: Int) {
 
 ${intArg} typed as {Int} cannot be used as a argument to {booleanArg}, typed as {Boolean}.
 
-List cardinality must also be the same. For example, lists cannot be passed into singular
+List cardinality must be compatible. For example, lists cannot be passed into singular
 values.
 
 ```graphql counter-example
 query booleanListCannotGoIntoBoolean($booleanListArg: [Boolean]) {
   arguments {
     booleanArgField(booleanArg: $booleanListArg)
+  }
+}
+```
+
+However, for consistency with type coercion, singular values can be passed into lists,
+including nullable singular values for nullable lists of non-nullable values.
+
+```graphql example
+query booleanCanGoIntoBooleanList($booleanArg: Boolean!) {
+  arguments {
+    booleanListArgField(booleanListArg: $booleanArg)
   }
 }
 ```

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -28,13 +28,12 @@ request is determined by the result of executing this operation according to the
 ExecuteRequest(schema, document, operationName, variableValues, initialValue):
 
   * Let {operation} be the result of {GetOperation(document, operationName)}.
-  * Let {coercedVariableValues} be the result of {CoerceVariableValues(schema, operation, variableValues)}.
   * If {operation} is a query operation:
-    * Return {ExecuteQuery(operation, schema, coercedVariableValues, initialValue)}.
+    * Return {ExecuteQuery(operation, schema, variableValues, initialValue)}.
   * Otherwise if {operation} is a mutation operation:
-    * Return {ExecuteMutation(operation, schema, coercedVariableValues, initialValue)}.
+    * Return {ExecuteMutation(operation, schema, variableValues, initialValue)}.
   * Otherwise if {operation} is a subscription operation:
-    * Return {Subscribe(operation, schema, coercedVariableValues, initialValue)}.
+    * Return {Subscribe(operation, schema, variableValues, initialValue)}.
 
 GetOperation(document, operationName):
 
@@ -65,48 +64,6 @@ not changed.
 For example: the request may be validated during development, provided it does
 not later change, or a service may validate a request once and memoize the
 result to avoid validating the same request again in the future.
-
-
-### Coercing Variable Values
-
-If the operation has defined any variables, then the values for
-those variables need to be coerced using the input coercion rules
-of variable's declared type. If a query error is encountered during
-input coercion of variable values, then the operation fails without
-execution.
-
-CoerceVariableValues(schema, operation, variableValues):
-
-  * Let {coercedValues} be an empty unordered Map.
-  * Let {variableDefinitions} be the variables defined by {operation}.
-  * For each {variableDefinition} in {variableDefinitions}:
-    * Let {variableName} be the name of {variableDefinition}.
-    * Let {variableType} be the expected type of {variableDefinition}.
-    * Assert: {IsInputType(variableType)} must be {true}.
-    * Let {defaultValue} be the default value for {variableDefinition}.
-    * Let {hasValue} be {true} if {variableValues} provides a value for the
-      name {variableName}.
-    * Let {value} be the value provided in {variableValues} for the
-      name {variableName}.
-    * If {hasValue} is not {true} and {defaultValue} exists (including {null}):
-      * Add an entry to {coercedValues} named {variableName} with the
-        value {defaultValue}.
-    * Otherwise if {variableType} is a Non-Nullable type, and either {hasValue}
-      is not {true} or {value} is {null}, throw a query error.
-    * Otherwise if {hasValue} is true:
-      * If {value} is {null}:
-        * Add an entry to {coercedValues} named {variableName} with the
-          value {null}.
-      * Otherwise:
-        * If {value} cannot be coerced according to the input coercion
-          rules of {variableType}, throw a query error.
-        * Let {coercedValue} be the result of coercing {value} according to the
-          input coercion rules of {variableType}.
-        * Add an entry to {coercedValues} named {variableName} with the
-          value {coercedValue}.
-  * Return {coercedValues}.
-
-Note: This algorithm is very similar to {CoerceArgumentValues()}.
 
 
 ## Executing Operations
@@ -591,9 +548,6 @@ CoerceArgumentValues(objectType, field, variableValues):
       * If {value} is {null}:
         * Add an entry to {coercedValues} named {argumentName} with the
           value {null}.
-      * Otherwise, if {argumentValue} is a {Variable}:
-        * Add an entry to {coercedValues} named {argumentName} with the
-          value {value}.
       * Otherwise:
         * If {value} cannot be coerced according to the input coercion
             rules of {variableType}, throw a field error.
@@ -602,10 +556,6 @@ CoerceArgumentValues(objectType, field, variableValues):
         * Add an entry to {coercedValues} named {argumentName} with the
           value {coercedValue}.
   * Return {coercedValues}.
-
-Note: Variable values are not coerced because they are expected to be coerced
-before executing the operation in {CoerceVariableValues()}, and valid queries
-must only allow usage of variables of appropriate types.
 
 
 ### Value Resolution


### PR DESCRIPTION
This is a follow-up to discussion in https://github.com/graphql/graphql-relay-js/issues/20#issuecomment-416809871.

The current coercion rules, for convenience, allow passing in singular literals in positions expecting lists. However, they do not allow passing in singular variables.

This proposal would allow passing in singular variables as well. The coercion rules already ensure reasonable behavior when this happens. Enabling this allows easier evolution of APIs, as it would enable converting singular filtering/ordering fields per the linked issues to plural ones without breaking clients.

cc @dschafer 