### PR TITLE
Input unions: improve accuracy of objection

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -150,7 +150,7 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
-* Objection: input types and output types are distinct. Output types support aliases and arguments whereas input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
+* Objection: composite input types and composite output types are distinct. Fields on composite output types support aliases and arguments whereas field on composite input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
 
 ### C) Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -150,7 +150,7 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
-* Objection: composite input types and composite output types are distinct. Fields on composite output types support aliases and arguments whereas field on composite input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
+* Objection: composite input types and composite output types are distinct. Fields on composite output types support aliases and arguments whereas fields on composite input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
 
 ### C) Doesn't inhibit [schema evolution](https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution)
 


### PR DESCRIPTION
Addresses the issues in lazy language usage raised by @binaryseed in #642.

Note the GraphQL spec states:

> Note: The GraphQL Object type (ObjectTypeDefinition) defined above is inappropriate for re‐use here, because Object types can contain fields that define arguments or contain references to interfaces and unions, neither of which is appropriate for use as an input argument. For this reason, input objects have a separate type in the system.
> -- https://graphql.github.io/graphql-spec/June2018/#sec-Input-Objects
