### PR TITLE
Update 'Field Collection' explanation

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -451,7 +451,7 @@ A correct executor must generate the following result for that selection set:
 Before execution, the selection set is converted to a grouped field set by
 calling {CollectFields()}. Each entry in the grouped field set is a list of
 fields that share a response key (the alias if defined, otherwise the field
-name). This ensures all fields with the same response key included via
+name). This ensures all fields with the same response key including via
 referenced fragments are executed at the same time.
 
 As an example, collecting the fields of this selection set would collect two


### PR DESCRIPTION
This change seems to alter the semantic of content, but I think this make semantic  to be more accurate. 

This ensures all fields with the same response key **included** via referenced fragments are executed at the same time.
This ensures all fields with the same response key **including** via referenced fragments are executed at the same time.