### PR TITLE
Input Union: expand backwards-compatiblity requirements

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -135,7 +135,7 @@ A wide variety of solutions have been explored by the community, and they are ou
 
 ## Requirements
 
-1. **Backwards compatible** ─ adding a new member type to an Input Union or doing any non-breaking change to existing member types must not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable must not break previously valid client operations.
+1. **Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)** ─ adding a new member type to an Input Union or doing any non-breaking change to existing member types must not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable must not break previously valid client operations.
 
 **Note**: Input Unions may enforce some restrictions on member types, but if they do so compliance with these restrictions must be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -135,10 +135,9 @@ A wide variety of solutions have been explored by the community, and they are ou
 
 ## Requirements
 
-1. **Backwards compatible** ─ the following actions must not break previously valid operations:
-    1. Adding a new member type to an Input Union
-    1. Adding a new optional field to a member Input Object type of an Input Union
-    1. Changing a field from non-nullable to nullable in a member Input Object type of an Input Union
+1. **Backwards compatible** ─ adding a new member type to an Input Union or doing any non-breaking change to existing member types must not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable must not break previously valid client operations.
+
+**Note**: Input Unions may enforce some restrictions on member types, but if they do so compliance with these restrictions must be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
 
 ## Use Cases
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -135,7 +135,10 @@ A wide variety of solutions have been explored by the community, and they are ou
 
 ## Requirements
 
-1. **Backwards compatible** Adding a new member type to an Input Union must not break previously valid operations
+1. **Backwards compatible** ─ the following actions must not break previously valid operations:
+    1. Adding a new member type to an Input Union
+    1. Adding a new optional field to a member Input Object type of an Input Union
+    1. Changing a field from non-nullable to nullable in a member Input Object type of an Input Union
 
 ## Use Cases
 


### PR DESCRIPTION
Following on from #621 and the discussion therein, here's a couple more requirements I think we're generally agreed on ─ standard non-breaking GraphQL behaviours.

@leebyron @binaryseed @IvanGoncharov 