### PR TITLE
__Type represents all types in the system

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -218,10 +218,10 @@ enum __DirectiveLocation {
 ### The __Type Type
 
 `__Type` is at the core of the type introspection system, it represents all
-types in the system: both named types and type modifiers.
-
-Type modifiers, which are used to modify a referenced type (`ofType: __Type`),
-are how we represent lists, non-nullable types, and the combinations thereof.
+types in the system: both named types (e.g. Scalars and Object types) and 
+type modifiers. Type modifiers are used to modify a referenced type 
+(`ofType: __Type`) to represent lists, non-nullable types, and the 
+combinations thereof.
 
 
 ### Type Kinds

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -217,12 +217,11 @@ enum __DirectiveLocation {
 
 ### The __Type Type
 
-`__Type` is at the core of the type introspection system. It represents all
-named types in the system.
+`__Type` is at the core of the type introspection system, it represents all
+types in the system: both named types and type modifiers.
 
-`__Type` also represents type modifiers, which are used to modify a type
-that it refers to (`ofType: __Type`). This is how we represent lists,
-non-nullable types, and the combinations thereof.
+Type modifiers, which are used to modify a referenced type (`ofType: __Type`),
+are how we represent lists, non-nullable types, and the combinations thereof.
 
 
 ### Type Kinds

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -219,10 +219,11 @@ enum __DirectiveLocation {
 
 `__Type` is at the core of the type introspection system, it represents all
 types in the system: both named types (e.g. Scalars and Object types) and 
-type modifiers. Type modifiers are used to modify a referenced type 
-(`ofType: __Type`) to represent lists, non-nullable types, and the 
-combinations thereof.
+type modifiers (e.g. List and Non-Null types). 
 
+Type modifiers are used to modify the type presented in the field `ofType`. 
+This modified type may recursively be a modified type, representing lists, 
+non-nullables, and combinations thereof, ultimately modifying a named type.
 
 ### Type Kinds
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -218,7 +218,7 @@ enum __DirectiveLocation {
 ### The __Type Type
 
 `__Type` is at the core of the type introspection system. It represents all
-types in the system.
+named types in the system.
 
 `__Type` also represents type modifiers, which are used to modify a type
 that it refers to (`ofType: __Type`). This is how we represent lists,

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -217,8 +217,8 @@ enum __DirectiveLocation {
 
 ### The __Type Type
 
-`__Type` is at the core of the type introspection system.
-It represents scalars, interfaces, object types, unions, enums, input objects types in the system.
+`__Type` is at the core of the type introspection system. It represents all
+types in the system.
 
 `__Type` also represents type modifiers, which are used to modify a type
 that it refers to (`ofType: __Type`). This is how we represent lists,

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -345,6 +345,9 @@ Lists represent sequences of values in GraphQL. A List type is a type modifier:
 it wraps another type instance in the `ofType` field, which defines the type of
 each item in the list.
 
+The modified type in the `ofType` field may itself be a modified type, allowing
+the representation of Lists of Lists, or Lists of Non-Nulls.
+
 Fields
 
 * `kind` must return `__TypeKind.LIST`.
@@ -356,12 +359,16 @@ Fields
 
 GraphQL types are nullable. The value {null} is a valid response for field type.
 
-A Non-null type is a type modifier: it wraps another type instance in the
+A Non-Null type is a type modifier: it wraps another type instance in the
 `ofType` field. Non-null types do not allow {null} as a response, and indicate
 required inputs for arguments and input object fields.
 
+The modified type in the `ofType` field may itself be a modified List type, 
+allowing the representation of Non-Null of Lists. However it must not be a 
+modified Non-Null type to avoid a redundant Non-Null of Non-Null.
+
 * `kind` must return `__TypeKind.NON_NULL`.
-* `ofType`: Any type except Non-null.
+* `ofType`: Any type except Non-Null.
 * All other fields must return {null}.
 
 


### PR DESCRIPTION
In https://github.com/graphql/graphql-spec/pull/733#discussion_r466615699 @leebyron noted:

> maybe we should just say: "It represents all types in the system."

I wasn't quite comfortable with what "all types" meant - whether it was inclusive or exclusive of modified types. The second paragraph implied exclusive due to the `also` but this didn't sit quite right with me. At first I edited it to say "all _named_ types in the system", but felt it made the second paragraph feel a bit disjoint.

I've further modified the text and feel it's much clearer now.

I'm trying to move discussions like this out of the Tagged type spec itself, to keep the signal to noise ratio high (and figure they're useful mods for any future type additions anyway, keeping maintenance burden down).