### PR TITLE
Fixed a Deadlink in GraphQL.md

### DIFF
--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -79,7 +79,7 @@ is equivalent. Algorithms described in this document are written to be easy to
 understand. Implementers are encouraged to include equivalent but
 optimized implementations.
 
-See [Appendix A](#sec-Appendix-Notation-Conventions) for more details
+See [Appendix A](#appendix-notation-conventions) for more details
 about the definition of algorithms and other notational conventions used in this
 document.
 

--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -79,7 +79,7 @@ is equivalent. Algorithms described in this document are written to be easy to
 understand. Implementers are encouraged to include equivalent but
 optimized implementations.
 
-See [Appendix A](#appendix-notation-conventions) for more details
+See [Appendix A](#appendix-a-notation-conventions) for more details
 about the definition of algorithms and other notational conventions used in this
 document.
 
@@ -125,6 +125,6 @@ Note: This is an example of a non-normative note.
 
 # [Response](Section%207%20--%20Response.md)
 
-# [Appendix: Notation Conventions](Appendix%20A%20--%20Notation%20Conventions.md)
+# [Appendix A: Notation Conventions](Appendix%20A%20--%20Notation%20Conventions.md)
 
-# [Appendix: Grammar Summary](Appendix%20B%20--%20Grammar%20Summary.md)
+# [Appendix B: Grammar Summary](Appendix%20B%20--%20Grammar%20Summary.md)


### PR DESCRIPTION
The Appendix A link now is fixed and redirects the user to the particular section, Also I have renamed the Section to specify the Appendix A and B.
