### PR TITLE
[Editorial] Fix example for Variable Uniqueness

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1552,7 +1552,7 @@ query B($atOtherHomes: Boolean) {
   ...HouseTrainedFragment
 }
 
-fragment HouseTrainedFragment {
+fragment HouseTrainedFragment on Query {
   dog {
     isHousetrained(atOtherHomes: $atOtherHomes)
   }


### PR DESCRIPTION
I think the fragment definition in this example was wrong
