### PR TITLE
remove redundant step from SameResponseShape

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -432,7 +432,6 @@ SameResponseShape(fieldA, fieldB) :
   * If {typeA} or {typeB} is Scalar or Enum.
     * If {typeA} and {typeB} are the same type return true, otherwise return
       false.
-  * If {typeA} or {typeB} is not a composite type, return false.
   * Let {mergedSet} be the result of adding the selection set of {fieldA} and
     the selection set of {fieldB}.
   * Let {fieldsForName} be the set of selections with a given response name in

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -432,6 +432,7 @@ SameResponseShape(fieldA, fieldB) :
   * If {typeA} or {typeB} is Scalar or Enum.
     * If {typeA} and {typeB} are the same type return true, otherwise return
       false.
+  * Assert: {typeA} and {typeB} are both composite types.
   * Let {mergedSet} be the result of adding the selection set of {fieldA} and
     the selection set of {fieldB}.
   * Let {fieldsForName} be the set of selections with a given response name in


### PR DESCRIPTION
Unless I'm misinterpreting something, this step from `SameResponseShape` doesn't serve any purpose except to make me question myself.

If `typeA` or `typeB` is not a composite type, one of them is a scalar or enum, and the function would have returned in the previous step.