### PR TITLE
InputUnion: note a possible inconsistency between solution criteria.

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -156,6 +156,8 @@ Adding a new member type to an Input Union or doing any non-breaking change to e
 
 If a solution places any restrictions on member types, compliance with these restrictions should be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
 
+However this restriction may be in conflict with criteria `Input polymorphism matches output polymorphism` because for describing output union one can use `__resolveType` in order to resolve which exactly type this union member resolves to.
+
 ### A member type may be a Leaf type
 
 In addition to containing Input types, member type may also contain Leaf types like `Scalar`s or `Enum`s.


### PR DESCRIPTION
There is some inconsistency may be seen between criteria that can result in producing solution which is not 100% compatible with existing aspects of output unions:
Sometimes there is a case when you cant have a priory knowledge what input data some of specific union should have, and output union have `__resolveType` to solve this problem. IMHO the whole point of union is to describe a situation when you do not have exact knowledge of type until you have it and when you can only describe what it can be. Please correct me if im wrong on this and `__resolveType` have different purpose.