### PR TITLE
fix list coercion examples

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1489,8 +1489,9 @@ Expected Type | Provided Value   | Coerced Value
 `[Int]`       | `[1, "b", true]` | Error: Incorrect item value
 `[Int]`       | `1`              | `[1]`
 `[Int]`       | `null`           | `null`
-`[[Int]]`     | `[[1], [2, 3]]`  | `[[1], [2, 3]`
-`[[Int]]`     | `[1, 2, 3]`      | Error: Incorrect item value
+`[[Int]]`     | `[[1], [2, 3]]`  | `[[1], [2, 3]]`
+`[[Int]]`     | `[1, 2, 3]`      | `[[1], [2], [3]]`
+`[[Int]]`     | `[1, null, 3]`   | `[[1], null, [3]]`
 `[[Int]]`     | `1`              | `[[1]]`
 `[[Int]]`     | `null`           | `null`
 


### PR DESCRIPTION
I believe this example is inconsistent with this part of the spec:

> If the value passed as an input to a list type is not a list and not the null value, then the result of input coercion is a list of size one, where the single item value is the result of input coercion for the list’s item type on the provided value (note this may apply recursively for nested lists).

Specifically the part about how "this may apply recursively for nested lists" is applicable here.