### PR TITLE
make clear that some String escape sequences are optional

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -821,10 +821,10 @@ be interpreted as the beginning of a block string. As an example, the source
 {`""""""`} can only be interpreted as a single empty block string and not three
 empty strings.
 
-Note: Unicode characters are allowed within standard quoted strings, however
-{SourceCharacter} must not contain some ASCII control characters so escape
-sequences must be used to represent these characters. Also {`\`}, {`"`} and {LineTerminator}
-must be escaped. All other escape sequences are optional.
+Non-ASCII Unicode characters are allowed within single-quoted strings. 
+Since {SourceCharacter} must not contain some ASCII control characters, escape 
+sequences must be used to represent these characters. The {`\`}, {`"`} 
+characters also must be escaped. All other escape sequences are optional.
 
 **Block Strings**
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -823,7 +823,8 @@ empty strings.
 
 Note: Unicode characters are allowed within String value literals, however
 {SourceCharacter} must not contain some ASCII control characters so escape
-sequences must be used to represent these characters.
+sequences must be used to represent these characters. Also {`\`}, {`"`} and {LineTerminator}
+must be escaped. All other escape sequences are optional.
 
 **Block Strings**
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -821,7 +821,7 @@ be interpreted as the beginning of a block string. As an example, the source
 {`""""""`} can only be interpreted as a single empty block string and not three
 empty strings.
 
-Note: Unicode characters are allowed within String value literals, however
+Note: Unicode characters are allowed within standard quoted strings, however
 {SourceCharacter} must not contain some ASCII control characters so escape
 sequences must be used to represent these characters. Also {`\`}, {`"`} and {LineTerminator}
 must be escaped. All other escape sequences are optional.


### PR DESCRIPTION
Escaping is not always required, but rather optional if the code point can be represent directly inside a String literal. This small change makes it clear.