### PR TITLE
Fix ambiguity about optional variables in non-null args

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1938,9 +1938,9 @@ A notable exception to typical variable type compatibility is allowing a
 variable definition with a nullable type to be provided to a non-null location
 as long as either that variable or that location provides a default value.
 
-In the example below, an optional variable is allowed to be used in an 
-non-null optional argument (`optionalBooleanArg`) because it provides a default 
-value (`false`).
+In the example below, an optional variable `$booleanArg` is allowed to be used
+in the non-null argument `optionalBooleanArg` because the field argument is
+optional since it provides a default value in the schema.
 
 ```graphql example
 query booleanArgQueryWithDefault($booleanArg: Boolean) {
@@ -1950,11 +1950,12 @@ query booleanArgQueryWithDefault($booleanArg: Boolean) {
 }
 ```
 
-In the example below, an optional variable (`$booleanArg`) provides a default 
-value (`true`) and can be used in a non-null requied argument. This behavior is 
-explicitly supported for compatibility with earlier editions of this 
-specification. GraphQL authoring tools may wish to report this is a warning with 
-the suggestion to replace `Boolean` with `Boolean!` to avoid ambiguity.
+In the example below, an optional variable `$booleanArg` is allowed to be used
+in the non-null argument (`nonNullBooleanArg`) because the variable provides
+a default value in the query. This behavior is explicitly supported for
+compatibility with earlier editions of this specification. GraphQL authoring
+tools may wish to report this is a warning with the suggestion to replace
+`Boolean` with `Boolean!` to avoid ambiguity.
 
 ```graphql example
 query booleanArgQueryWithDefault($booleanArg: Boolean = true) {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1938,6 +1938,10 @@ A notable exception to typical variable type compatibility is allowing a
 variable definition with a nullable type to be provided to a non-null location
 as long as either that variable or that location provides a default value.
 
+In the example below, an optional variable is allowed to be used in an 
+non-null optional argument (`optionalBooleanArg`) because it provides a default 
+value (`false`).
+
 ```graphql example
 query booleanArgQueryWithDefault($booleanArg: Boolean) {
   arguments {
@@ -1946,7 +1950,11 @@ query booleanArgQueryWithDefault($booleanArg: Boolean) {
 }
 ```
 
-In the example above, an optional variable is allowed to be used in an non-null argument which provides a default value.
+In the example below, an optional variable (`$booleanArg`) provides a default 
+value (`true`) and can be used in a non-null requied argument. This behavior is 
+explicitly supported for compatibility with earlier editions of this 
+specification. GraphQL authoring tools may wish to report this is a warning with 
+the suggestion to replace `Boolean` with `Boolean!` to avoid ambiguity.
 
 ```graphql example
 query booleanArgQueryWithDefault($booleanArg: Boolean = true) {
@@ -1955,11 +1963,6 @@ query booleanArgQueryWithDefault($booleanArg: Boolean = true) {
   }
 }
 ```
-
-In the example above, a variable provides a default value and can be used in a
-non-null argument. This behavior is explicitly supported for compatibility with
-earlier editions of this specification. GraphQL authoring tools may wish to
-report this is a warning with the suggestion to replace `Boolean` with `Boolean!`.
 
 Note: The value {null} could still be provided to a such a variable at runtime.
 A non-null argument must produce a field error if provided a {null} value.


### PR DESCRIPTION
"Allowing optional variables when default values exist" wasn't very clear about what elements of the example were being referred to as optional/required or non-nullable. This minor rewrite attempts to resolve that ambiguity

Fixes #507