### PR TITLE
Update copyright and URLs from Facebook to GraphQL Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # GraphQL
 
 The GraphQL specification is edited in the markdown files found in [`/spec`](./spec)
-the latest release of which is published at https://facebook.github.io/graphql/.
+the latest release of which is published at https://graphql.github.io/graphql-spec/.
 
-The latest draft specification can be found at https://facebook.github.io/graphql/draft/
+The latest draft specification can be found at https://graphql.github.io/graphql-spec/draft/
 which tracks the latest commit to the master branch in this repository.
 
 Previous releases of the GraphQL specification can be found at permalinks that
-match their [release tag](https://github.com/facebook/graphql/releases). For
-example, https://facebook.github.io/graphql/October2016/. If you are linking
+match their [release tag](https://github.com/graphql/graphql-spec/releases). For
+example, https://graphql.github.io/graphql-spec/October2016/. If you are linking
 directly to the GraphQL specification, it's best to link to a tagged permalink
 for the particular referenced version.
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,10 @@
     "Daniel Schafer <dschafer@fb.com>"
   ],
   "license": "OWFa-1.0",
-  "homepage": "https://facebook.github.io/graphql",
-  "bugs": {
-    "url": "https://github.com/facebook/graphql/issues"
-  },
+  "homepage": "https://graphql.github.io/graphql-spec",
   "repository": {
     "type": "git",
-    "url": "http://github.com/facebook/graphql.git"
+    "url": "http://github.com/graphql/graphql-spec.git"
   },
   "scripts": {
     "test": "spec-md spec/GraphQL.md > /dev/null",

--- a/publish.sh
+++ b/publish.sh
@@ -11,7 +11,7 @@ GITTAG=$(git tag --points-at HEAD)
 # Check out gh-pages locally.
 echo "Cloning gh-pages"
 rm -rf gh-pages
-git clone -b gh-pages "https://${GH_TOKEN}@github.com/facebook/graphql.git" gh-pages > /dev/null 2>&1
+git clone -b gh-pages "https://${GH_TOKEN}@github.com/graphql/graphql-spec.git" gh-pages > /dev/null 2>&1
 
 # Replace /draft with this build.
 echo "Publishing to: /draft"
@@ -74,7 +74,7 @@ HTML="$HTML
       <td></td>
     </tr>"
 
-GITHUB_RELEASES="https://github.com/facebook/graphql/releases/tag"
+GITHUB_RELEASES="https://github.com/graphql/graphql-spec/releases/tag"
 for GITTAG in $(git tag -l --sort='-*committerdate') ; do
   VERSIONYEAR=${GITTAG: -4}
   TAGTITLE="${GITTAG%$VERSIONYEAR} $VERSIONYEAR"

--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -8,16 +8,19 @@ GraphQL
 This is the specification for GraphQL, a query language and execution engine
 originally created at Facebook in 2012 for describing the capabilities and
 requirements of data models for client-server applications. The development of
-this open standard started in 2015.
+this open standard started in 2015. This specification was licensed under OWFa
+1.0 in 2017. Copyright and trademark was transfered to the GraphQL Foundation
+in 2019.
 
 GraphQL has evolved and may continue to evolve in future editions of this
 specification. Previous editions of the GraphQL specification can be found at
-permalinks that match their [release tag](https://github.com/facebook/graphql/releases).
-The latest working draft release can be found at [facebook.github.io/graphql/draft/](https://facebook.github.io/graphql/draft/).
+permalinks that match their [release tag](https://github.com/graphql/graphql-spec/releases).
+The latest working draft release can be found at [https://graphql.github.io/graphql-spec/draft](https://graphql.github.io/graphql-spec/draft).
 
 **Copyright notice**
 
-Copyright © 2015-present, Facebook, Inc.
+Copyright © 2015-2018, Facebook, Inc.
+Copyright © 2019-present, GraphQL Foundation
 
 As of September 26, 2017, the following persons or entities have made this
 Specification available under the Open Web Foundation Final Specification
@@ -26,7 +29,7 @@ Agreement (OWFa 1.0), which is available at [openwebfoundation.org](http://www.o
 * Facebook, Inc.
 
 You can review the signed copies of the Open Web Foundation Final Specification
-Agreement Version 1.0 for this specification at [github.com/facebook/graphql](https://github.com/facebook/graphql/tree/master/signed-agreements),
+Agreement Version 1.0 for this specification at [github.com/graphql/graphql-spec](https://github.com/graphql/graphql-spec/tree/master/signed-agreements),
 which may also include additional parties to those listed above.
 
 Your use of this Specification may be subject to other third party rights.


### PR DESCRIPTION
Long overdue update! This changes all links in the spec to the new github org links to avoid the redirect, and updates the spec history and copyright to reflect the 2019 ownership transfer to the GraphQL Foundation