### PR TITLE
[editorial] Localized note about order of skip and include directives

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -535,6 +535,9 @@ DoesFragmentTypeApply(objectType, fragmentType):
   * If {fragmentType} is a Union:
     * if {objectType} is a possible type of {fragmentType}, return {true} otherwise return {false}.
 
+Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
+directives may be applied in either order since they apply commutatively.
+
 
 ## Executing Fields
 


### PR DESCRIPTION
While a similar note already exists where the `@skip` and `@include` are defined, some confusion about this still exists so adding a small note where the CollectFields algorithm is defined to explain that these steps can be applied commutatively.