### PR TITLE
[RFC] allow empty selections

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -311,7 +311,7 @@ Note: many examples below will use the query short-hand syntax.
 
 ## Selection Sets
 
-SelectionSet : { Selection+ }
+SelectionSet : { Selection* }
 
 Selection :
   - Field

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -569,7 +569,7 @@ fragment conflictingDifferingResponses on Pet {
   * If {selectionType} is a scalar or enum:
     * The subselection set of that selection must be empty
   * If {selectionType} is an interface, union, or object
-    * The subselection set of that selection must NOT BE empty
+    * The subselection set of that selection must exist, but CAN BE empty
 
 **Explanatory Text**
 
@@ -621,6 +621,14 @@ query directQueryOnInterfaceWithoutSubFields {
 
 query directQueryOnUnionWithoutSubFields {
   catOrDog
+}
+```
+
+However, an empty selection is valid
+
+```graphql example
+query directQueryOnObjectWithEmptySubFields {
+  catOrDog {}
 }
 ```
 


### PR DESCRIPTION
Sometimes, product code might only be interested in the existence of an object. Currently, this forces a workaround of either querying `__typename` or adding a bool field like `has_thing`.

It seems natural and not too confusing to allow empty selections:

```
query {
  event {
    location {}
  }
}
```

The response should either return `null` or an empty object for `location`.

(The spec changes are incomplete.)