### PR TITLE
Input Union: Remove incorrect objection

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -148,8 +148,6 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
-* Objection: input types and output types are distinct. Output types support aliases and arguments whereas input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
-
 ### Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)
 
 Adding a new member type to an Input Union or doing any non-breaking change to existing member types does not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable does not break previously valid client operations.


### PR DESCRIPTION
In this PR, I'd like to make the case that this objection is not correct and should be removed (or replaced with clarified objections)

> Objection: input types and output types are distinct. Output types support aliases and arguments whereas input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.

1) "Input" and "output" have differences but are not distinct. An "input" can be an Input Object, Enum, Scalar, List. An "output" can be a Object, Enum, Scalar, List. Both are structures that contain fields. What is different is that arguments and input fields must be Input Objects.

1) Strictly speaking, output types do _not_ support aliases or arguments. Fields support aliases and arguments. A field has a name which can be aliased. Fields may have arguments & an "output type" - the type itself does not have arguments.

1) Types themselves do not have a notion of nullability, only fields & arguments do. Being able to represent a specific data structure with types is orthogonal to the important ability for a schema to evolve in a non-breaking manner. Even then, there are a whole host of changes that are already possible in GraphQL that will be a breaking change, so that isn't a reason not to support input polymorphism.

-------

I'm open to ideas about how to capture this kind of debate in the document vs just deleting the objection...

@IvanGoncharov @leebyron @benjie @jturkel @eapache