### PR TITLE
Formatting: use markdown lists in 'one of' lists

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -59,13 +59,13 @@ NameContinue ::
   - Digit
   - `_`
 
-Letter :: one of
-  `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`
-  `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
-  `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
+Letter :: one of  
+  `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`  
+  `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`  
+  `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`  
   `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
 
-Digit :: one of
+Digit :: one of  
   `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
 IntValue :: IntegerPart [lookahead != {Digit, `.`, NameStart}]
@@ -313,25 +313,25 @@ DirectiveLocation :
   - ExecutableDirectiveLocation
   - TypeSystemDirectiveLocation
 
-ExecutableDirectiveLocation : one of
-  `QUERY`
-  `MUTATION`
-  `SUBSCRIPTION`
-  `FIELD`
-  `FRAGMENT_DEFINITION`
-  `FRAGMENT_SPREAD`
-  `INLINE_FRAGMENT`
+ExecutableDirectiveLocation : one of  
+  `QUERY`  
+  `MUTATION`  
+  `SUBSCRIPTION`  
+  `FIELD`  
+  `FRAGMENT_DEFINITION`  
+  `FRAGMENT_SPREAD`  
+  `INLINE_FRAGMENT`  
   `VARIABLE_DEFINITION`
 
-TypeSystemDirectiveLocation : one of
-  `SCHEMA`
-  `SCALAR`
-  `OBJECT`
-  `FIELD_DEFINITION`
-  `ARGUMENT_DEFINITION`
-  `INTERFACE`
-  `UNION`
-  `ENUM`
-  `ENUM_VALUE`
-  `INPUT_OBJECT`
+TypeSystemDirectiveLocation : one of  
+  `SCHEMA`  
+  `SCALAR`  
+  `OBJECT`  
+  `FIELD_DEFINITION`  
+  `ARGUMENT_DEFINITION`  
+  `INTERFACE`  
+  `UNION`  
+  `ENUM`  
+  `ENUM_VALUE`  
+  `INPUT_OBJECT`  
   `INPUT_FIELD_DEFINITION`

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -59,14 +59,14 @@ NameContinue ::
   - Digit
   - `_`
 
-Letter :: one of  
-  `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`  
-  `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`  
-  `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`  
-  `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
+Letter :: one of
+  - `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`
+  - `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
+  - `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
+  - `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
 
-Digit :: one of  
-  `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
+Digit :: one of
+  - `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
 IntValue :: IntegerPart [lookahead != {Digit, `.`, NameStart}]
 
@@ -313,25 +313,25 @@ DirectiveLocation :
   - ExecutableDirectiveLocation
   - TypeSystemDirectiveLocation
 
-ExecutableDirectiveLocation : one of  
-  `QUERY`  
-  `MUTATION`  
-  `SUBSCRIPTION`  
-  `FIELD`  
-  `FRAGMENT_DEFINITION`  
-  `FRAGMENT_SPREAD`  
-  `INLINE_FRAGMENT`  
-  `VARIABLE_DEFINITION`
+ExecutableDirectiveLocation : one of
+  - `QUERY`
+  - `MUTATION`
+  - `SUBSCRIPTION`
+  - `FIELD`
+  - `FRAGMENT_DEFINITION`
+  - `FRAGMENT_SPREAD`
+  - `INLINE_FRAGMENT`
+  - `VARIABLE_DEFINITION`
 
-TypeSystemDirectiveLocation : one of  
-  `SCHEMA`  
-  `SCALAR`  
-  `OBJECT`  
-  `FIELD_DEFINITION`  
-  `ARGUMENT_DEFINITION`  
-  `INTERFACE`  
-  `UNION`  
-  `ENUM`  
-  `ENUM_VALUE`  
-  `INPUT_OBJECT`  
-  `INPUT_FIELD_DEFINITION`
+TypeSystemDirectiveLocation : one of
+  - `SCHEMA`
+  - `SCALAR`
+  - `OBJECT`
+  - `FIELD_DEFINITION`
+  - `ARGUMENT_DEFINITION`
+  - `INTERFACE`
+  - `UNION`
+  - `ENUM`
+  - `ENUM_VALUE`
+  - `INPUT_OBJECT`
+  - `INPUT_FIELD_DEFINITION`

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -200,13 +200,13 @@ NameContinue ::
   - Digit
   - `_`
 
-Letter :: one of
-  `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`
-  `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
-  `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
+Letter :: one of  
+  `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`  
+  `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`  
+  `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`  
   `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
 
-Digit :: one of
+Digit :: one of  
   `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
 GraphQL Documents are full of named things: operations, fields, arguments,

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -200,14 +200,14 @@ NameContinue ::
   - Digit
   - `_`
 
