### PR TITLE
[Editorial]: Use non-null for if variable in @skip and @include

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1863,7 +1863,7 @@ In this example `experimentalField` will only be queried if the variable
 `$someTest` has the value `false`.
 
 ```graphql example
-query myQuery($someTest: Boolean) {
+query myQuery($someTest: Boolean!) {
   experimentalField @skip(if: $someTest)
 }
 ```
@@ -1883,7 +1883,7 @@ In this example `experimentalField` will only be queried if the variable
 `$someTest` has the value `true`
 
 ```graphql example
-query myQuery($someTest: Boolean) {
+query myQuery($someTest: Boolean!) {
   experimentalField @include(if: $someTest)
 }
 ```


### PR DESCRIPTION
To match argument type in directive definitions