### PR TITLE
Make 'Field Selections' header stable

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -324,7 +324,9 @@ must provide the operation name as described in {GetOperation()}.
 
 ## Fields
 
-### Field Selections on Objects, Interfaces, and Unions Types
+### Field Selections
+
+Field selections must exist on Object, Interface, and Union types.
 
 **Formal Specification**
 


### PR DESCRIPTION
In #733, @leebyron [suggested renaming this header](https://github.com/graphql/graphql-spec/pull/733#discussion_r466619908) to simply 'Field Selections' with the line below it. I assume this is to increase the stability of this header such that permalinks to it will be stable.

It makes sense to me to introduce this change as early as possible, so I've separated it out into this PR.

Note: this also fixes a gramatical issue, it should read `on Objects, Interfaces, and Unions` or `on Object, Interface and Union Types`; the mixed plural currently seems incorrect.