-Letter :: one of  
-  `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`  
-  `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`  
-  `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`  
-  `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
+Letter :: one of
+  - `A` `B` `C` `D` `E` `F` `G` `H` `I` `J` `K` `L` `M`
+  - `N` `O` `P` `Q` `R` `S` `T` `U` `V` `W` `X` `Y` `Z`
+  - `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` `m`
+  - `n` `o` `p` `q` `r` `s` `t` `u` `v` `w` `x` `y` `z`
 
-Digit :: one of  
-  `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
+Digit :: one of
+  - `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
 GraphQL Documents are full of named things: operations, fields, arguments,
 types, directives, fragments, and variables. All names must follow the same

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1785,27 +1785,27 @@ DirectiveLocation :
   - ExecutableDirectiveLocation
   - TypeSystemDirectiveLocation
 
-ExecutableDirectiveLocation : one of
-  `QUERY`
-  `MUTATION`
-  `SUBSCRIPTION`
-  `FIELD`
-  `FRAGMENT_DEFINITION`
-  `FRAGMENT_SPREAD`
-  `INLINE_FRAGMENT`
+ExecutableDirectiveLocation : one of  
+  `QUERY`  
+  `MUTATION`  
+  `SUBSCRIPTION`  
+  `FIELD`  
+  `FRAGMENT_DEFINITION`  
+  `FRAGMENT_SPREAD`  
+  `INLINE_FRAGMENT`  
   `VARIABLE_DEFINITION`
 
-TypeSystemDirectiveLocation : one of
-  `SCHEMA`
-  `SCALAR`
-  `OBJECT`
-  `FIELD_DEFINITION`
-  `ARGUMENT_DEFINITION`
-  `INTERFACE`
-  `UNION`
-  `ENUM`
-  `ENUM_VALUE`
-  `INPUT_OBJECT`
+TypeSystemDirectiveLocation : one of  
+  `SCHEMA`  
+  `SCALAR`  
+  `OBJECT`  
+  `FIELD_DEFINITION`  
+  `ARGUMENT_DEFINITION`  
+  `INTERFACE`  
+  `UNION`  
+  `ENUM`  
+  `ENUM_VALUE`  
+  `INPUT_OBJECT`  
   `INPUT_FIELD_DEFINITION`
 
 A GraphQL schema describes directives which are used to annotate various parts

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1785,28 +1785,28 @@ DirectiveLocation :
   - ExecutableDirectiveLocation
   - TypeSystemDirectiveLocation
 
-ExecutableDirectiveLocation : one of  
-  `QUERY`  
-  `MUTATION`  
-  `SUBSCRIPTION`  
-  `FIELD`  
-  `FRAGMENT_DEFINITION`  
-  `FRAGMENT_SPREAD`  
-  `INLINE_FRAGMENT`  
-  `VARIABLE_DEFINITION`
+ExecutableDirectiveLocation : one of
+  - `QUERY`
+  - `MUTATION`
+  - `SUBSCRIPTION`
+  - `FIELD`
+  - `FRAGMENT_DEFINITION`
+  - `FRAGMENT_SPREAD`
+  - `INLINE_FRAGMENT`
+  - `VARIABLE_DEFINITION`
 
-TypeSystemDirectiveLocation : one of  
-  `SCHEMA`  
-  `SCALAR`  
-  `OBJECT`  
-  `FIELD_DEFINITION`  
-  `ARGUMENT_DEFINITION`  
-  `INTERFACE`  
-  `UNION`  
-  `ENUM`  
-  `ENUM_VALUE`  
-  `INPUT_OBJECT`  
-  `INPUT_FIELD_DEFINITION`
+TypeSystemDirectiveLocation : one of
+  - `SCHEMA`
+  - `SCALAR`
+  - `OBJECT`
+  - `FIELD_DEFINITION`
+  - `ARGUMENT_DEFINITION`
+  - `INTERFACE`
+  - `UNION`
+  - `ENUM`
+  - `ENUM_VALUE`
+  - `INPUT_OBJECT`
+  - `INPUT_FIELD_DEFINITION`
 
 A GraphQL schema describes directives which are used to annotate various parts
 of a GraphQL document as an indicator that they should be evaluated differently


### PR DESCRIPTION
`spec-md` recently [added support for bulleted "one of" productions](https://github.com/leebyron/spec-md/pull/51); this PR leverages this features to make the "one of" productions render similarly in regular markdown parsers (such as GitHub's) as they do in `spec-md`.

This is a precursor to formatting the spec with `prettier` (since, without this formatting, prettier will remove these "significant" line breaks).

---

Originally attempted with Markdown linebreaks, but there was significant pushback. ~~These whitespace changes make the `one of` lists render similarly in regular markdown parsers (such as GitHub's) as they do in `spec-md`.~~