### PR TITLE
[RFC] Allow @deprecated directive for input fields

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1901,7 +1901,7 @@ must *not* be queried if either the `@skip` condition is true *or* the
 ```graphql
 directive @deprecated(
   reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE
+) on FIELD_DEFINITION | ENUM_VALUE | INPUT_FIELD_DEFINITION
 ```
 
 The `@deprecated` directive is used within the type system definition language


### PR DESCRIPTION
The PR fixes the problem that in the current specification it is not allowed to use the `@deprecated` directive for input fields.