### PR TITLE
Note that GraphQL Subscriptions are official

### DIFF
--- a/rfcs/Subscriptions.md
+++ b/rfcs/Subscriptions.md
@@ -1,3 +1,7 @@
+NOTE: this document is kept for historic purposes; GraphQL Subscriptions have been specified and released as part of the official [June 2018 GraphQL Specification](https://spec.graphql.org/June2018/).
+
+---
+
 RFC: GraphQL Subscriptions
 -------
 


### PR DESCRIPTION
This document has caused people unfamiliar with GraphQL to think that GraphQL Subscriptions are not yet fully specified/official. I suggest we add a note like this one to the top of the document to avoid confusion.