### PR TITLE
Editorial: Make grammar recursion more clear

### DIFF
--- a/spec/Appendix A -- Notation Conventions.md
+++ b/spec/Appendix A -- Notation Conventions.md
@@ -40,8 +40,8 @@ A definition may refer to itself, which describes repetitive sequences,
 for example:
 
 ListOfLetterA :
-  - `a`
   - ListOfLetterA `a`
+  - `a`
 
 
 ## Lexical and Syntactical Grammar
@@ -108,11 +108,11 @@ Sentence : Noun Verb Adverb?
 is shorthand for
 
 Sentence :
-  - Noun Verb
   - Noun Verb Adverb
+  - Noun Verb
 
-A subscript suffix "{Symbol+}" is shorthand for a list of
-one or more of that symbol.
+A subscript suffix "{Symbol+}" is shorthand for a list of one or more of that
+symbol, represented as an additional recursive production.
 
 As an example:
 
@@ -123,8 +123,8 @@ is shorthand for
 Book : Cover Page_list Cover
 
 Page_list :
-  - Page
   - Page_list Page
+  - Page
 
 
 **Parameterized Grammar Productions**

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -233,8 +233,8 @@ ObjectTypeExtension :
   - extend type Name ImplementsInterfaces
 
 ImplementsInterfaces :
-  - implements `&`? NamedType
   - ImplementsInterfaces & NamedType
+  - implements `&`? NamedType
 
 FieldsDefinition : { FieldDefinition+ }
 
@@ -253,8 +253,8 @@ InterfaceTypeExtension :
 UnionTypeDefinition : Description? union Name Directives[Const]? UnionMemberTypes?
 
 UnionMemberTypes :
-  - = `|`? NamedType
   - UnionMemberTypes | NamedType
+  - = `|`? NamedType
 
 UnionTypeExtension :
   - extend union Name Directives[Const]? UnionMemberTypes
@@ -281,8 +281,8 @@ InputObjectTypeExtension :
 DirectiveDefinition : Description? directive @ Name ArgumentsDefinition? on DirectiveLocations
 
 DirectiveLocations :
-  - `|`? DirectiveLocation
   - DirectiveLocations | DirectiveLocation
+  - `|`? DirectiveLocation
 
 DirectiveLocation :
   - ExecutableDirectiveLocation

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -553,8 +553,8 @@ Scalar type extensions have the potential to be invalid if incorrectly defined.
 ObjectTypeDefinition : Description? type Name ImplementsInterfaces? Directives[Const]? FieldsDefinition?
 
 ImplementsInterfaces :
-  - implements `&`? NamedType
   - ImplementsInterfaces & NamedType
+  - implements `&`? NamedType
 
 FieldsDefinition : { FieldDefinition+ }
 
@@ -1125,8 +1125,8 @@ Interface type extensions have the potential to be invalid if incorrectly define
 UnionTypeDefinition : Description? union Name Directives[Const]? UnionMemberTypes?
 
 UnionMemberTypes :
-  - = `|`? NamedType
   - UnionMemberTypes | NamedType
+  - = `|`? NamedType
 
 GraphQL Unions represent an object that could be one of a list of GraphQL
 Object types, but provides for no guaranteed fields between those types.
@@ -1610,8 +1610,8 @@ Expected Type | Internal Value   | Coerced Result
 DirectiveDefinition : Description? directive @ Name ArgumentsDefinition? on DirectiveLocations
 
 DirectiveLocations :
-  - `|`? DirectiveLocation
   - DirectiveLocations | DirectiveLocation
+  - `|`? DirectiveLocation
 
 DirectiveLocation :
   - ExecutableDirectiveLocation


### PR DESCRIPTION
When reviewing our grammar appendixes, I found some subtle inconsistencies between how we phrase things in prose and how we represent them in grammar.

This editorial change seeks to make this more clear with two subtle changes. 

First, wherever a grammatical production recursion occurs, move the recursive rule to the top of the list of rules to make it more clear that recursion is possible. 

Second, when describing the "list" rule, add some prose that explains this shorthand is defined by creating such a recursive production.
