### PR TITLE
Input Union: Evaluation cleanup

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -244,7 +244,7 @@ Preferably without loss of functionality.
 
 The less typing and fewer bytes transmitted, the better.
 
-* Objection: The quantity of "typing" isn't a worthwhile metric, most interactions with an API are programatic.
+* Objection: The quantity of "typing" isn't a worthwhile metric, most interactions with an API are programmatic.
 * Objection: Simply compressing an HTTP request will reduce the bytes transmitted more than anything having to do with the structure of a Schema.
 
 ### L) Input unions should be performant for servers

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -291,15 +291,16 @@ type Mutation {
 }
 ```
 
-#### Variations:
+#### Variations
 
 * A `default` type may be defined, for which specifying the `__typename` is not required. This enables a field to migration from an `Input` to an `Input Union`
 
 #### 🔬 Evaluation
 
-##### [Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
-
-* ⚠️ One additional field is required.
+* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+  * ✅
+* [H - Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * ⚠️ One additional field is required.
 
 -----
 
@@ -338,66 +339,82 @@ type Mutation {
 }
 ```
 
-#### Variations:
+#### Variations
 
 * Value is a `Enum` literal
 
-This solution is derived from discussions in https://github.com/graphql/graphql-spec/issues/488
+This variation is derived from discussions in https://github.com/graphql/graphql-spec/issues/488
 
-```graphql
-enum AnimalKind {
-  CAT
-  DOG
-}
+<details>
+  <summary>
+    Demonstration
+  </summary>
 
-input CatInput {
-  kind: AnimalKind::CAT
-  name: String!
-  age: Int
-  livesLeft: Int
-}
-input DogInput {
-  kind: AnimalKind::DOG
-  name: String!
-  age: Int
-  breed: DogBreed
-}
+  ```graphql
+  enum AnimalKind {
+    CAT
+    DOG
+  }
 
-# Variables:
-{
-  location: "Portland, OR",
-  animals: [
-    {
-      kind: "CAT",
-      name: "Buster",
-      livesLeft: 7
-    }
-  ]
-}
-```
+  input CatInput {
+    kind: AnimalKind::CAT
+    name: String!
+    age: Int
+    livesLeft: Int
+  }
+  input DogInput {
+    kind: AnimalKind::DOG
+    name: String!
+    age: Int
+    breed: DogBreed
+  }
+
+  # Variables:
+  {
+    location: "Portland, OR",
+    animals: [
+      {
+        kind: "CAT",
+        name: "Buster",
+        livesLeft: 7
+      }
+    ]
+  }
+  ```
+
+</details>
+
 
 * Value is a `String` literal
 
-```graphql
-input CatInput {
-  kind: "cat"
-  name: String!
-  age: Int
-  livesLeft: Int
-}
-input DogInput {
-  kind: "dog"
-  name: String!
-  age: Int
-  breed: DogBreed
-}
-```
+<details>
+  <summary>
+    Demonstration
+  </summary>
+
+  ```graphql
+  input CatInput {
+    kind: "cat"
+    name: String!
+    age: Int
+    livesLeft: Int
+  }
+  input DogInput {
+    kind: "dog"
+    name: String!
+    age: Int
+    breed: DogBreed
+  }
+  ```
+
+</<details>
 
 #### 🔬 Evaluation
 
