### PR TITLE
Fix typo in schema definition grammar productions.

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -200,7 +200,7 @@ SchemaExtension :
   - extend schema Directives[Const]? { OperationTypeDefinition+ }
   - extend schema Directives[Const]
 
-OperationTypeDefinition : OperationType : NamedType
+RootOperationTypeDefinition : OperationType : NamedType
 
 Description : StringValue
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -153,7 +153,7 @@ type Query {
 ### Schema Extension
 
 SchemaExtension :
-  - extend schema Directives[Const]? { OperationTypeDefinition+ }
+  - extend schema Directives[Const]? { RootOperationTypeDefinition+ }
   - extend schema Directives[Const]
 
 Schema extensions are used to represent a schema which has been extended from


### PR DESCRIPTION
The Schema section refers to and defines RootOperationTypeDefinition.
This production is missing in the appendix.

The SchemaExtension section refers to OperationTypeDefinition.
This production is not defined anywhere except in the appendix.

The two productions are identical. They are meant to be the same thing.