### PR TITLE
Add explanation about argument name uniquess.

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -816,7 +816,9 @@ of rules must be adhered to by every Object type in a GraphQL schema.
    4. For each argument of the field:
       1. The argument must not have a name which begins with the
          characters {"__"} (two underscores).
-      2. The argument must accept a type where {IsInputType(argumentType)}
+      2. The argument must have a unique name within that field;
+         no two arguments may share the same name.
+      3. The argument must accept a type where {IsInputType(argumentType)}
          returns {true}.
 3. An object type may declare that it implements one or more unique interfaces.
 4. An object type must be a super-set of all interfaces it implements:
@@ -1158,7 +1160,9 @@ Interface types have the potential to be invalid if incorrectly defined.
    4. For each argument of the field:
       1. The argument must not have a name which begins with the
          characters {"__"} (two underscores).
-      2. The argument must accept a type where {IsInputType(argumentType)}
+      2. The argument must have a unique name within that field;
+         no two arguments may share the same name.
+      3. The argument must accept a type where {IsInputType(argumentType)}
          returns {true}.
 3. An interface type may declare that it implements one or more unique
    interfaces, but may not implement itself.
@@ -1846,7 +1850,9 @@ repeatable directives.
 4. For each argument of the directive:
    1. The argument must not have a name which begins with the
       characters {"__"} (two underscores).
-   2. The argument must accept a type where {IsInputType(argumentType)}
+   2. The argument must have a unique name within that field;
+      no two arguments may share the same name.
+   3. The argument must accept a type where {IsInputType(argumentType)}
       returns {true}.
 
 ### @skip


### PR DESCRIPTION
Add explanation about argument name uniquess.

Arguments of a single field in interface, object, directive must not share the same name.