### PR TITLE
Update Grammar Summary with Interface ImplementsInterface

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -268,11 +268,12 @@ ArgumentsDefinition : ( InputValueDefinition+ )
 
 InputValueDefinition : Description? Name : Type DefaultValue? Directives[Const]?
 
-InterfaceTypeDefinition : Description? interface Name Directives[Const]? FieldsDefinition?
+InterfaceTypeDefinition : Description? interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition?
 
 InterfaceTypeExtension :
-  - extend interface Name Directives[Const]? FieldsDefinition
-  - extend interface Name Directives[Const]
+  - extend interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition
+  - extend interface Name ImplementsInterfaces? Directives[Const]
+  - extend interface Name ImplementsInterfaces
 
 UnionTypeDefinition : Description? union Name Directives[Const]? UnionMemberTypes?
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -975,7 +975,7 @@ Object type extensions have the potential to be invalid if incorrectly defined.
 
 ## Interfaces
 
-InterfaceTypeDefinition : Description? interface Name Directives[Const]? FieldsDefinition?
+InterfaceTypeDefinition : Description? interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition?
 
 GraphQL interfaces represent a list of named fields and their arguments. GraphQL
 objects and interfaces can then implement these interfaces which requires that
@@ -1164,8 +1164,9 @@ Interface types have the potential to be invalid if incorrectly defined.
 ### Interface Extensions
 
 InterfaceTypeExtension :
-  - extend interface Name Directives[Const]? FieldsDefinition
-  - extend interface Name Directives[Const]
+  - extend interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition
+  - extend interface Name ImplementsInterfaces? Directives[Const]
+  - extend interface Name ImplementsInterfaces
 
 Interface type extensions are used to represent an interface which has been
 extended from some original interface. For example, this might be used to


### PR DESCRIPTION
The Grammar for interfaces implementing interfaces wasn't updated when we added the descriptions for how interfaces implement interfaces

Now, besides the word `interface` vs `type`, the Interface grammar is identical to the Object grammar.

Updated both the "Appendix B -- Grammar Summary", as well as "Section 3 -- Type System"
