### PR TITLE
Contributing: issue or PR clarification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,10 @@ advancements typically occur during
 [Working Group](https://github.com/graphql/graphql-wg) meetings, however may
 occur on GitHub.
 
+In general, it's preferable to start with a pull request so that we can best
+evaluate the RFC in detail. However, starting with an issue is also permitted if
+the full details are not worked out.
+
 All RFCs start as either a *strawman* or *proposal*.
 
 ## Stage 0: *Strawman*


### PR DESCRIPTION
The contributing document was not clear on whether you should start with an issue or PR, and in looking through them, I see examples of both. So I assumed you must start with an issue. However then I was making the issue, it suggested I do a PR if I could.

So I'm providing this small update to the contributors document to clarify this point.
