### PR TITLE
Mark EnumValuesDefinition as required in EnumTypeDefinition

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1244,7 +1244,7 @@ Union type extensions have the potential to be invalid if incorrectly defined.
 
 ## Enums
 
-EnumTypeDefinition : Description? enum Name Directives[Const]? EnumValuesDefinition?
+EnumTypeDefinition : Description? enum Name Directives[Const]? EnumValuesDefinition
 
 EnumValuesDefinition : { EnumValueDefinition+ }
 


### PR DESCRIPTION
I believe this to be a typo, as the Type Validation section reads:

> An Enum type must define one or more unique enum values.

Syntactically, I don't see a reason to permit a production like:

```graphql
enum Foo
```

because it will never be valid by the above rule. Are there any tools that permit this production?