### PR TITLE
Fix Github template links

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,8 +4,8 @@ Before creating your issue:
 
 * Have a question? Find community resources at https://graphql.org/community/
 
-* Find an editing mistake? Create a Pull Request with the edited fix! The Github UI allows you to edit files directly, find the source files at: https://github.com/facebook/graphql/tree/master/spec
+* Find an editing mistake? Create a Pull Request with the edited fix! The Github UI allows you to edit files directly, find the source files at: https://github.com/graphql/graphql-spec/tree/master/spec
 
 * Improvements to documentation? Head over to https://github.com/graphql/graphql.github.io
 
-* Feature request? First read https://github.com/facebook/graphql/blob/master/CONTRIBUTING.md and prefer creating a Pull Request!
+* Feature request? First read https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md and prefer creating a Pull Request!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,3 @@
 !!! IMPORTANT !!!
 
-Please Read https://github.com/facebook/graphql/blob/master/CONTRIBUTING.md before creating a Pull Request.
+Please Read https://github.com/graphql/graphql-spec/blob/master/CONTRIBUTING.md before creating a Pull Request.


### PR DESCRIPTION
This PR fixes the links in the Github issue and pull request templates to point to https://github.com/graphql/graphql-spec rather than https://github.com/facebook/graphql.