-##### [Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
-
-* ⚠️ One additional field is required.
+* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+  * ✅
+* [H - Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * ⚠️ One additional field is required.
 
 -----
 
@@ -445,9 +462,10 @@ type Mutation {
 
 #### 🔬 Evaluation
 
-##### [Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
-
-* 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
+* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+  * ✅
+* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+  * 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
 
 <details>
   <summary>
@@ -528,15 +546,16 @@ input DogInput {
 }
 ```
 
-#### Variations:
+#### Variations
 
 * Consider the field _type_ along with the field _name_ when determining uniqueness.
 
 #### 🔬 Evaluation
 
-##### [Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
-
-* ⚠️ Inputs may be pushed to include extraneous fields to ensure uniqueness.
+* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+  * ✅
+* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+  * ⚠️ Inputs may be pushed to include extraneous fields to ensure uniqueness.
 
 -----
 
@@ -546,9 +565,9 @@ This solution was presented in:
 * https://github.com/graphql/graphql-spec/pull/395#issuecomment-361373097
 * https://github.com/graphql/graphql-spec/pull/586
 
-The type is discriminated using features already available, with an intermediate input type that acts to "tag" the field.
+The type is discriminated using features already available in GraphQL, with an intermediate input type that acts to "tag" the field.
 
-A proposed directive would specify that only one of the fields may be selected.
+A proposed directive would specify that only one of the fields in an input type may be provided. This provides schema-level validation instead of relying on a runtime error to express the restriction.
 
 ```graphql
 input CatInput {
@@ -585,6 +604,7 @@ type Mutation {
 
 #### 🔬 Evaluation
 
-##### [Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
-
-* 🚫 The shape of the input type is forced to have a different structure than the corresponding output type.
+* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+  * ⚠️ This isn't a polymorphic input type, it's extra schema validation for a "wrapper" type
+* [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+  * 🚫 The shape of the input type is forced to have a different structure than the corresponding output type.

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -275,11 +275,11 @@ Many people in the wild are solving the need for input unions with validation at
 
 ### J) A GraphQL schema that supports input unions can be queried by older GraphQL clients
 
-Preferably without loss of functionality.
+Preferably without a loss of or change in functionality.
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ### K) Input unions should be expressed efficiently in the query and on the wire
 
@@ -359,6 +359,8 @@ type Mutation {
   * ✅ Defaulting to the previous input type enables migration.
 * [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+  * ✅ Changes are additive only
 
 ### 💡 2. Explicit configurable Discriminator field
 
@@ -479,6 +481,8 @@ input DogInput {
   * ✅ Defaulting to the previous input type enables migration.
 * [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+  * ✅ Changes are additive only
 
 ### 💡 3. Order based discrimination
 
@@ -530,10 +534,6 @@ type Mutation {
   * ✅ Data structures can mirror eachother
 * [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
-  * ✅ Listing the old input type first enables migration
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
-  * ✅
 
     Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
 
@@ -547,6 +547,12 @@ type Mutation {
     ```
 
     Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
+* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+  * ✅ Listing the old input type first enables migration
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * ✅ No extra fields or structure required
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+  * ✅ Changes are additive only
 
 ### 💡 4. Structural uniqueness
 
@@ -620,7 +626,9 @@ input DogInput {
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ All new types added to the union must differ structurally from the previous type
 * [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
-  * ✅
+  * ✅ No extra fields or structure required
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+  * ✅ Changes are additive only
 
 ### 💡 5. One Of (Tagged Union)
 
@@ -677,3 +685,5 @@ type Mutation {
   * ✅ No migration required, as this is already possible
 * [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
   * 🚫 The shape of a data structure is forced to contain an intermediate type
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+  * ✅ Changes are additive only

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -239,7 +239,7 @@ In addition to containing Input types, member type may also contain Leaf types l
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| 🚫 | 🚫 | ✅⚠️ | 🚫 | ✅ |
 
 ## 🎯 F. Migrating a field to a polymorphic input type is non-breaking
 
@@ -376,19 +376,21 @@ type Mutation {
 
 ### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
+* [A. GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
+* [B. Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother.
   * ⚠️ `__typename` can not match since Input & Output types are distinct (ex: `Cat` vs `CatInput`).
-* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
+* [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
+  * 🚫 Requires a type to provide a discriminator field
+* [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
-* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
+* [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ## 💡 2. Explicit configurable Discriminator field
@@ -499,18 +501,20 @@ input DogInput {
 
 ### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
+* [A. GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
+* [B. Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother.
-* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
+* [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
+  * 🚫 Requires a type to provide a discriminator field
+* [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
-* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
+* [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ## 💡 3. Order based discrimination
@@ -557,11 +561,11 @@ type Mutation {
 
 ### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
+* [A. GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
+* [B. Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother
-* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
+* [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
 
     Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
@@ -576,11 +580,14 @@ type Mutation {
     ```
 
     Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
+  * ✅ Scalars could be listed in the inputunion and evaluated in order
+  * ⚠️ Subject to subtle dangerous behavior. ie: `String` listed before an Enum could never match the Enum
+* [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ Listing the old input type first enables migration
-* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
+* [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ✅ No extra fields or structure required
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ## 💡 4. Structural uniqueness
@@ -645,18 +652,20 @@ input DogInput {
 
 ### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
+* [A. GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
+* [B. Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother's fields
   * ⚠️ Restrictions on required fields may prevent matching output types
-* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
+* [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ⚠️ Inputs may be forced to include extraneous fields to ensure uniqueness.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
+  * 🚫 Ambiguous types unable to be discriminated. ex: `String` vs `Enum` vs `ID`
+* [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ All new types added to the union must differ structurally from the previous type
-* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
+* [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ✅ No extra fields or structure required
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ## 💡 5. One Of (Tagged Union)
@@ -704,17 +713,19 @@ type Mutation {
 
 ### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
+* [A. GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ⚠️ This isn't a polymorphic input type, it's extra schema-level validation for an intermediate type
-* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
+* [B. Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * 🚫 The shape of the input type is forced to have a different structure than the corresponding output type.
-* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
+* [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ This technique is already in use in many schemas with the extra validation
-* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
+  * ✅ Any GraphQL type may be used
+* [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ No migration required, as this is already possible
-* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
+* [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * 🚫 The shape of a data structure is forced to contain an intermediate type
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 
@@ -728,7 +739,7 @@ A quick glance at the evaluation results. Remember that passing or failing a spe
 | [B](#-b-input-polymorphism-matches-output-polymorphism) | ✅⚠️ | ✅ | ✅ | ✅⚠️ | 🚫 |
 | [C](#-c-doesnt-inhibit-schema-evolution) | ✅ | ✅ | 🚫 | ⚠️ | ✅ |
 | [D](#-d-any-member-type-restrictions-are-validated-in-schema) | ❔ | ❔ | ❔ | ❔ | ❔ |
-| [E](#-e-a-member-type-may-be-a-leaf-type) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [E](#-e-a-member-type-may-be-a-leaf-type) | 🚫 | 🚫 | ✅⚠️ | 🚫 | ✅ |
 | [F](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking) | 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
 | [G](#-g-input-unions-may-include-other-input-unions) | ❔ | ❔ | ❔ | ❔ | ❔ |
 | [H](#-h-input-unions-should-accept-plain-data) | ⚠️ | ⚠️ | ✅ | ✅ | 🚫 |

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -169,8 +169,6 @@ There have been a variety of use cases described by users asking for an abstract
 * [Observability Cloud Integrations](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#cloud-integrations)
 * [Observability Dashboards](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#dashboards)
 
------
-
 ## ⚖️ Solution Criteria
 
 This section sketches out the potential goals that a solution might attempt to fulfill. These goals will be evaluated with the [GraphQL Spec Guiding Principles](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md#guiding-principles) in mind:
@@ -302,8 +300,6 @@ Ideally a server does not have to do much computation to determine which concret
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
------
-
 ## 🏗 Possible Solutions
 
 ### 💡 1. Explicit `__typename` Discriminator field
@@ -361,8 +357,6 @@ type Mutation {
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
-
------
 
 ### 💡 2. Explicit configurable Discriminator field
 
@@ -484,8 +478,6 @@ input DogInput {
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
 
------
-
 ### 💡 3. Order based discrimination
 
 The concrete type is the first type in the input union definition that matches.
@@ -551,8 +543,6 @@ type Mutation {
     Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ Listing the old input type first enables migration
-
------
 
 ### 💡 4. Structural uniqueness
 
@@ -625,8 +615,6 @@ input DogInput {
   * ⚠️ Inputs may be forced to include extraneous fields to ensure uniqueness.
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ All new types added to the union must differ structurally from the previous type
-
------
 
 ### 💡 5. One Of (Tagged Union)
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -343,7 +343,7 @@ type Mutation {
 
 * The discriminator field may be `__inputname` to differentiate from an Output's `__typename`
 
-#### 🔮 Evaluation
+#### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -464,7 +464,7 @@ input DogInput {
 
 * A `default` type may be defined, for which specifying the `__typename` is not required. This enables a field to migration from an `Input` to an `Input Union`
 
-#### 🔮 Evaluation
+#### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -520,7 +520,7 @@ type Mutation {
 }
 ```
 
-#### 🔮 Evaluation
+#### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -604,7 +604,7 @@ input DogInput {
 
 * Consider the field _type_ along with the field _name_ when determining uniqueness.
 
-#### 🔮 Evaluation
+#### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -659,7 +659,7 @@ type Mutation {
 }
 ```
 
-#### 🔮 Evaluation
+#### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ⚠️ This isn't a polymorphic input type, it's extra schema-level validation for an intermediate type

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -413,6 +413,7 @@ input DogInput {
   name: String!
   age: Int
   breed: DogBreed
+  owner: ID
 }
 
 inputunion AnimalInput = CatInput | DogInput
@@ -444,8 +445,28 @@ type Mutation {
 
 ##### [Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
 
-* `x` Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
+* [🚫] Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
 
+<details>
+  <summary>
+    Demonstration
+  </summary>
+
+  Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
+
+  ```graphql
+  mutation {
+    logAnimalDropOff(
+      location: "Portland, OR",
+      animals: [
+        {name: "Spot", age: 5, owner: "Sally"}
+      ]
+    )
+  }
+  ```
+
+  Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, that becomes `CatInput` even though the mutation submitted has not changed.
+</details>
 
 ### 4. Structural uniqueness
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -189,11 +189,19 @@ Each criteria is identified with a Letter so they can be referenced in the rest 
 
 The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ✅ | ✅ | ✅ | ✅ | ⚠️ |
+
 ### B) Input polymorphism matches output polymorphism
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
 * ✂️ Objection: composite input types and composite output types are distinct. Fields on composite output types support aliases and arguments whereas fields on composite input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
+
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
 
 ### C) Doesn't inhibit schema evolution
 
@@ -202,9 +210,17 @@ https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evoluti
 
 Adding a new member type to an Input Union or doing any non-breaking change to existing member types does not result in breaking change. For example, adding a new optional field to member type or changing a field from non-nullable to nullable does not break previously valid client operations.
 
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
 ### D) Any member type restrictions are validated in schema
 
 If a solution places any restrictions on member types, compliance with these restrictions should be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
+
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
 
 ### E) A member type may be a Leaf type
 
@@ -214,6 +230,10 @@ In addition to containing Input types, member type may also contain Leaf types l
   * Potential solution: only allow a single built-in leaf type per input union.
 * ✂️ Objection: Output polymorphism is restricted to Object types only. Supporting Leaf types in Input polymorphism would create a new inconsistency.
 
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
 ### F) Migrating a field to a polymorphic input type is non-breaking
 
 Since the input object type is now a member of the input union, existing input objects being sent through should remain valid.
@@ -221,15 +241,27 @@ Since the input object type is now a member of the input union, existing input o
 * ✂️ Objection: achieving this by indicating the default in the union (either explicitly or implicitly via the order) is undesirable as it may require multiple equivalent unions being created where only the default differs.
 * ✂️ Objection: Numerous changes to a schema currently introduce breaking changes. The possibility of a breaking change isn't a breaking change and shouldn't prevent a polymorphic input type from existing.
 
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
 ### G) Input unions may include other input unions
 
 To ease development.
 
 * ✂️ Objection: Adds complexity without enabling any new use cases.
 
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
 ### H) Input unions should accept plain data
 
 Clients should be able to pass "natural" input data to unions without specially formatting it or adding extra metadata.
+
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
 
 ### I) Input unions should be easy to upgrade from existing solutions
 
@@ -237,9 +269,17 @@ Many people in the wild are solving the need for input unions with validation at
 
 * ✂️ Objection: The addition of a polymorphic input type shouldn't depend on the ability to change the type of an existing field or an existing usage pattern. One can always add new fields that leverage new features.
 
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
 ### J) A GraphQL schema that supports input unions can be queried by older GraphQL clients
 
 Preferably without loss of functionality.
+
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
 
 ### K) Input unions should be expressed efficiently in the query and on the wire
 
@@ -248,11 +288,19 @@ The less typing and fewer bytes transmitted, the better.
 * ✂️ Objection: The quantity of "typing" isn't a worthwhile metric, most interactions with an API are programmatic.
 * ✂️ Objection: Simply compressing an HTTP request will reduce the bytes transmitted more than anything having to do with the structure of a Schema.
 
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
 ### L) Input unions should be performant for servers
 
 Ideally a server does not have to do much computation to determine which concrete type is represented by an input.
 
 * ✂️ Objection: None of the solutions discussed so far do anything that is computationally expensive.
+
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
 
 -----
 
@@ -426,7 +474,7 @@ input DogInput {
 
 -----
 
-### 💡 3. Order based type matching
+### 💡 3. Order based discrimination
 
 The concrete type is the first type in the input union definition that matches.
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -302,6 +302,22 @@ Ideally a server does not have to do much computation to determine which concret
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
+### M) Existing SDL parsers are backwards compatible with SDL additions
+
+Common tools that parse GraphQL SDL should not fail when pointed at a schema which supports polymorphic input types.
+
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
+### N) Existing code generated tooling is backwards compatible with Introspection additions
+
+For example, GraphiQL should successfully render when pointed at a schema which contains polymorphic input types. It should continue to function even if it can't support the polymorphic input type.
+
+| [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+|----|----|----|----|----|
+| ❔ | ❔ | ❔ | ❔ | ❔ |
+
 ## 🏗 Possible Solutions
 
 ### 💡 1. Explicit `__typename` Discriminator field

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -327,7 +327,7 @@ For example, GraphiQL should successfully render when pointed at a schema which 
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-# 🏗 Possible Solutions
+# 🚧 Possible Solutions
 
 The community has imagined a variety of possible solutions, synthesized here.
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -181,9 +181,18 @@ This section sketches out the potential goals that a solution might attempt to f
 * Preserve option value
 * Understandability is just as important as correctness
 
-Each criteria is identified with a Letter so they can be referenced in the rest of the document. New criteria must be added to the end of the list.
+Each criteria is identified with a `Letter` so they can be referenced in the rest of the document. New criteria must be added to the end of the list.
 
-### 🎯 A) GraphQL should contain a polymorphic Input type
+Solutions are evaluated and scored using a simple 3 part scale. A solution may have multiple evaluations based on variations present in the solution.
+
+* ✅ **Pass.** The solution clearly meets the criteria
+* ⚠️ **Warning.** The solution doesn't clearly meet or fail the criteria
+* 🚫 **Fail.** The solution clearly fails the criteria
+* ❔ The criteria hasn't been evaluated yet
+
+Passing or failing a specific criteria is NOT the final word. Both the Criteria _and_ the Solutions are up for debate.
+
+### 🎯 A. GraphQL should contain a polymorphic Input type
 
 The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
@@ -191,7 +200,7 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 |----|----|----|----|----|
 | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
-### 🎯 B) Input polymorphism matches output polymorphism
+### 🎯 B. Input polymorphism matches output polymorphism
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
@@ -201,7 +210,7 @@ Any data structure that can be modeled with output type polymorphism should be a
 |----|----|----|----|----|
 | ✅⚠️ | ✅ | ✅ | ✅⚠️ | 🚫 |
 
-### 🎯 C) Doesn't inhibit schema evolution
+### 🎯 C. Doesn't inhibit schema evolution
 
 The GraphQL specification mentions the ability to evolve your schema as one of its core values:
 https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution
@@ -212,7 +221,7 @@ Adding a new member type to an Input Union or doing any non-breaking change to e
 |----|----|----|----|----|
 | ✅ | ✅ | 🚫 | ⚠️ | ✅ |
 
-### 🎯 D) Any member type restrictions are validated in schema
+### 🎯 D. Any member type restrictions are validated in schema
 
 If a solution places any restrictions on member types, compliance with these restrictions should be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
 
@@ -220,7 +229,7 @@ If a solution places any restrictions on member types, compliance with these res
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 E) A member type may be a Leaf type
+### 🎯 E. A member type may be a Leaf type
 
 In addition to containing Input types, member type may also contain Leaf types like `Scalar`s or `Enum`s.
 
@@ -232,7 +241,7 @@ In addition to containing Input types, member type may also contain Leaf types l
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 F) Migrating a field to a polymorphic input type is non-breaking
+### 🎯 F. Migrating a field to a polymorphic input type is non-breaking
 
 Since the input object type is now a member of the input union, existing input objects being sent through should remain valid.
 
@@ -243,7 +252,7 @@ Since the input object type is now a member of the input union, existing input o
 |----|----|----|----|----|
 | 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
 
-### 🎯 G) Input unions may include other input unions
+### 🎯 G. Input unions may include other input unions
 
 To ease development.
 
@@ -253,7 +262,7 @@ To ease development.
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 H) Input unions should accept plain data
+### 🎯 H. Input unions should accept plain data
 
 Clients should be able to pass "natural" input data to unions without specially formatting it or adding extra metadata.
 
@@ -263,7 +272,7 @@ Clients should be able to pass "natural" input data to unions without specially 
 |----|----|----|----|----|
 | ⚠️ | ⚠️ | ✅ | ✅ | 🚫 |
 
-### 🎯 I) Input unions should be easy to upgrade from existing solutions
+### 🎯 I. Input unions should be easy to upgrade from existing solutions
 
 Many people in the wild are solving the need for input unions with validation at run-time (e.g. using the "tagged union" pattern). Formalising support for these existing patterns in a non-breaking way would enable existing schemas to become retroactively more type-safe.
 
@@ -273,7 +282,7 @@ Many people in the wild are solving the need for input unions with validation at
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 J) A GraphQL schema that supports input unions can be queried by older GraphQL clients
+### 🎯 J. A GraphQL schema that supports input unions can be queried by older GraphQL clients
 
 Preferably without a loss of or change in functionality.
 
@@ -281,7 +290,7 @@ Preferably without a loss of or change in functionality.
 |----|----|----|----|----|
 | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-### 🎯 K) Input unions should be expressed efficiently in the query and on the wire
+### 🎯 K. Input unions should be expressed efficiently in the query and on the wire
 
 The less typing and fewer bytes transmitted, the better.
 
@@ -292,7 +301,7 @@ The less typing and fewer bytes transmitted, the better.
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 L) Input unions should be performant for servers
+### 🎯 L. Input unions should be performant for servers
 
 Ideally a server does not have to do much computation to determine which concrete type is represented by an input.
 
@@ -302,7 +311,7 @@ Ideally a server does not have to do much computation to determine which concret
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 M) Existing SDL parsers are backwards compatible with SDL additions
+### 🎯 M. Existing SDL parsers are backwards compatible with SDL additions
 
 Common tools that parse GraphQL SDL should not fail when pointed at a schema which supports polymorphic input types.
 
@@ -310,7 +319,7 @@ Common tools that parse GraphQL SDL should not fail when pointed at a schema whi
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 N) Existing code generated tooling is backwards compatible with Introspection additions
+### 🎯 N. Existing code generated tooling is backwards compatible with Introspection additions
 
 For example, GraphiQL should successfully render when pointed at a schema which contains polymorphic input types. It should continue to function even if it can't support the polymorphic input type.
 
@@ -319,6 +328,10 @@ For example, GraphiQL should successfully render when pointed at a schema which 
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
 ## 🏗 Possible Solutions
+
+The community has imagined a variety of possible solutions, synthesized here.
+
+Each solution is identified with a `Number` so they can be referenced in the rest of the document. New solutions must be added to the end of the list.
 
 ### 💡 1. Explicit `__typename` Discriminator field
 
@@ -703,3 +716,25 @@ type Mutation {
   * 🚫 The shape of a data structure is forced to contain an intermediate type
 * [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
+
+
+## 🏆 Evaluation Overview
+
+A quick glance at the evaluation results. Remember that passing or failing a specific criteria is NOT the final word.
+
+|    | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
+| -- | -- | -- | -- | -- | -- |
+| [A](#-a-graphql-should-contain-a-polymorphic-input-type) | ✅ | ✅ | ✅ | ✅ | ⚠️ |
+| [B](#-b-input-polymorphism-matches-output-polymorphism) | ✅⚠️ | ✅ | ✅ | ✅⚠️ | 🚫 |
+| [C](#-c-doesnt-inhibit-schema-evolution) | ✅ | ✅ | 🚫 | ⚠️ | ✅ |
+| [D](#-d-any-member-type-restrictions-are-validated-in-schema) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [E](#-e-a-member-type-may-be-a-leaf-type) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [F](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking) | 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
+| [G](#-g-input-unions-may-include-other-input-unions) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [H](#-h-input-unions-should-accept-plain-data) | ⚠️ | ⚠️ | ✅ | ✅ | 🚫 |
+| [I](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [J](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| [K](#-k-input-unions-should-be-expressed-efficiently-in-the-query-and-on-the-wire) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [L](#-l-input-unions-should-be-performant-for-servers) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [M](#-m-existing-sdl-parsers-are-backwards-compatible-with-sdl-additions) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [N](#-n-existing-code-generated-tooling-is-backwards-compatible-with-introspection-additions) | ❔ | ❔ | ❔ | ❔ | ❔ |

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -201,7 +201,7 @@ Any data structure that can be modeled with output type polymorphism should be a
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| ✅⚠️ | ✅ | ✅ | ✅⚠️ | 🚫 |
 
 ### C) Doesn't inhibit schema evolution
 
@@ -212,7 +212,7 @@ Adding a new member type to an Input Union or doing any non-breaking change to e
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| ❔ | ❔ | 🚫 | ⚠️ | ✅ |
 
 ### D) Any member type restrictions are validated in schema
 
@@ -261,7 +261,7 @@ Clients should be able to pass "natural" input data to unions without specially 
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| ⚠️ | ⚠️ | ❔ | ❔ | ❔ |
 
 ### I) Input unions should be easy to upgrade from existing solutions
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -243,7 +243,7 @@ Since the input object type is now a member of the input union, existing input o
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
 
 ### G) Input unions may include other input unions
 
@@ -349,15 +349,18 @@ type Mutation {
 
 #### 🔮 Evaluation
 
-* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
-  * ✅ Data structures can mirror eachother
-  * ⚠️ `__typename` can not match since Input & Output types are distinct (ex: `Cat` vs `CatInput`)
-* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
-  * ✅ Discriminator is explicit
-* [H - Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+  * ✅ Data structures can mirror eachother.
+  * ⚠️ `__typename` can not match since Input & Output types are distinct (ex: `Cat` vs `CatInput`).
+* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+  * ✅ Discriminator is explicit.
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
+* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+  * 🚫 Discriminator field is required.
+  * ✅ Defaulting to the previous input type enables migration.
 
 -----
 
@@ -465,16 +468,21 @@ input DogInput {
 }
 ```
 
+* A `default` type may be defined, for which specifying the `__typename` is not required. This enables a field to migration from an `Input` to an `Input Union`
+
 #### 🔮 Evaluation
 
-* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
-  * ✅ Data structures can mirror eachother
-* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
-  * ✅ Discriminator is explicit
-* [H - Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+  * ✅ Data structures can mirror eachother.
+* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+  * ✅ Discriminator is explicit.
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
+* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+  * 🚫 Discriminator field is required.
+  * ✅ Defaulting to the previous input type enables migration.
 
 -----
 
@@ -522,11 +530,11 @@ type Mutation {
 
 #### 🔮 Evaluation
 
-* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother
-* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
 
     Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
@@ -541,6 +549,8 @@ type Mutation {
     ```
 
     Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
+* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+  * ✅ Listing the old input type first enables migration
 
 -----
 
@@ -606,13 +616,15 @@ input DogInput {
 
 #### 🔮 Evaluation
 
-* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother's fields
   * ⚠️ Restrictions on required fields may prevent matching output types
-* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * ⚠️ Inputs may be forced to include extraneous fields to ensure uniqueness.
+* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+  * ✅ All new types added to the union must differ structurally from the previous type
 
 -----
 
@@ -661,9 +673,11 @@ type Mutation {
 
 #### 🔮 Evaluation
 
-* [A - GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
   * ⚠️ This isn't a polymorphic input type, it's extra schema-level validation for an intermediate type
-* [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
   * 🚫 The shape of the input type is forced to have a different structure than the corresponding output type.
-* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * ✅ This technique is already in use in many schemas with the extra validation
+* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+  * ✅ No migration required, as this is already possible

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -227,7 +227,7 @@ If a solution places any restrictions on member types, compliance with these res
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## 🎯 E. A member type may be a Leaf type
 
@@ -383,6 +383,8 @@ type Mutation {
   * ⚠️ `__typename` can not match since Input & Output types are distinct (ex: `Cat` vs `CatInput`).
 * [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
+* [D. Any member type restrictions are validated in schema](#-d-any-member-type-restrictions-are-validated-in-schema)
+  * ✅ No member type restrictions
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * 🚫 Requires a type to provide a discriminator field
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
@@ -507,6 +509,8 @@ input DogInput {
   * ✅ Data structures can mirror eachother.
 * [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
+* [D. Any member type restrictions are validated in schema](#-d-any-member-type-restrictions-are-validated-in-schema)
+  * ✅ Schema validation can check that all members of the input union have the discriminator field
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * 🚫 Requires a type to provide a discriminator field
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
@@ -580,6 +584,8 @@ type Mutation {
     ```
 
     Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
+* [D. Any member type restrictions are validated in schema](#-d-any-member-type-restrictions-are-validated-in-schema)
+  * ✅ No member type restrictions
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * ✅ Scalars could be listed in the inputunion and evaluated in order
   * ⚠️ Subject to subtle dangerous behavior. ie: `String` listed before an Enum could never match the Enum
@@ -659,6 +665,8 @@ input DogInput {
   * ⚠️ Restrictions on required fields may prevent matching output types
 * [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ⚠️ Inputs may be forced to include extraneous fields to ensure uniqueness.
+* [D. Any member type restrictions are validated in schema](#-d-any-member-type-restrictions-are-validated-in-schema)
+  * ✅ A "uniqueness" algorithm must be applied during schema validation
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * 🚫 Ambiguous types unable to be discriminated. ex: `String` vs `Enum` vs `ID`
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
@@ -719,6 +727,8 @@ type Mutation {
   * 🚫 The shape of the input type is forced to have a different structure than the corresponding output type.
 * [C. Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ This technique is already in use in many schemas with the extra validation
+* [D. Any member type restrictions are validated in schema](#-e-a-member-type-may-be-a-leaf-type)
+  * ✅ No schema changes, only an additional client side validation is added
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * ✅ Any GraphQL type may be used
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
@@ -738,7 +748,7 @@ A quick glance at the evaluation results. Remember that passing or failing a spe
 | [A](#-a-graphql-should-contain-a-polymorphic-input-type) | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 | [B](#-b-input-polymorphism-matches-output-polymorphism) | ✅⚠️ | ✅ | ✅ | ✅⚠️ | 🚫 |
 | [C](#-c-doesnt-inhibit-schema-evolution) | ✅ | ✅ | 🚫 | ⚠️ | ✅ |
-| [D](#-d-any-member-type-restrictions-are-validated-in-schema) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [D](#-d-any-member-type-restrictions-are-validated-in-schema) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [E](#-e-a-member-type-may-be-a-leaf-type) | 🚫 | 🚫 | ✅⚠️ | 🚫 | ✅ |
 | [F](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking) | 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
 | [G](#-g-input-unions-may-include-other-input-unions) | ❔ | ❔ | ❔ | ❔ | ❔ |

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -11,13 +11,13 @@ From that shared understanding, the GraphQL Working Group aims to reach a consen
 
 To help bring this idea to reality, you can contribute [PRs to this RFC document.](https://github.com/graphql/graphql-spec/edit/master/rfcs/InputUnion.md)
 
-## 📜 Problem Statement
+# 📜 Problem Statement
 
 GraphQL currently provides polymorphic types that enable schema authors to model complex **Object** types that have multiple shapes while remaining type-safe, but lacks an equivilant capability for **Input** types.
 
 Over the years there have been numerous proposals from the community to add a polymorphic input type. Without such a type, schema authors have resorted to a handful of work-arounds to model their domains. These work-arounds have led to schemas that aren't as expressive as they could be, and schemas where mutations that ideally mirror queries are forced to be modeled differently.
 
-## 🐕 Problem Sketch
+# 🐕 Problem Sketch
 
 To understand the problem space a little more, we'll sketch out an example that explores a domain from the perspective of a Query and a Mutation. However, it's important to note that the problem is not limited to mutations, since `Input` types are used in field arguments for any GraphQL operation type.
 
@@ -129,7 +129,7 @@ In this mutation, we encounter the main challenge of the **Input Union** - we ne
 A wide variety of solutions have been explored by the community, and they are outlined in detail in this document under [Possible Solutions](#Possible-Solutions).
 
 
-## 🎨 Prior Art
+# 🎨 Prior Art
 
 Many other technologies provide polymorphic types, and have done so using a variety of techniques.
 
@@ -157,7 +157,7 @@ The topic has also been extensively explored in Computer Science more generally.
 * [C2 Wiki: Nominative And Structural Typing](http://wiki.c2.com/?NominativeAndStructuralTyping)
 
 
-## 🛠 Use Cases
+# 🛠 Use Cases
 
 There have been a variety of use cases described by users asking for an abstract input type.
 
@@ -169,7 +169,7 @@ There have been a variety of use cases described by users asking for an abstract
 * [Observability Cloud Integrations](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#cloud-integrations)
 * [Observability Dashboards](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#dashboards)
 
-## 📋 Solution Criteria
+# 📋 Solution Criteria
 
 This section sketches out the potential goals that a solution might attempt to fulfill. These goals will be evaluated with the [GraphQL Spec Guiding Principles](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md#guiding-principles) in mind:
 
@@ -192,7 +192,7 @@ Solutions are evaluated and scored using a simple 3 part scale. A solution may h
 
 Passing or failing a specific criteria is NOT the final word. Both the Criteria _and_ the Solutions are up for debate.
 
-### 🎯 A. GraphQL should contain a polymorphic Input type
+## 🎯 A. GraphQL should contain a polymorphic Input type
 
 The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
@@ -200,7 +200,7 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 |----|----|----|----|----|
 | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
-### 🎯 B. Input polymorphism matches output polymorphism
+## 🎯 B. Input polymorphism matches output polymorphism
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
@@ -210,7 +210,7 @@ Any data structure that can be modeled with output type polymorphism should be a
 |----|----|----|----|----|
 | ✅⚠️ | ✅ | ✅ | ✅⚠️ | 🚫 |
 
-### 🎯 C. Doesn't inhibit schema evolution
+## 🎯 C. Doesn't inhibit schema evolution
 
 The GraphQL specification mentions the ability to evolve your schema as one of its core values:
 https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution
@@ -221,7 +221,7 @@ Adding a new member type to an Input Union or doing any non-breaking change to e
 |----|----|----|----|----|
 | ✅ | ✅ | 🚫 | ⚠️ | ✅ |
 
-### 🎯 D. Any member type restrictions are validated in schema
+## 🎯 D. Any member type restrictions are validated in schema
 
 If a solution places any restrictions on member types, compliance with these restrictions should be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
 
@@ -229,7 +229,7 @@ If a solution places any restrictions on member types, compliance with these res
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 E. A member type may be a Leaf type
+## 🎯 E. A member type may be a Leaf type
 
 In addition to containing Input types, member type may also contain Leaf types like `Scalar`s or `Enum`s.
 
@@ -241,7 +241,7 @@ In addition to containing Input types, member type may also contain Leaf types l
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 F. Migrating a field to a polymorphic input type is non-breaking
+## 🎯 F. Migrating a field to a polymorphic input type is non-breaking
 
 Since the input object type is now a member of the input union, existing input objects being sent through should remain valid.
 
@@ -252,7 +252,7 @@ Since the input object type is now a member of the input union, existing input o
 |----|----|----|----|----|
 | 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
 
-### 🎯 G. Input unions may include other input unions
+## 🎯 G. Input unions may include other input unions
 
 To ease development.
 
@@ -262,7 +262,7 @@ To ease development.
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 H. Input unions should accept plain data
+## 🎯 H. Input unions should accept plain data
 
 Clients should be able to pass "natural" input data to unions without specially formatting it or adding extra metadata.
 
@@ -272,7 +272,7 @@ Clients should be able to pass "natural" input data to unions without specially 
 |----|----|----|----|----|
 | ⚠️ | ⚠️ | ✅ | ✅ | 🚫 |
 
-### 🎯 I. Input unions should be easy to upgrade from existing solutions
+## 🎯 I. Input unions should be easy to upgrade from existing solutions
 
 Many people in the wild are solving the need for input unions with validation at run-time (e.g. using the "tagged union" pattern). Formalising support for these existing patterns in a non-breaking way would enable existing schemas to become retroactively more type-safe.
 
@@ -282,7 +282,7 @@ Many people in the wild are solving the need for input unions with validation at
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 J. A GraphQL schema that supports input unions can be queried by older GraphQL clients
+## 🎯 J. A GraphQL schema that supports input unions can be queried by older GraphQL clients
 
 Preferably without a loss of or change in functionality.
 
@@ -290,7 +290,7 @@ Preferably without a loss of or change in functionality.
 |----|----|----|----|----|
 | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-### 🎯 K. Input unions should be expressed efficiently in the query and on the wire
+## 🎯 K. Input unions should be expressed efficiently in the query and on the wire
 
 The less typing and fewer bytes transmitted, the better.
 
@@ -301,7 +301,7 @@ The less typing and fewer bytes transmitted, the better.
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 L. Input unions should be performant for servers
+## 🎯 L. Input unions should be performant for servers
 
 Ideally a server does not have to do much computation to determine which concrete type is represented by an input.
 
@@ -311,7 +311,7 @@ Ideally a server does not have to do much computation to determine which concret
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 M. Existing SDL parsers are backwards compatible with SDL additions
+## 🎯 M. Existing SDL parsers are backwards compatible with SDL additions
 
 Common tools that parse GraphQL SDL should not fail when pointed at a schema which supports polymorphic input types.
 
@@ -319,7 +319,7 @@ Common tools that parse GraphQL SDL should not fail when pointed at a schema whi
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### 🎯 N. Existing code generated tooling is backwards compatible with Introspection additions
+## 🎯 N. Existing code generated tooling is backwards compatible with Introspection additions
 
 For example, GraphiQL should successfully render when pointed at a schema which contains polymorphic input types. It should continue to function even if it can't support the polymorphic input type.
 
@@ -327,13 +327,13 @@ For example, GraphiQL should successfully render when pointed at a schema which 
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-## 🏗 Possible Solutions
+# 🏗 Possible Solutions
 
 The community has imagined a variety of possible solutions, synthesized here.
 
 Each solution is identified with a `Number` so they can be referenced in the rest of the document. New solutions must be added to the end of the list.
 
-### 💡 1. Explicit `__typename` Discriminator field
+## 💡 1. Explicit `__typename` Discriminator field
 
 This solution was discussed in https://github.com/graphql/graphql-spec/pull/395
 
@@ -368,13 +368,13 @@ type Mutation {
 }
 ```
 
-#### 🎲 Variations
+### 🎲 Variations
 
 * A `default` type may be defined, for which specifying the `__typename` is not required. This enables a field to migration from an `Input` to an `Input Union`
 
 * The discriminator field may be `__inputname` to differentiate from an Output's `__typename`
 
-#### ⚖️ Evaluation
+### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -391,7 +391,7 @@ type Mutation {
 * [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
-### 💡 2. Explicit configurable Discriminator field
+## 💡 2. Explicit configurable Discriminator field
 
 A configurable discriminator field enables schema authors to model type discrimination into their schema more naturally.
 
@@ -399,7 +399,7 @@ A schema author may choose to add their chosen type discriminator field to outpu
 
 The mechanism for configuring the discriminator field is open to debate, in this example it's represented with the use of a schema directive.
 
-#### 🎲 Variations
+### 🎲 Variations
 
 * Value is the input's type name
 
@@ -497,7 +497,7 @@ input DogInput {
 
 * A `default` type may be defined, for which specifying the `__typename` is not required. This enables a field to migration from an `Input` to an `Input Union`
 
-#### ⚖️ Evaluation
+### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -513,7 +513,7 @@ input DogInput {
 * [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
-### 💡 3. Order based discrimination
+## 💡 3. Order based discrimination
 
 The concrete type is the first type in the input union definition that matches.
 
@@ -555,7 +555,7 @@ type Mutation {
 }
 ```
 
-#### ⚖️ Evaluation
+### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -583,7 +583,7 @@ type Mutation {
 * [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
-### 💡 4. Structural uniqueness
+## 💡 4. Structural uniqueness
 
 Schema Rule: Each type in the union must have a unique set of required field names
 
@@ -639,11 +639,11 @@ input DogInput {
 }
 ```
 
-#### 🎲 Variations
+### 🎲 Variations
 
 * Consider the field _type_ along with the field _name_ when determining uniqueness.
 
-#### ⚖️ Evaluation
+### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
@@ -659,7 +659,7 @@ input DogInput {
 * [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
-### 💡 5. One Of (Tagged Union)
+## 💡 5. One Of (Tagged Union)
 
 This solution was presented in:
 * https://github.com/graphql/graphql-spec/pull/395#issuecomment-361373097
@@ -702,7 +702,7 @@ type Mutation {
 }
 ```
 
-#### ⚖️ Evaluation
+### ⚖️ Evaluation
 
 * [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ⚠️ This isn't a polymorphic input type, it's extra schema-level validation for an intermediate type
@@ -718,7 +718,7 @@ type Mutation {
   * ✅ Changes are additive only
 
 
-## 🏆 Evaluation Overview
+# 🏆 Evaluation Overview
 
 A quick glance at the evaluation results. Remember that passing or failing a specific criteria is NOT the final word.
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -407,7 +407,7 @@ This variation is derived from discussions in https://github.com/graphql/graphql
   }
   ```
 
-</<details>
+</details>
 
 #### 🔬 Evaluation
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -212,7 +212,7 @@ Adding a new member type to an Input Union or doing any non-breaking change to e
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | 🚫 | ⚠️ | ✅ |
+| ✅ | ✅ | 🚫 | ⚠️ | ✅ |
 
 ### D) Any member type restrictions are validated in schema
 
@@ -354,6 +354,8 @@ type Mutation {
 * [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother
   * ⚠️ `__typename` can not match since Input & Output types are distinct (ex: `Cat` vs `CatInput`)
+* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+  * ✅ Discriminator is explicit
 * [H - Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
 
@@ -469,6 +471,8 @@ input DogInput {
   * ✅
 * [B - Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother
+* [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+  * ✅ Discriminator is explicit
 * [H - Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
 

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -169,7 +169,7 @@ There have been a variety of use cases described by users asking for an abstract
 * [Observability Cloud Integrations](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#cloud-integrations)
 * [Observability Dashboards](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#dashboards)
 
-## ⚖️ Solution Criteria
+## 📋 Solution Criteria
 
 This section sketches out the potential goals that a solution might attempt to fulfill. These goals will be evaluated with the [GraphQL Spec Guiding Principles](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md#guiding-principles) in mind:
 
@@ -183,7 +183,7 @@ This section sketches out the potential goals that a solution might attempt to f
 
 Each criteria is identified with a Letter so they can be referenced in the rest of the document. New criteria must be added to the end of the list.
 
-### A) GraphQL should contain a polymorphic Input type
+### 🎯 A) GraphQL should contain a polymorphic Input type
 
 The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
@@ -191,7 +191,7 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 |----|----|----|----|----|
 | ✅ | ✅ | ✅ | ✅ | ⚠️ |
 
-### B) Input polymorphism matches output polymorphism
+### 🎯 B) Input polymorphism matches output polymorphism
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
@@ -201,7 +201,7 @@ Any data structure that can be modeled with output type polymorphism should be a
 |----|----|----|----|----|
 | ✅⚠️ | ✅ | ✅ | ✅⚠️ | 🚫 |
 
-### C) Doesn't inhibit schema evolution
+### 🎯 C) Doesn't inhibit schema evolution
 
 The GraphQL specification mentions the ability to evolve your schema as one of its core values:
 https://graphql.github.io/graphql-spec/draft/#sec-Validation.Type-system-evolution
@@ -212,7 +212,7 @@ Adding a new member type to an Input Union or doing any non-breaking change to e
 |----|----|----|----|----|
 | ✅ | ✅ | 🚫 | ⚠️ | ✅ |
 
-### D) Any member type restrictions are validated in schema
+### 🎯 D) Any member type restrictions are validated in schema
 
 If a solution places any restrictions on member types, compliance with these restrictions should be fully validated during schema building (analagous to how interfaces enforce restrictions on member types).
 
@@ -220,7 +220,7 @@ If a solution places any restrictions on member types, compliance with these res
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### E) A member type may be a Leaf type
+### 🎯 E) A member type may be a Leaf type
 
 In addition to containing Input types, member type may also contain Leaf types like `Scalar`s or `Enum`s.
 
@@ -232,7 +232,7 @@ In addition to containing Input types, member type may also contain Leaf types l
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### F) Migrating a field to a polymorphic input type is non-breaking
+### 🎯 F) Migrating a field to a polymorphic input type is non-breaking
 
 Since the input object type is now a member of the input union, existing input objects being sent through should remain valid.
 
@@ -243,7 +243,7 @@ Since the input object type is now a member of the input union, existing input o
 |----|----|----|----|----|
 | 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
 
-### G) Input unions may include other input unions
+### 🎯 G) Input unions may include other input unions
 
 To ease development.
 
@@ -253,7 +253,7 @@ To ease development.
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### H) Input unions should accept plain data
+### 🎯 H) Input unions should accept plain data
 
 Clients should be able to pass "natural" input data to unions without specially formatting it or adding extra metadata.
 
@@ -263,7 +263,7 @@ Clients should be able to pass "natural" input data to unions without specially 
 |----|----|----|----|----|
 | ⚠️ | ⚠️ | ✅ | ✅ | 🚫 |
 
-### I) Input unions should be easy to upgrade from existing solutions
+### 🎯 I) Input unions should be easy to upgrade from existing solutions
 
 Many people in the wild are solving the need for input unions with validation at run-time (e.g. using the "tagged union" pattern). Formalising support for these existing patterns in a non-breaking way would enable existing schemas to become retroactively more type-safe.
 
@@ -273,7 +273,7 @@ Many people in the wild are solving the need for input unions with validation at
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### J) A GraphQL schema that supports input unions can be queried by older GraphQL clients
+### 🎯 J) A GraphQL schema that supports input unions can be queried by older GraphQL clients
 
 Preferably without a loss of or change in functionality.
 
@@ -281,7 +281,7 @@ Preferably without a loss of or change in functionality.
 |----|----|----|----|----|
 | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-### K) Input unions should be expressed efficiently in the query and on the wire
+### 🎯 K) Input unions should be expressed efficiently in the query and on the wire
 
 The less typing and fewer bytes transmitted, the better.
 
@@ -292,7 +292,7 @@ The less typing and fewer bytes transmitted, the better.
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### L) Input unions should be performant for servers
+### 🎯 L) Input unions should be performant for servers
 
 Ideally a server does not have to do much computation to determine which concrete type is represented by an input.
 
@@ -302,7 +302,7 @@ Ideally a server does not have to do much computation to determine which concret
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### M) Existing SDL parsers are backwards compatible with SDL additions
+### 🎯 M) Existing SDL parsers are backwards compatible with SDL additions
 
 Common tools that parse GraphQL SDL should not fail when pointed at a schema which supports polymorphic input types.
 
@@ -310,7 +310,7 @@ Common tools that parse GraphQL SDL should not fail when pointed at a schema whi
 |----|----|----|----|----|
 | ❔ | ❔ | ❔ | ❔ | ❔ |
 
-### N) Existing code generated tooling is backwards compatible with Introspection additions
+### 🎯 N) Existing code generated tooling is backwards compatible with Introspection additions
 
 For example, GraphiQL should successfully render when pointed at a schema which contains polymorphic input types. It should continue to function even if it can't support the polymorphic input type.
 
@@ -363,19 +363,19 @@ type Mutation {
 
 #### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother.
   * ⚠️ `__typename` can not match since Input & Output types are distinct (ex: `Cat` vs `CatInput`).
-* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ### 💡 2. Explicit configurable Discriminator field
@@ -486,18 +486,18 @@ input DogInput {
 
 #### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother.
-* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ### 💡 3. Order based discrimination
@@ -544,11 +544,11 @@ type Mutation {
 
 #### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother
-* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
 
     Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
@@ -563,11 +563,11 @@ type Mutation {
     ```
 
     Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ Listing the old input type first enables migration
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ✅ No extra fields or structure required
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ### 💡 4. Structural uniqueness
@@ -632,18 +632,18 @@ input DogInput {
 
 #### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ✅
-* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * ✅ Data structures can mirror eachother's fields
   * ⚠️ Restrictions on required fields may prevent matching output types
-* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ⚠️ Inputs may be forced to include extraneous fields to ensure uniqueness.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ All new types added to the union must differ structurally from the previous type
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ✅ No extra fields or structure required
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
 ### 💡 5. One Of (Tagged Union)
@@ -691,15 +691,15 @@ type Mutation {
 
 #### ⚖️ Evaluation
 
-* [A) GraphQL should contain a polymorphic Input type](#a-graphql-should-contain-a-polymorphic-input-type)
+* [A) GraphQL should contain a polymorphic Input type](#-a-graphql-should-contain-a-polymorphic-input-type)
   * ⚠️ This isn't a polymorphic input type, it's extra schema-level validation for an intermediate type
-* [B) Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
+* [B) Input polymorphism matches output polymorphism](#-b-input-polymorphism-matches-output-polymorphism)
   * 🚫 The shape of the input type is forced to have a different structure than the corresponding output type.
-* [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
+* [C) Doesn't inhibit schema evolution](#-c-doesnt-inhibit-schema-evolution)
   * ✅ This technique is already in use in many schemas with the extra validation
-* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+* [F) Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ No migration required, as this is already possible
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+* [H) Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * 🚫 The shape of a data structure is forced to contain an intermediate type
-* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
+* [J) A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -295,12 +295,13 @@ type Mutation {
 
 * A `default` type may be defined, for which specifying the `__typename` is not required. This enables a field to migration from an `Input` to an `Input Union`
 
-#### Evaluation
+#### 🔬 Evaluation
 
 ##### [Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
 
-* `x` One additional field is required.
+* ⚠️ One additional field is required.
 
+-----
 
 ### 2. Configurable Discriminator field
 
@@ -392,12 +393,13 @@ input DogInput {
 }
 ```
 
-#### Evaluation
+#### 🔬 Evaluation
 
 ##### [Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
 
-* `x` One additional field is required.
+* ⚠️ One additional field is required.
 
+-----
 
 ### 3. Order based type matching
 
@@ -441,11 +443,11 @@ type Mutation {
 }
 ```
 
-#### Evaluation
+#### 🔬 Evaluation
 
 ##### [Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
 
-* [🚫] Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
+* 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
 
 <details>
   <summary>
@@ -467,6 +469,8 @@ type Mutation {
 
   Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, that becomes `CatInput` even though the mutation submitted has not changed.
 </details>
+
+-----
 
 ### 4. Structural uniqueness
 
@@ -528,11 +532,13 @@ input DogInput {
 
 * Consider the field _type_ along with the field _name_ when determining uniqueness.
 
-#### Evaluation
+#### 🔬 Evaluation
 
 ##### [Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
 
-Inputs may be pushed to include extraneous fields to ensure uniqueness.
+* ⚠️ Inputs may be pushed to include extraneous fields to ensure uniqueness.
+
+-----
 
 ### 5. One Of (Tagged Union)
 
@@ -577,8 +583,8 @@ type Mutation {
 }
 ```
 
-#### Evaluation
+#### 🔬 Evaluation
 
 ##### [Input polymorphism matches output polymorphism](#b-input-polymorphism-matches-output-polymorphism)
 
-The shape of the input type is forced to have a different structure than the corresponding output type.
+* 🚫 The shape of the input type is forced to have a different structure than the corresponding output type.

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -257,9 +257,11 @@ To ease development.
 
 Clients should be able to pass "natural" input data to unions without specially formatting it or adding extra metadata.
 
+* ✂️ Objection: This is a matter of taste - legitimate [Prior Art](#-prior-art) exists that require formatting / extra metadata.
+
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ⚠️ | ⚠️ | ❔ | ❔ | ❔ |
+| ⚠️ | ⚠️ | ✅ | ✅ | 🚫 |
 
 ### I) Input unions should be easy to upgrade from existing solutions
 
@@ -352,11 +354,11 @@ type Mutation {
   * ⚠️ `__typename` can not match since Input & Output types are distinct (ex: `Cat` vs `CatInput`).
 * [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
-  * ⚠️ One additional field is required.
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * ⚠️ One additional field is required.
 
 ### 💡 2. Explicit configurable Discriminator field
 
@@ -472,11 +474,11 @@ input DogInput {
   * ✅ Data structures can mirror eachother.
 * [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * ✅ Discriminator is explicit.
-* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
-  * ⚠️ One additional field is required.
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * 🚫 Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * ⚠️ One additional field is required.
 
 ### 💡 3. Order based discrimination
 
@@ -528,6 +530,10 @@ type Mutation {
   * ✅ Data structures can mirror eachother
 * [C) Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
+* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+  * ✅ Listing the old input type first enables migration
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * ✅
 
     Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
 
@@ -541,8 +547,6 @@ type Mutation {
     ```
 
     Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
-* [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
-  * ✅ Listing the old input type first enables migration
 
 ### 💡 4. Structural uniqueness
 
@@ -615,6 +619,8 @@ input DogInput {
   * ⚠️ Inputs may be forced to include extraneous fields to ensure uniqueness.
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ All new types added to the union must differ structurally from the previous type
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * ✅
 
 ### 💡 5. One Of (Tagged Union)
 
@@ -669,3 +675,5 @@ type Mutation {
   * ✅ This technique is already in use in many schemas with the extra validation
 * [F) Migrating a field to a polymorphic input type is non-breaking](#f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
   * ✅ No migration required, as this is already possible
+* [H) Input unions should accept plain data](#h-input-unions-should-accept-plain-data)
+  * 🚫 The shape of a data structure is forced to contain an intermediate type

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -11,13 +11,13 @@ From that shared understanding, the GraphQL Working Group aims to reach a consen
 
 To help bring this idea to reality, you can contribute [PRs to this RFC document.](https://github.com/graphql/graphql-spec/edit/master/rfcs/InputUnion.md)
 
-## Problem Statement
+## 📜 Problem Statement
 
 GraphQL currently provides polymorphic types that enable schema authors to model complex **Object** types that have multiple shapes while remaining type-safe, but lacks an equivilant capability for **Input** types.
 
 Over the years there have been numerous proposals from the community to add a polymorphic input type. Without such a type, schema authors have resorted to a handful of work-arounds to model their domains. These work-arounds have led to schemas that aren't as expressive as they could be, and schemas where mutations that ideally mirror queries are forced to be modeled differently.
 
-## Problem Sketch
+## 🐕 Problem Sketch
 
 To understand the problem space a little more, we'll sketch out an example that explores a domain from the perspective of a Query and a Mutation. However, it's important to note that the problem is not limited to mutations, since `Input` types are used in field arguments for any GraphQL operation type.
 
@@ -129,7 +129,7 @@ In this mutation, we encounter the main challenge of the **Input Union** - we ne
 A wide variety of solutions have been explored by the community, and they are outlined in detail in this document under [Possible Solutions](#Possible-Solutions).
 
 
-## Prior Art
+## 🎨 Prior Art
 
 Many other technologies provide polymorphic types, and have done so using a variety of techniques.
 
@@ -157,7 +157,7 @@ The topic has also been extensively explored in Computer Science more generally.
 * [C2 Wiki: Nominative And Structural Typing](http://wiki.c2.com/?NominativeAndStructuralTyping)
 
 
-## Use Cases
+## 🛠 Use Cases
 
 There have been a variety of use cases described by users asking for an abstract input type.
 
@@ -170,7 +170,7 @@ There have been a variety of use cases described by users asking for an abstract
 * [Observability Dashboards](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#dashboards)
 
 
-## Solution Criteria
+## ⚖️ Solution Criteria
 
 This section sketches out the potential goals that a solution might attempt to fulfill. These goals will be evaluated with the [GraphQL Spec Guiding Principles](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md#guiding-principles) in mind:
 
@@ -192,7 +192,7 @@ The premise of this RFC - GraphQL should contain a polymorphic Input type.
 
 Any data structure that can be modeled with output type polymorphism should be able to be mirrored with Input polymorphism. Minimal transformation of outputs should be required to send a data structure back as inputs.
 
-* Objection: composite input types and composite output types are distinct. Fields on composite output types support aliases and arguments whereas fields on composite input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
+* ✂️ Objection: composite input types and composite output types are distinct. Fields on composite output types support aliases and arguments whereas fields on composite input types do not. Marking an output field as non-nullable is a non-breaking change, but marking an input field as non-nullable is a breaking change.
 
 ### C) Doesn't inhibit schema evolution
 
@@ -209,22 +209,22 @@ If a solution places any restrictions on member types, compliance with these res
 
 In addition to containing Input types, member type may also contain Leaf types like `Scalar`s or `Enum`s.
 
-* Objection: multiple Leaf types serialize the same way, making it impossible to distinguish the type without additional information. For example, a `String`, `ID` and `Enum`.
+* ✂️ Objection: multiple Leaf types serialize the same way, making it impossible to distinguish the type without additional information. For example, a `String`, `ID` and `Enum`.
   * Potential solution: only allow a single built-in leaf type per input union.
-* Objection: Output polymorphism is restricted to Object types only. Supporting Leaf types in Input polymorphism would create a new inconsistency.
+* ✂️ Objection: Output polymorphism is restricted to Object types only. Supporting Leaf types in Input polymorphism would create a new inconsistency.
 
 ### F) Migrating a field to a polymorphic input type is non-breaking
 
 Since the input object type is now a member of the input union, existing input objects being sent through should remain valid.
 
-* Objection: achieving this by indicating the default in the union (either explicitly or implicitly via the order) is undesirable as it may require multiple equivalent unions being created where only the default differs.
-* Objection: Numerous changes to a schema currently introduce breaking changes. The possibility of a breaking change isn't a breaking change and shouldn't prevent a polymorphic input type from existing.
+* ✂️ Objection: achieving this by indicating the default in the union (either explicitly or implicitly via the order) is undesirable as it may require multiple equivalent unions being created where only the default differs.
+* ✂️ Objection: Numerous changes to a schema currently introduce breaking changes. The possibility of a breaking change isn't a breaking change and shouldn't prevent a polymorphic input type from existing.
 
 ### G) Input unions may include other input unions
 
 To ease development.
 
-* Objection: Adds complexity without enabling any new use cases.
+* ✂️ Objection: Adds complexity without enabling any new use cases.
 
 ### H) Input unions should accept plain data
 
@@ -234,7 +234,7 @@ Clients should be able to pass "natural" input data to unions without specially 
 
 Many people in the wild are solving the need for input unions with validation at run-time (e.g. using the "tagged union" pattern). Formalising support for these existing patterns in a non-breaking way would enable existing schemas to become retroactively more type-safe.
 
-* Objection: The addition of a polymorphic input type shouldn't depend on the ability to change the type of an existing field or an existing usage pattern. One can always add new fields that leverage new features.
+* ✂️ Objection: The addition of a polymorphic input type shouldn't depend on the ability to change the type of an existing field or an existing usage pattern. One can always add new fields that leverage new features.
 
 ### J) A GraphQL schema that supports input unions can be queried by older GraphQL clients
 
@@ -244,19 +244,19 @@ Preferably without loss of functionality.
 
 The less typing and fewer bytes transmitted, the better.
 
-* Objection: The quantity of "typing" isn't a worthwhile metric, most interactions with an API are programmatic.
-* Objection: Simply compressing an HTTP request will reduce the bytes transmitted more than anything having to do with the structure of a Schema.
+* ✂️ Objection: The quantity of "typing" isn't a worthwhile metric, most interactions with an API are programmatic.
+* ✂️ Objection: Simply compressing an HTTP request will reduce the bytes transmitted more than anything having to do with the structure of a Schema.
 
 ### L) Input unions should be performant for servers
 
 Ideally a server does not have to do much computation to determine which concrete type is represented by an input.
 
-* Objection: None of the solutions discussed so far do anything that is computationally expensive.
+* ✂️ Objection: None of the solutions discussed so far do anything that is computationally expensive.
 
 
-## Possible Solutions
+## 🏗 Possible Solutions
 
-### 1. Explicit `__typename` Discriminator field
+### 💡 1. Explicit `__typename` Discriminator field
 
 This solution was discussed in https://github.com/graphql/graphql-spec/pull/395
 
@@ -309,7 +309,7 @@ type Mutation {
 
 -----
 
-### 2. Explicit configurable Discriminator field
+### 💡 2. Explicit configurable Discriminator field
 
 A configurable discriminator field enables schema authors to model type discrimination into their schema more naturally.
 
@@ -424,7 +424,7 @@ input DogInput {
 
 -----
 
-### 3. Order based type matching
+### 💡 3. Order based type matching
 
 The concrete type is the first type in the input union definition that matches.
 
@@ -498,7 +498,7 @@ type Mutation {
 
 -----
 
-### 4. Structural uniqueness
+### 💡 4. Structural uniqueness
 
 Schema Rule: Each type in the union must have a unique set of required field names
 
@@ -570,7 +570,7 @@ input DogInput {
 
 -----
 
-### 5. One Of (Tagged Union)
+### 💡 5. One Of (Tagged Union)
 
 This solution was presented in:
 * https://github.com/graphql/graphql-spec/pull/395#issuecomment-361373097

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -186,7 +186,7 @@ Each criteria is identified with a `Letter` so they can be referenced in the res
 Solutions are evaluated and scored using a simple 3 part scale. A solution may have multiple evaluations based on variations present in the solution.
 
 * ✅ **Pass.** The solution clearly meets the criteria
-* ⚠️ **Warning.** The solution doesn't clearly meet or fail the criteria
+* ⚠️ **Warning.** The solution doesn't clearly meet or fail the criteria, or there is an important caveat to passing the criteria
 * 🚫 **Fail.** The solution clearly fails the criteria
 * ❔ The criteria hasn't been evaluated yet
 
@@ -250,7 +250,7 @@ Since the input object type is now a member of the input union, existing input o
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
+| ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
 
 ## 🎯 G. Input unions may include other input unions
 
@@ -276,11 +276,13 @@ Clients should be able to pass "natural" input data to unions without specially 
 
 Many people in the wild are solving the need for input unions with validation at run-time (e.g. using the "tagged union" pattern). Formalising support for these existing patterns in a non-breaking way would enable existing schemas to become retroactively more type-safe.
 
+Note: This criteria is similar to  [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
+
 * ✂️ Objection: The addition of a polymorphic input type shouldn't depend on the ability to change the type of an existing field or an existing usage pattern. One can always add new fields that leverage new features.
 
 | [1](#-1-explicit-__typename-discriminator-field) | [2](#-2-explicit-configurable-discriminator-field) | [3](#-3-order-based-discrimination) | [4](#-4-structural-uniqueness) | [5](#-5-one-of-tagged-union) |
 |----|----|----|----|----|
-| ❔ | ❔ | ❔ | ❔ | ❔ |
+| ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
 
 ## 🎯 J. A GraphQL schema that supports input unions can be queried by older GraphQL clients
 
@@ -388,10 +390,12 @@ type Mutation {
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * 🚫 Requires a type to provide a discriminator field
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
-  * 🚫 Discriminator field is required.
+  * ⚠️ Discriminator field is required.
   * ✅ Defaulting to the previous input type enables migration.
 * [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
+* [I. Input unions should be easy to upgrade from existing solutions](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions)
+  * ✅ Defaulting to the previous input type enables upgrading
 * [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
@@ -514,10 +518,12 @@ input DogInput {
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * 🚫 Requires a type to provide a discriminator field
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
-  * 🚫 Discriminator field is required.
-  * ✅ Defaulting to the previous input type enables migration.
+  * ⚠️ Discriminator field is required.
+  * ✅ Defaulting to the previous input type enables migration
 * [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ⚠️ One additional field is required.
+* [I. Input unions should be easy to upgrade from existing solutions](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions)
+  * ✅ Defaulting to the previous input type enables upgrading
 * [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
@@ -593,6 +599,8 @@ type Mutation {
   * ✅ Listing the old input type first enables migration
 * [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ✅ No extra fields or structure required
+* [I. Input unions should be easy to upgrade from existing solutions](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions)
+  * ✅ Listing the old input type first enables enables upgrading
 * [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
@@ -670,9 +678,11 @@ input DogInput {
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * 🚫 Ambiguous types unable to be discriminated. ex: `String` vs `Enum` vs `ID`
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
-  * ✅ All new types added to the union must differ structurally from the previous type
+  * ⚠️ All new types added to the union must differ structurally from the previous type
 * [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * ✅ No extra fields or structure required
+* [I. Input unions should be easy to upgrade from existing solutions](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions)
+  * ⚠️ All new types added to the union must differ structurally from the previous type
 * [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
@@ -732,9 +742,11 @@ type Mutation {
 * [E. A member type may be a Leaf type](#-e-a-member-type-may-be-a-leaf-type)
   * ✅ Any GraphQL type may be used
 * [F. Migrating a field to a polymorphic input type is non-breaking](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking)
-  * ✅ No migration required, as this is already possible
+  * ✅ No migration required, as this pattern is already possible
 * [H. Input unions should accept plain data](#-h-input-unions-should-accept-plain-data)
   * 🚫 The shape of a data structure is forced to contain an intermediate type
+* [I. Input unions should be easy to upgrade from existing solutions](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions)
+  * ✅ No migration required, as this pattern is already possible
 * [J. A GraphQL schema that supports input unions can be queried by older GraphQL clients](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients)
   * ✅ Changes are additive only
 
@@ -750,10 +762,10 @@ A quick glance at the evaluation results. Remember that passing or failing a spe
 | [C](#-c-doesnt-inhibit-schema-evolution) | ✅ | ✅ | 🚫 | ⚠️ | ✅ |
 | [D](#-d-any-member-type-restrictions-are-validated-in-schema) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [E](#-e-a-member-type-may-be-a-leaf-type) | 🚫 | 🚫 | ✅⚠️ | 🚫 | ✅ |
-| [F](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking) | 🚫✅ | 🚫✅ | ✅ | ✅ | ✅ |
+| [F](#-f-migrating-a-field-to-a-polymorphic-input-type-is-non-breaking) | ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
 | [G](#-g-input-unions-may-include-other-input-unions) | ❔ | ❔ | ❔ | ❔ | ❔ |
 | [H](#-h-input-unions-should-accept-plain-data) | ⚠️ | ⚠️ | ✅ | ✅ | 🚫 |
-| [I](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions) | ❔ | ❔ | ❔ | ❔ | ❔ |
+| [I](#-i-input-unions-should-be-easy-to-upgrade-from-existing-solutions) | ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
 | [J](#-j-a-graphql-schema-that-supports-input-unions-can-be-queried-by-older-graphql-clients) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [K](#-k-input-unions-should-be-expressed-efficiently-in-the-query-and-on-the-wire) | ❔ | ❔ | ❔ | ❔ | ❔ |
 | [L](#-l-input-unions-should-be-performant-for-servers) | ❔ | ❔ | ❔ | ❔ | ❔ |

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -169,6 +169,7 @@ There have been a variety of use cases described by users asking for an abstract
 * [Observability Cloud Integrations](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#cloud-integrations)
 * [Observability Dashboards](https://gist.github.com/binaryseed/f2dd63d1a1406124be70c17e2e796891#dashboards)
 
+-----
 
 ## ⚖️ Solution Criteria
 
@@ -253,6 +254,7 @@ Ideally a server does not have to do much computation to determine which concret
 
 * ✂️ Objection: None of the solutions discussed so far do anything that is computationally expensive.
 
+-----
 
 ## 🏗 Possible Solutions
 
@@ -475,26 +477,18 @@ type Mutation {
 * [C - Doesn't inhibit schema evolution](#c-doesnt-inhibit-schema-evolution)
   * 🚫 Adding a nullable field to an input object could change the detected type of fields or arguments in pre-existing operations.
 
-<details>
-  <summary>
-    Demonstration
-  </summary>
+    Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
 
-  Using the example Schema, we can demonstrate this problem. Assume a mutation like this is being submitted:
+    ```graphql
+    mutation {
+      logAnimalDropOff(
+        location: "Portland, OR"
+        animals: [{name: "Old Yeller", age: 10, owner: "Travis"}]
+      )
+    }
+    ```
 
-  ```graphql
-  mutation {
-    logAnimalDropOff(
-      location: "Portland, OR",
-      animals: [
-        {name: "Spot", age: 5, owner: "Sally"}
-      ]
-    )
-  }
-  ```
-
-  Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, that becomes `CatInput` even though the mutation submitted has not changed.
-</details>
+    Currently, order based type descrimination resolves to `DogInput`. However, if we modify `CatInput` to contain an `owner` field, type descrimination changes to `CatInput` even though the mutation submitted has not changed.
 
 -----
 


### PR DESCRIPTION
After further reviewing the state of this document, I'm not sure we're ready to lay out a matrix of evaluations yet. I believe we need to first decide what criteria matter to us first.

To that end, I've temporarily removed the evaluation matrix (we can add it back in the future), done a small amount of cleanup, and added a few more "Objections" to the criteria.

I think we should try to reach agreement about which of the criteria are `MUST`. If a criteria is  `MUST`, then failing it would strike a solution off the table for consideration...

Perhaps each criterial should have `MUST`, `SHOULD` or `MAY` in it's title ?

cc/ @spawnia @jturkel @benjie