### PR TITLE
[Input Union] Adjust weighting of criteria H

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -292,7 +292,7 @@ Clients should be able to pass "natural" input data to unions without specially 
 |----|----|----|----|----|
 | ⚠️ | ⚠️ | ✅ | ✅ | ⚠️ |
 
-Criteria score: 🥈
+Criteria score: 🥉
 
 ## 🎯 I. Input unions should be easy to upgrade from existing solutions
 
@@ -844,7 +844,7 @@ A quick glance at the evaluation results. Remember that passing or failing a spe
 | [E][criteria-e] 🥉 | 🚫 | 🚫 | ✅⚠️ | 🚫 | ✅ |
 | [F][criteria-f] 🥉 | ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
 | [G][criteria-g] 🥉 | ❔ | ❔ | ❔ | ❔ | ❔ |
-| [H][criteria-h] 🥈 | ⚠️ | ⚠️ | ✅ | ✅ | ⚠️ |
+| [H][criteria-h] 🥉 | ⚠️ | ⚠️ | ✅ | ✅ | ⚠️ |
 | [I][criteria-i] 🥉 | ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
 | [J][criteria-j] 🥇 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [K][criteria-k] 🥉 | ❔ | ❔ | ❔ | ❔ | ✅ |


### PR DESCRIPTION
Original discussion here: https://github.com/graphql/graphql-spec/pull/677/files#r370736117

First comment:

> I'm not convinced this [criteria] is important - in fact I actively think this is a bad idea. All the transport-level prior art except OpenAPI 3 and JSON Schema have some extra metadata somehow to indicate the data type. The programming languages also have this (they can know what a type is in memory), but they don't seem so relevant here, so I've only included ones that talk about serialization/memory format:
>
> - Protocol Buffers / [Oneof](https://developers.google.com/protocol-buffers/docs/proto3#oneof)
>   > You also get a special method for checking which value (if any) in the oneof is set. 
> - FlatBuffers / [Union](https://google.github.io/flatbuffers/flatbuffers_guide_writing_schema.html)
>   > additionally a field with the suffix _type is generated that holds the corresponding enum value, allowing you to know which type to cast to at runtime
> - Cap'n Proto / [Union](https://capnproto.org/language.html#unions) (interestingly this is basically solution 5, and they call it Union anyway)
>   > A union is two or more fields of a struct which are stored in the same location. Only one of these fields can be set at a time, and a separate tag is maintained to track which one is currently set.
> - Thrift / [Union](https://thrift.apache.org/docs/idl#union) (solution 5)
>   > Unions are similar to structs, except that they provide a means to transport exactly one field of a possible set of fields, just like union {} in C++. Consequently, union members are implicitly considered optional (see requiredness).
> - Arvo / [Union](https://avro.apache.org/docs/current/spec.html#Unions)
>   >  two types with different names are permitted. (Names permit efficient resolution when reading and writing unions.)

cc @binaryseed 
