### PR TITLE
[grammar] add "the " to Type Condition section

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -609,7 +609,7 @@ object).
 
 Fragments can be specified on object types, interfaces, and unions.
 
-Selections within fragments only return values when concrete type of the object
+Selections within fragments only return values when the concrete type of the object
 it is operating on matches the type of the fragment.
 
 For example in this query on the Facebook data model:


### PR DESCRIPTION
4 character PR 👍 

There's also a reference to an earlier example in the "Fragments" section that reads a lot like the example was accidentally omitted:
> Fragments must specify the type they apply to. In this example, `friendFields`
can be used in the context of querying a `User`.

