### PR TITLE
Clarify how lexical tokens are separated

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -98,9 +98,9 @@ LineTerminator ::
   - "Carriage Return (U+000D)" "New Line (U+000A)"
 
 Like white space, line terminators are used to improve the legibility of source
-text and separate lexical tokens, any amount may appear before or after any other token and have no
-significance to the semantic meaning of a GraphQL Document. Line
-terminators are not found within any other token.
+text and separate lexical tokens, any amount may appear before or after any 
+other token and have no significance to the semantic meaning of a GraphQL 
+Document. Line terminators are not found within any other token.
 
 Note: Any error reporting which provide the line number in the source of the
 offending syntax should use the preceding amount of {LineTerminator} to produce
@@ -137,7 +137,7 @@ syntactically and semantically insignificant within GraphQL Documents.
 Non-significant comma characters ensure that the absence or presence of a comma
 does not meaningfully alter the interpreted syntax of the document, as this can
 be a common user-error in other languages. It also allows for the stylistic use
-of either trailing commas or line-terminators as list delimiters which are both
+of either trailing commas or line terminators as list delimiters which are both
 often desired for legibility and maintainability of source code.
 
 
@@ -152,7 +152,7 @@ Token ::
 
 A GraphQL document is comprised of several kinds of indivisible lexical tokens
 defined here in a lexical grammar by patterns of source Unicode characters. 
-Lexical tokens must be separated by either white space, line terminators, or commas.
+Lexical tokens may be separated by {Ignored} tokens.
 
 Tokens are later used as terminal symbols in GraphQL syntactic grammar rules.
 
@@ -167,8 +167,8 @@ Ignored ::
   - Comma
 
 {Ignored} tokens are used to improve readability and provide separation between
-{Token}s, but are otherwise insignificant and not referenced in syntactical
-grammar productions.
+Lexical tokens, but are otherwise insignificant and not referenced in
+syntactical grammar productions.
 
 Any amount of {Ignored} may appear before and after every lexical token. No
 ignored regions of a source document are significant, however {SourceCharacter}

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -98,7 +98,7 @@ LineTerminator ::
   - "Carriage Return (U+000D)" "New Line (U+000A)"
 
 Like white space, line terminators are used to improve the legibility of source
-text, any amount may appear before or after any other token and have no
+text and separate lexical tokens, any amount may appear before or after any other token and have no
 significance to the semantic meaning of a GraphQL Document. Line
 terminators are not found within any other token.
 
@@ -151,7 +151,8 @@ Token ::
   - StringValue
 
 A GraphQL document is comprised of several kinds of indivisible lexical tokens
-defined here in a lexical grammar by patterns of source Unicode characters.
+defined here in a lexical grammar by patterns of source Unicode characters. 
+Lexical tokens must be separated by either white space, line terminators, or commas.
 
 Tokens are later used as terminal symbols in GraphQL syntactic grammar rules.
 
@@ -166,7 +167,7 @@ Ignored ::
   - Comma
 
 {Ignored} tokens are used to improve readability and provide separation between
-{Token}, but are otherwise insignificant and not referenced in syntactical
+{Token}s, but are otherwise insignificant and not referenced in syntactical
 grammar productions.
 
 Any amount of {Ignored} may appear before and after every lexical token. No

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -167,7 +167,7 @@ Ignored ::
   - Comma
 
 {Ignored} tokens are used to improve readability and provide separation between
-Lexical tokens, but are otherwise insignificant and not referenced in
+lexical tokens, but are otherwise insignificant and not referenced in
 syntactical grammar productions.
 
 Any amount of {Ignored} may appear before and after every lexical token. No


### PR DESCRIPTION
1. The **Line Terminators** section (2.1.3) didn't mention that they can be used to separate tokens, but this is implied in other sections (2.1.5 and 2.1.7). If it's true that in GraphQL line terminators alone can be used to separate tokens, this should be stated explicitly in the Line Terminators section.

2. The **Lexical Tokens** section (2.1.6) didn't say anything about how lexical tokens must be separated by either white space, line terminators, or commas. And this isn't stated anywhere else in one place. If it's true that they must be so separated, this should be stated explicitly in the Lexical Tokens section. Right now, this requirement scattered across different sections (and the Line Terminators section is silent on it).

3. Might want to revisit how commas are called "insignificant" (2.1.5) and how commas, white space, and line terminators are all called "ignored" tokens (2.1.7). Those are odd descriptors for tokens that are in fact required. That is, either white space, line terminators, or commas are required to separate tokens. Thus, they're not ignored or insignificant in the normal English usage of those terms, but there might be a spec-writing usage I'm not familiar with.

If you need to keep this usage, it might be worth collapsing "insignificant" and "ignored" (and "non-significant" in 2.1.5) into one or the other term. Section 2.1.5 is titled "Insignificant Commas", but 2.1.2 isn't called "Insignificant White Space" and 2.1.3 isn't called "Insignificant Line Terminators". They're just called "White Space" and "Line Terminators", and they're listed in 2.1.7 Ignored Tokens. Commas could be treated the same way, as just "Commas", and then just listed in 2.1.7.