### PR TITLE
RFC: __typename is not valid at subscription root

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -98,7 +98,8 @@ identify which actual type of the possible types has been returned.
 
 This field is implicit and does not appear in the fields list in any defined type.
 
-Note: `__typename` may not be used as a root field in a subscription operation.
+Note: `__typename` may not be included as a root field in a subscription
+operation.
 
 ## Schema Introspection
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -89,9 +89,10 @@ warnings.
 
 ## Type Name Introspection
 
-GraphQL supports type name introspection at any point within a query by the
+GraphQL supports type name introspection at any point within an operation by the
 meta-field `__typename: String!` when querying against any Object, Interface,
-or Union. It returns the name of the object type currently being queried.
+or Union; with the single exception of the subscription root operation type. It
+returns the name of the object type currently being queried.
 
 This is most often used when querying against Interface or Union types to
 identify which actual type of the possible types has been returned.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -98,8 +98,7 @@ identify which actual type of the possible types has been returned.
 
 This field is implicit and does not appear in the fields list in any defined type.
 
-Note: `__typename` may not be used as a root field in a subscription operation
-because it does not return an async iterable.
+Note: `__typename` may not be used as a root field in a subscription operation.
 
 ## Schema Introspection
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -89,16 +89,17 @@ warnings.
 
 ## Type Name Introspection
 
-GraphQL supports type name introspection at any point within an operation by the
+GraphQL supports type name introspection at any point within a query by the
 meta-field `__typename: String!` when querying against any Object, Interface,
-or Union; with the single exception of the subscription root operation type. It
-returns the name of the object type currently being queried.
+or Union. It returns the name of the object type currently being queried.
 
 This is most often used when querying against Interface or Union types to
 identify which actual type of the possible types has been returned.
 
 This field is implicit and does not appear in the fields list in any defined type.
 
+Note: `__typename` may not be used as a root field in a subscription operation
+because it does not return an async iterable.
 
 ## Schema Introspection
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -249,10 +249,8 @@ query getName {
 * Let {variableValues} be the empty set.
 * Let {groupedFieldSet} be the result of
   {CollectFields(subscriptionType, selectionSet, variableValues)}.
-* {groupedFieldSet} must have exactly one entry.
-* Let {fields} be the value of the first entry in {groupedFieldSet}.
-* Let {field} be the first entry in {fields}.
-* {field} must not be an introspection field.
+* {groupedFieldSet} must have exactly one entry, which must not be an 
+  introspection field.
 
 **Explanatory Text**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -308,8 +308,8 @@ fragment multipleSubscriptions on Subscription {
 }
 ```
 
-The root field of an introspection operation must not be an introspection
-field. The following example is also invalid:
+The root field of a subscription operation must not be an introspection field.
+The following example is also invalid:
 
 ```graphql counter-example
 subscription sub {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -250,6 +250,9 @@ query getName {
 * Let {groupedFieldSet} be the result of
   {CollectFields(subscriptionType, selectionSet, variableValues)}.
 * {groupedFieldSet} must have exactly one entry.
+* Let {fields} be the value of the first entry in {groupedFieldSet}.
+* Let {field} be the first entry in {fields}.
+* {field} must not be an introspection field.
 
 **Explanatory Text**
 
@@ -305,14 +308,11 @@ fragment multipleSubscriptions on Subscription {
 }
 ```
 
-Introspection fields are counted. The following example is also invalid:
+The root field of an introspection operation must not be an introspection
+field. The following example is also invalid:
 
 ```graphql counter-example
 subscription sub {
-  newMessage {
-    body
-    sender
-  }
   __typename
 }
 ```


### PR DESCRIPTION
I'm writing up some of the GraphQL "query ambiguity" work currently and noticed this issue in the spec. In the case of a subscription it seems that

```graphql
subscription {
  __typename
}
```

does not correctly get evaluated by the reference implementation during subscriptions (though you can query it with `graphql(...)` you can't access it via `subscribe(...)`). It doesn't really make sense to request `__typename` here since it's not ever going to change during the life of the schema, and subscriptions only support one root-level field, however I thought it was worth highlighting.

Reproduction with GraphQL-js (toggle which `doc` is commented to see a functioning subscription):

```js
const {
  GraphQLSchema,
  GraphQLObjectType,
  GraphQLInt,
  GraphQLFloat,
  parse,
  validate,
  subscribe,
} = require("graphql");

const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));

async function* everySecond() {
  for (let i = 0; i < 1000; i++) {
    yield i;
    await sleep(1000);
  }
}

const Query = new GraphQLObjectType({
  name: "Query",
  fields: {
    a: {
      type: GraphQLInt,
    },
  },
});

const Subscription = new GraphQLObjectType({
  name: "Subscription",
  fields: {
    ts: {
      type: GraphQLFloat,
      subscribe() {
        return everySecond();
      },
      resolve() {
        return Date.now();
      },
    },
  },
});

const schema = new GraphQLSchema({
  query: Query,
  subscription: Subscription,
});

async function main() {
  const doc = parse("subscription { __typename }");
  // const doc = parse("subscription { ts }");
  const errors = validate(schema, doc);
  if (errors && errors.length) {
    console.dir(errors);
    throw new Error("Errors occurred");
  }
  const result = await subscribe(schema, doc);
  console.dir(result);
  for await (const r of result) {
    console.dir(r);
  }
}

main().catch(e => {
  console.dir(e);
  process.exit(1);
});
```

Produces this error:

```
Error: Subscription field must return Async Iterable. Received: undefined
    at [...]/node_modules/graphql/subscription/subscribe.js:169:13
    at async main ([...]/test.js:57:18)
```