### PR TITLE
Input Union RFC: Move Requirements to "Criteria"

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -133,13 +133,13 @@ In this mutation, we encounter the main challenge of the **Input Union** - we ne
 
 A wide variety of solutions have been explored by the community, and they are outlined in detail in this document under [Possible Solutions](#Possible-Solutions).
 
-## Solution Shape - Aims & Objections
+## Solution Criteria
 
 Hypothetical goals that a solution might attempt to fulfill.
 
 ### GraphQL should contain a polymorphic Input type
 
-The premise of this RFC - GraphQL should contain a polymorphic Input Union type.
+The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
 ### Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)
 
@@ -149,15 +149,12 @@ Adding a new member type to an Input Union or doing any non-breaking change to e
 
 If a solution places any restrictions on member types, compliance with these restrictions should be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
 
-### A member type may be a Scalar
+### A member type may be a Leaf type
 
-In addition to containing Input types, an Input Union may also contain Scalars.
+In addition to containing Input types, member type may also contain Leaf types like `Scalar`s or `Enum`s.
 
-### A member type may be an Enum
-
-In addition to containing Input types, an Input Union may also contain `Scalar`s or `Enum`s.
-
-* Objection: An input union containing both a `String` and an `Enum` would be impossible to distinguish.
+* Objection: Multiple Leaf types serialize the same way, making it impossible to distinguish the type. For example, a `String`, `ID` and `Enum`.
+* Objection: Output polymorphism is restricted to Object types only. Supporting Leaf types in Input polymorphism would create a new inconsistency.
 
 ## Use Cases
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -135,7 +135,15 @@ A wide variety of solutions have been explored by the community, and they are ou
 
 ## Solution Criteria
 
-Hypothetical goals that a solution might attempt to fulfill.
+Hypothetical goals that a solution might attempt to fulfill. These goals will be evaluated with the [GraphQL Spec Guiding Principles](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md#guiding-principles) in mind:
+
+* Backwards compatibility
+* Performance is a feature
+* Favor no change
+* Enable new capabilities motivated by real use cases
+* Simplicity and consistency over expressiveness and terseness
+* Preserve option value
+* Understandability is just as important as correctness
 
 ### GraphQL should contain a polymorphic Input type
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -143,7 +143,7 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
 ### Input polymorphism matches output polymorphism
 
-Any data structure that can be modeled with output type polymorphism should be able to be modeled with Input polymorphism.
+Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
 ### Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -141,6 +141,10 @@ Hypothetical goals that a solution might attempt to fulfill.
 
 The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
+### Input polymorphism matches output polymorphism
+
+Any data structure that can be modeled with output type polymorphism should be able to be modeled with Input polymorphism.
+
 ### Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)
 
 Adding a new member type to an Input Union or doing any non-breaking change to existing member types does not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable does not break previously valid client operations.

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -3,9 +3,9 @@ RFC: GraphQL Input Union
 
 The addition of an Input Union type has been discussed in the GraphQL community for many years now. The value of this feature has largely been agreed upon, but the implementation has not.
 
-This document attempts to bring together all the various solutions that have been discussed with the goal of reaching a shared understanding of the problem space.
+This document attempts to bring together all the various solutions and perspectives that have been discussed with the goal of reaching a shared understanding of the problem space.
 
-From that shared understanding, this document can then evolve into a proposed solution.
+From that shared understanding, the GraphQL Working Group aims to reach a concensus on how to address the proposal.
 
 ### Contributing
 
@@ -133,11 +133,31 @@ In this mutation, we encounter the main challenge of the **Input Union** - we ne
 
 A wide variety of solutions have been explored by the community, and they are outlined in detail in this document under [Possible Solutions](#Possible-Solutions).
 
-## Requirements
+## Solution Shape - Aims & Objections
 
-1. **Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)** ─ adding a new member type to an Input Union or doing any non-breaking change to existing member types must not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable must not break previously valid client operations.
+Hypothetical goals that a solution might attempt to fulfill.
 
-**Note**: Input Unions may enforce some restrictions on member types, but if they do so compliance with these restrictions must be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
+### GraphQL should contain an Input Union type
+
+The premise of this RFC - GraphQL should contain a polymorphic Input Union type.
+
+### Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)
+
+Adding a new member type to an Input Union or doing any non-breaking change to existing member types does not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable does not break previously valid client operations.
+
+### Any member type restrictions are validated in schema
+
+If a solution places any restrictions on member types, compliance with these restrictions should be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
+
+### A member type may be a Scalar
+
+In addition to containing Input types, an Input Union may also contain Scalars.
+
+### A member type may be an Enum
+
+In addition to containing Input types, an Input Union may also contain `Scalar`s or `Enum`s.
+
+* Objection: An input union containing both a `String` and an `Enum` would be impossible to distinguish.
 
 ## Use Cases
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -5,7 +5,7 @@ The addition of an Input Union type has been discussed in the GraphQL community 
 
 This document attempts to bring together all the various solutions and perspectives that have been discussed with the goal of reaching a shared understanding of the problem space.
 
-From that shared understanding, the GraphQL Working Group aims to reach a concensus on how to address the proposal.
+From that shared understanding, the GraphQL Working Group aims to reach a consensus on how to address the proposal.
 
 ### Contributing
 
@@ -137,7 +137,7 @@ A wide variety of solutions have been explored by the community, and they are ou
 
 Hypothetical goals that a solution might attempt to fulfill.
 
-### GraphQL should contain an Input Union type
+### GraphQL should contain a polymorphic Input type
 
 The premise of this RFC - GraphQL should contain a polymorphic Input Union type.
 


### PR DESCRIPTION
As discussed in the last Working Group meeting, this PR converts the "Requirements" section to an "Aims" section.

This is inline with the purpose of this document which is to gather all perspectives on the issue.

I've also added a few basic aims, one of which has an "objection"

@leebyron @IvanGoncharov @benjie 