### PR TITLE
[RFC] Add note recommending directive names to be namespaced

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1095,11 +1095,6 @@ and operations.
 As future versions of GraphQL adopt new configurable execution capabilities,
 they may be exposed via directives.
 
-Note: When defining a directive, it is recommended to namespace the directive name 
-to prevent name collisions with directives added in future versions of the specification. 
-For example, `@fb_auth` directive would represent an authentication directive 
-with the prefix `fb` as namespace.
-
 **Directive order is significant**
 
 Directives may be provided in a specific syntactic order which may have semantic interpretation.

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1095,6 +1095,11 @@ and operations.
 As future versions of GraphQL adopt new configurable execution capabilities,
 they may be exposed via directives.
 
+Note: When defining a directive, it is recommended to namespace the directive name 
+to prevent name collisions with directives added in future versions of the specification. 
+For example, `@fb_auth` directive would represent an authentication directive 
+with the prefix `fb` as namespace.
+
 **Directive order is significant**
 
 Directives may be provided in a specific syntactic order which may have semantic interpretation.

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1093,7 +1093,9 @@ Directives can be used to describe additional information for types, fields, fra
 and operations.
 
 As future versions of GraphQL adopt new configurable execution capabilities,
-they may be exposed via directives.
+they may be exposed via directives. GraphQL services and tools may also provide
+additional [custom directives](#sec-Type-System.Directives.Custom-Directives)
+beyond those described here.
 
 **Directive order is significant**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1650,6 +1650,21 @@ GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of
 the schema.
 
+**Custom Directives**
+
+GraphQL services and client tooling may provide additional directives beyond
+those defined in this document. Directives are the preferred way to extend
+GraphQL with custom or experimental behavior.
+
+Note: When defining a directive, it is recommended to prefix the directive's
+name to make its scope of usage clear and to prevent a collision with directives
+which may be specified by future versions of this document (which will not
+include `_` in their name). For example, a custom directive used by Facebook's
+GraphQL service should be named `@fb_auth` instead of `@auth`. This is
+especially recommended for proposed additions to this specification which can
+change during the [RFC process](https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md).
+For example an work in progress version of `@live` should be named `@rfc_live`.
+
 Directives must only be used in the locations they are declared to belong in.
 In this example, a directive is defined which can be used to annotate a field:
 
@@ -1660,11 +1675,6 @@ fragment SomeFragment on SomeType {
   field @example
 }
 ```
-
-Note: When defining a directive, it is recommended to namespace the directive name
-to prevent name collisions with directives added in future versions of the specification.
-For example, `@fb_auth` directive would represent an authentication directive
-with the prefix `fb` as namespace.
 
 Directive locations may be defined with an optional leading `|` character to aid
 formatting when representing a longer list of possible locations:

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1661,6 +1661,11 @@ fragment SomeFragment on SomeType {
 }
 ```
 
+Note: When defining a directive, it is recommended to namespace the directive name
+to prevent name collisions with directives added in future versions of the specification.
+For example, `@fb_auth` directive would represent an authentication directive
+with the prefix `fb` as namespace.
+
 Directive locations may be defined with an optional leading `|` character to aid
 formatting when representing a longer list of possible locations:
 


### PR DESCRIPTION
As discussed in the[ 2012-12-05 working group meeting](https://github.com/graphql/graphql-wg/pull/323/commits/3c655a5bb3afafded7018080499385f71705366b#diff-637514917372885a3bba983f64fcff11R69), this informal RFC proposes adding a non-normative note recommending directive names to be namespaced to prevent name collisions when the specification adds new directives.

### Motivation / Context
The [Custom Scalar Specification URIs RFC](https://github.com/graphql/graphql-spec/pull/649) was discussed during multiple working group meetings and the potential winning approach involves defining a new standard directive named `@specified`. Existing GraphQL schemas that already defined this directive would now break as directive names must be unique. To prevent this inconvenience, it was proposed we add an explicit note to the specification recommending schema designers to prefix/namespace directive names to prevent name collisions when upgrading their GraphQL server.

## Open Questions
* I couldn't find any nomenclature in the specification to differentiate directives defined by the specification and directives defined by schema designers. I did "hear" terms such as "standard", "built-in" for the former, and  "custom" directives for the latter. Maybe it would be a good idea to introduce such terms to make the specification text clearer. Thoughts?
* I added an example but I can remove it if it is deemed unnecessary.
