### PR TITLE
add spec for punctuatedName and namedType #709

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -4,7 +4,7 @@ A GraphQL server supports introspection over its schema. This schema is queried
 using GraphQL itself, creating a powerful platform for tool-building.
 
 Take an example query for a trivial app. In this case there is a User type with
-three fields: id, name, and birthday.
+four fields: id, name, birthday, and messages.
 
 For example, given a server with the following type definition:
 
@@ -13,6 +13,7 @@ type User {
   id: String
   name: String
   birthday: Date
+  messages: [Message!]!
 }
 ```
 
@@ -26,6 +27,10 @@ The query
       name
       type {
         name
+        punctuatedName
+        namedType {
+          name
+        }
       }
     }
   }
@@ -41,16 +46,36 @@ would return
     "fields": [
       {
         "name": "id",
-        "type": { "name": "String" }
+        "type": {
+          "name": "String",
+          "punctuatedName": "String",
+          "namedType": { "name": "String" }
+        }
       },
       {
         "name": "name",
-        "type": { "name": "String" }
+        "type": {
+          "name": "String",
+          "punctuatedName": "String",
+          "namedType": { "name": "String" }
+        }
       },
       {
         "name": "birthday",
-        "type": { "name": "Date" }
+        "type": {
+          "name": "Date",
+          "punctuatedName": "Date",
+          "namedType": { "name": "Date" }
+        }
       },
+      {
+        "name": "messages",
+        "type": {
+          "name": null,
+          "punctuatedName": "[Message!]!",
+          "namedType": { "name": "Message" }
+        }
+      }
     ]
   }
 }
@@ -129,6 +154,8 @@ type __Type {
   kind: __TypeKind!
   name: String
   description: String
+  punctuatedName: String!
+  namedType: __Type!
 
   # should be non-null for OBJECT and INTERFACE only, must be null for the others
   fields(includeDeprecated: Boolean = false): [__Field!]
@@ -242,6 +269,8 @@ Fields
 * `kind` must return `__TypeKind.SCALAR`.
 * `name` must return a String.
 * `description` may return a String or {null}.
+* `punctuatedName` must return `name`.
+* `namedType` must return a reference to the __Type object {this}.
 * All other fields must return {null}.
 
 
@@ -259,6 +288,8 @@ Fields
   * Accepts the argument `includeDeprecated` which defaults to {false}. If
     {true}, deprecated fields are also returned.
 * `interfaces`: The set of interfaces that an object implements.
+* `punctuatedName` must return `name`.
+* `namedType` must return a reference to the __Type object {this}.
 * All other fields must return {null}.
 
 
@@ -275,6 +306,8 @@ Fields
 * `description` may return a String or {null}.
 * `possibleTypes` returns the list of types that can be represented within this
   union. They must be object types.
+* `punctuatedName` must return `name`.
+* `namedType` must return a reference to the __Type object {this}.
 * All other fields must return {null}.
 
 
@@ -296,6 +329,8 @@ Fields
 * `interfaces`: The set of interfaces that this interface implements.
 * `possibleTypes` returns the list of types that implement this interface.
   They must be object types.
+* `punctuatedName` must return `name`.
+* `namedType` must return a reference to the __Type object {this}.
 * All other fields must return {null}.
 
 
@@ -312,6 +347,8 @@ Fields
   must have unique names.
   * Accepts the argument `includeDeprecated` which defaults to {false}. If
     {true}, deprecated enum values are also returned.
+* `punctuatedName` must return `name`.
+* `namedType` must return a reference to the __Type object {this}.
 * All other fields must return {null}.
 
 
@@ -335,6 +372,8 @@ Fields
 * `name` must return a String.
 * `description` may return a String or {null}.
 * `inputFields`: a list of `InputValue`.
+* `punctuatedName` must return `name`.
+* `namedType` must return a reference to the __Type object {this}.
 * All other fields must return {null}.
 
 
@@ -348,6 +387,8 @@ Fields
 
 * `kind` must return `__TypeKind.LIST`.
 * `ofType`: Any type.
+* `punctuatedName` must return `'[' + ofType.punctuatedName + ']'`.
+* `namedType` must return `ofType.namedType`.
 * All other fields must return {null}.
 
 
@@ -361,6 +402,8 @@ required inputs for arguments and input object fields.
 
 * `kind` must return `__TypeKind.NON_NULL`.
 * `ofType`: Any type except Non-null.
+* `punctuatedName` must return `ofType.punctuatedName + '!'`.
+* `namedType` must return `ofType.namedType`.
 * All other fields must return {null}.
 
 


### PR DESCRIPTION
**Problem**: There are a few issues one runs into when using the introspection of a schema to get the return types of fields.
- nested query required for each NonNull and List means never guaranteed to get the full return type of a field on the first query
- requires more effort than necessary to piece together the return type of a field

Example:
```gql
type StringTable {
    values: [[String!]!]!
}
```

As seen, StringTable is a simple container for a string[][]. The query just to find that out would look like this:

```gql
{
    __type(name:"StringTable") {
        kind
        name
        fields {
            name
            type {
                kind
                name
                ofType {
                    kind
                    name
                    ofType {
                        kind
                        name
                        ofType {
                            kind
                            name
                            ofType {
                                kind
                                name
                                ofType {
                                    kind
                                    name
                                }
                            }
                        }
                    }
                }
            }
        }
    }
}
```

The output of which is as follows:
```json
{
  "data": {
    "__type": {
      "kind": "OBJECT",
      "name": "StringTable",
      "fields": [
        {
          "name": "values",
          "type": {
            "kind": "NON_NULL",
            "name": null,
            "ofType": {
              "kind": "LIST",
              "name": null,
              "ofType": {
                "kind": "NON_NULL",
                "name": null,
                "ofType": {
                  "kind": "LIST",
                  "name": null,
                  "ofType": {
                    "kind": "NON_NULL",
                    "name": null,
                    "ofType": {
                      "kind": "SCALAR",
                      "name": "String"
                    }
                  }
                }
              }
            }
          }
        }
      ]
    }
  }
}
```

All that just for just one field is unnecessary. It's even worse when viewing several fields for several types. If there were another List added for some reason, the query would need to be modified to add another level and resent. To avoid the process of modifying and resending queries, the initial query usually includes several levels to start.

**Solution:** I'd like to propose adding two fields to __Type: `namedType` and `punctuatedName`.

```gql
extend type __Type {
    namedType: __Type!
    punctuatedName: String!
}
```

`namedType` returns the underlying named type, found by continually unwrapping the type until a named type is found - i.e. the type with all non-null and list wrappers removed.

`punctuatedName` returns the name of the (wrapped) type as it would be expressed in [GraphQL's IDL](https://spec.graphql.org/draft/#sec-Type-System); i.e. the underlying named types' name with additional punctuators from wrapping Lists and NonNulls.

Depending on the type's kind, `namedType` would resolve to the following:
- Lists & NonNulls: `namedType := ofType.namedType`
- All other types: `namedType` would yield a reference to itself.

Depending on the type's kind, `punctuatedName` would resolve to the following:
- Lists: `punctuatedName := '[' + ofType.punctuatedName + ']'`
- NonNulls: `punctuatedName := ofType.punctuatedName + '!'`
- All other types: `punctuatedName := name`

Adding `namedType` and `punctuatedName` to __Type would allow for the following query:

```gql
{
    __type(name:"StringTable") {
        kind
        name
        fields {
            name
            type {
                name
                namedType {
                  kind
                  name
                }
                punctuatedName
            }
        }
    }
}
```

Which would yield the following output:

```json
{
  "data": {
    "__type": {
      "kind": "OBJECT",
      "name": "StringTable",
      "fields": [
        {
          "name": "values",
          "type": {
            "name": null,
            "namedType": {
              "kind": "SCALAR",
              "name": "String"
            },
            "punctuatedName": "[[String!]!]!"
          }
        }
      ]
    }
  }
}
```

As seen, that is a much more compact query and response. It would also guarantee to provide a return information about the fields base type or punctuated name for any given field on the first request.
