### PR TITLE
Spec edits to reduce "query ambiguity"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ move forward. See editor Lee Byron talk about
 
   Once a query is written, it should always mean the same thing and return the
   same shaped result. Future changes should not change the meaning of existing
-  schema or queries or in any other way cause an existing compliant GraphQL
+  schema or operations or in any other way cause an existing compliant GraphQL
   service to become non-compliant for prior versions of the spec.
 
 * **Performance is a feature**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ move forward. See editor Lee Byron talk about
 
   Once a query is written, it should always mean the same thing and return the
   same shaped result. Future changes should not change the meaning of existing
-  schema or operations or in any other way cause an existing compliant GraphQL
+  schema or requests or in any other way cause an existing compliant GraphQL
   service to become non-compliant for prior versions of the spec.
 
 * **Performance is a feature**

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ type Droid implements Character {
 We're missing one last piece: an entry point into the type system.
 
 When we define a schema, we define an object type that is the basis for all
-queries. The name of this type is `Query` by convention, and it describes
+query operations. The name of this type is `Query` by convention, and it describes
 our public, top-level API. Our `Query` type for this example will look like
 this:
 

--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -26,7 +26,7 @@ Which produces the resulting data (in JSON):
 ```
 
 GraphQL is not a programming language capable of arbitrary computation, but is
-instead a language used to query application services that have
+instead a language used to make requests to application services that have
 capabilities defined in this specification. GraphQL does not mandate a
 particular programming language or storage system for application services that
 implement it. Instead, application services take their capabilities and map them

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -3,7 +3,7 @@
 Clients use the GraphQL query language to make requests to a GraphQL service.
 We refer to these request sources as documents. A document may contain
 operations (queries, mutations, and subscriptions) as well as fragments, a
-common unit of composition allowing for query reuse.
+common unit of composition allowing for data requirement reuse.
 
 A GraphQL document is defined as a syntactic grammar where terminal symbols are
 tokens (indivisible lexical units). These tokens are defined in a lexical
@@ -337,7 +337,7 @@ under-fetching data.
 }
 ```
 
-In this query, the `id`, `firstName`, and `lastName` fields form a selection
+In this query operation, the `id`, `firstName`, and `lastName` fields form a selection
 set. Selection sets may also contain fragment references.
 
 
@@ -408,7 +408,7 @@ Fields are conceptually functions which return values, and occasionally accept
 arguments which alter their behavior. These arguments often map directly to
 function arguments within a GraphQL service's implementation.
 
-In this example, we want to query a specific user (requested via the `id`
+In this example, we want to fetch a specific user (requested via the `id`
 argument) and their profile picture of a specific `size`:
 
 ```graphql example
@@ -438,7 +438,7 @@ Many arguments can exist for a given field:
 Arguments may be provided in any syntactic order and maintain identical
 semantic meaning.
 
-These two queries are semantically identical:
+These two operations are semantically identical:
 
 ```graphql example
 {
@@ -546,7 +546,7 @@ query noFragments {
 ```
 
 The repeated fields could be extracted into a fragment and composed by
-a parent fragment or query.
+a parent fragment or operation.
 
 ```graphql example
 query withFragments {
@@ -567,8 +567,8 @@ fragment friendFields on User {
 }
 ```
 
-Fragments are consumed by using the spread operator (`...`). All fields selected
-by the fragment will be added to the query field selection at the same level
+Fragments are consumed by using the spread operator (`...`). All fields
+selected by the fragment will be added to the field selection at the same level
 as the fragment invocation. This happens through multiple levels of fragment
 spreads.
 
@@ -597,7 +597,7 @@ fragment standardProfilePic on User {
 }
 ```
 
-The queries `noFragments`, `withFragments`, and `withNestedFragments` all
+The operations `noFragments`, `withFragments`, and `withNestedFragments` all
 produce the same response object.
 
 
@@ -616,7 +616,7 @@ Fragments can be specified on object types, interfaces, and unions.
 Selections within fragments only return values when the concrete type of the object
 it is operating on matches the type of the fragment.
 
-For example in this query on the Facebook data model:
+For example in this operation using the Facebook data model:
 
 ```graphql example
 query FragmentTyping {
@@ -1049,7 +1049,7 @@ literal representation of input objects as "object literals."
 Input object fields may be provided in any syntactic order and maintain
 identical semantic meaning.
 
-These two queries are semantically identical:
+These two operations are semantically identical:
 
 ```graphql example
 {
@@ -1113,7 +1113,7 @@ query getZuckProfile($devicePicSize: Int) {
 
 Values for those variables are provided to a GraphQL service along with a
 request so they may be substituted during execution. If providing JSON for the
-variables' values, we could run this query and request profilePic of
+variables' values, we could run this operation and fetch profilePic of
 size `60` width:
 
 ```json example
@@ -1124,7 +1124,7 @@ size `60` width:
 
 **Variable use within Fragments**
 
-Query variables can be used within fragments. Query variables have global scope
+Operation variables can be used within fragments. Operation variables have global scope
 with a given operation, so a variable used within a fragment must be declared
 in any top-level operation that transitively consumes that fragment. If
 a variable is referenced in a fragment and is included by an operation that does
@@ -1146,7 +1146,7 @@ NonNullType :
   - NamedType !
   - ListType !
 
-GraphQL describes the types of data expected by query variables. Input types
+GraphQL describes the types of data expected by operation variables. Input types
 may be lists of another input type, or a non-null variant of any other
 input type.
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -337,8 +337,8 @@ under-fetching data.
 }
 ```
 
-In this query operation, the `id`, `firstName`, and `lastName` fields form a selection
-set. Selection sets may also contain fragment references.
+In this query operation, the `id`, `firstName`, and `lastName` fields form a
+selection set. Selection sets may also contain fragment references.
 
 
 ## Fields
@@ -408,7 +408,7 @@ Fields are conceptually functions which return values, and occasionally accept
 arguments which alter their behavior. These arguments often map directly to
 function arguments within a GraphQL service's implementation.
 
-In this example, we want to fetch a specific user (requested via the `id`
+In this example, we want to query a specific user (requested via the `id`
 argument) and their profile picture of a specific `size`:
 
 ```graphql example
@@ -1096,7 +1096,9 @@ If not defined as constant (for example, in {DefaultValue}), a {Variable} can be
 supplied for an input value.
 
 Variables must be defined at the top of an operation and are in scope
-throughout the execution of that operation.
+throughout the execution of that operation. Values for those variables are
+provided to a GraphQL service as part of a request so they may be substituted
+in during execution.
 
 In this example, we want to fetch a profile picture size based on the size
 of a particular device:
@@ -1111,10 +1113,8 @@ query getZuckProfile($devicePicSize: Int) {
 }
 ```
 
-Values for those variables are provided to a GraphQL service along with a
-request so they may be substituted during execution. If providing JSON for the
-variables' values, we could run this operation and fetch profilePic of
-size `60` width:
+If providing JSON for the variables' values, we could request a `profilePic` of
+size `60`:
 
 ```json example
 {
@@ -1124,11 +1124,10 @@ size `60` width:
 
 **Variable use within Fragments**
 
-Operation variables can be used within fragments. Operation variables have global scope
-with a given operation, so a variable used within a fragment must be declared
-in any top-level operation that transitively consumes that fragment. If
-a variable is referenced in a fragment and is included by an operation that does
-not define that variable, the operation cannot be executed.
+Variables can be used within fragments. Variables have global scope with a given operation, so a variable used within a fragment must be declared in any
+top-level operation that transitively consumes that fragment. If a variable is
+referenced in a fragment and is included by an operation that does not define
+that variable, that operation is invalid (see [All Variable Uses Defined](#sec-All-Variable-Uses-Defined)).
 
 
 ## Type References
@@ -1146,9 +1145,9 @@ NonNullType :
   - NamedType !
   - ListType !
 
-GraphQL describes the types of data expected by operation variables. Input types
-may be lists of another input type, or a non-null variant of any other
-input type.
+GraphQL describes the types of data expected by arguments and variables.
+Input types may be lists of another input type, or a non-null variant of any
+other input type.
 
 **Semantics**
 
@@ -1188,8 +1187,8 @@ including or skipping a field. Directives provide this by describing additional 
 Directives have a name along with a list of arguments which may accept values
 of any input type.
 
-Directives can be used to describe additional information for types, fields, fragments
-and operations.
+Directives can be used to describe additional information for types, fields,
+fragments and operations.
 
 As future versions of GraphQL adopt new configurable execution capabilities,
 they may be exposed via directives. GraphQL services and tools may also provide

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1,8 +1,8 @@
 # Type System
 
 The GraphQL Type system describes the capabilities of a GraphQL service and is
-used to determine if a query is valid. The type system also describes the
-input types of query variables to determine if values provided at runtime
+used to determine if a request is valid. The type system also describes the
+input types of operation variables to determine if values provided at runtime
 are valid.
 
 TypeSystemDocument : TypeSystemDefinition+
@@ -79,7 +79,7 @@ schema {
 }
 
 """
-Root type for all your queries
+Root type for all your query operations
 """
 type Query {
   """
@@ -191,7 +191,7 @@ When using the type system definition language, a document must include at most
 one {`schema`} definition.
 
 In this example, a GraphQL schema is defined with both query and mutation
-root types:
+root operation types:
 
 ```graphql example
 schema {
@@ -424,7 +424,7 @@ raised (input values are validated before execution begins).
 
 GraphQL has different constant literals to represent integer and floating-point
 input values, and coercion rules may apply differently depending on which type
-of input value is encountered. GraphQL may be parameterized by query variables,
+of input value is encountered. GraphQL may be parameterized by operation variables,
 the values of which are often serialized when sent over a transport like HTTP. Since
 some common serializations (ex. JSON) do not discriminate between integer
 and floating-point values, they are interpreted as an integer input value if
@@ -601,14 +601,14 @@ FieldsDefinition : { FieldDefinition+ }
 
 FieldDefinition : Description? Name ArgumentsDefinition? : Type Directives[Const]?
 
-GraphQL queries are hierarchical and composed, describing a tree of information.
-While Scalar types describe the leaf values of these hierarchical queries, Objects
+GraphQL operations are hierarchical and composed, describing a tree of information.
+While Scalar types describe the leaf values of these hierarchical operations, Objects
 describe the intermediate levels.
 
 GraphQL Objects represent a list of named fields, each of which yield a value of
 a specific type. Object values should be serialized as ordered maps, where the
-queried field names (or aliases) are the keys and the result of evaluating
-the field is the value, ordered by the order in which they appear in the query.
+requested field names (or aliases) are the keys and the result of evaluating
+the field is the value, ordered by the order in which they appear in the operation.
 
 All fields defined within an Object type must not have a name which begins with
 {"__"} (two underscores), as this is used exclusively by GraphQL's
@@ -687,8 +687,8 @@ type Person {
 }
 ```
 
-Valid queries must supply a nested field set for a field that returns
-an object, so this query is not valid:
+Valid operations must supply a nested field set for a field that returns
+an object, so this operation is not valid:
 
 ```graphql counter-example
 {
@@ -722,7 +722,7 @@ And will yield the subset of each object type queried:
 **Field Ordering**
 
 When querying an Object, the resulting mapping of fields are conceptually
-ordered in the same order in which they were encountered during query execution,
+ordered in the same order in which they were encountered during request execution,
 excluding fragments for which the type does not apply and fields or
 fragments that are skipped via `@skip` or `@include` directives. This ordering
 is correctly produced when using the {CollectFields()} algorithm.
@@ -920,10 +920,10 @@ type Person {
 }
 ```
 
-GraphQL queries can optionally specify arguments to their fields to provide
+GraphQL operations can optionally specify arguments to their fields to provide
 these arguments.
 
-This example query:
+This example operation:
 
 ```graphql example
 {
@@ -948,7 +948,7 @@ Object, Interface, or Union type).
 ### Field Deprecation
 
 Fields in an object may be marked as deprecated as deemed necessary by the
-application. It is still legal to query for these fields (to ensure existing
+application. It is still legal to fetch these fields (to ensure existing
 clients are not broken by the change), but the fields should be appropriately
 treated in documentation and tooling.
 
@@ -1062,7 +1062,7 @@ type Contact {
 }
 ```
 
-This allows us to write a query for a `Contact` that can select the
+This allows us to write a selection set for a `Contact` that can select the
 common fields.
 
 ```graphql example
@@ -1074,10 +1074,10 @@ common fields.
 }
 ```
 
-When querying for fields on an interface type, only those fields declared on
+When selecting fields on an interface type, only those fields declared on
 the interface may be queried. In the above example, `entity` returns a
 `NamedEntity`, and `name` is defined on `NamedEntity`, so it is valid. However,
-the following would not be a valid query:
+the following would not be a valid selection set against `Contact`:
 
 ```graphql counter-example
 {
@@ -1091,7 +1091,7 @@ the following would not be a valid query:
 
 because `entity` refers to a `NamedEntity`, and `age` is not defined on that
 interface. Querying for `age` is only valid when the result of `entity` is a
-`Person`; the query can express this using a fragment or an inline fragment:
+`Person`; this can be expressed using a fragment or an inline fragment:
 
 ```graphql example
 {
@@ -1295,9 +1295,9 @@ type SearchQuery {
 ```
 
 When querying the `firstSearchResult` field of type `SearchQuery`, the
-query would ask for all fields inside of a fragment indicating the appropriate
-type. If the query wanted the name if the result was a Person, and the height if
-it was a photo, the following query is invalid, because the union itself
+request would ask for all fields inside of a fragment indicating the appropriate
+type. If the request wanted the name if the result was a Person, and the height if
+it was a photo, the following document is invalid, because the union itself
 defines no fields:
 
 ```graphql counter-example
@@ -1309,7 +1309,7 @@ defines no fields:
 }
 ```
 
-Instead, the query would be:
+Instead, the document would be:
 
 ```graphql example
 {
@@ -1415,7 +1415,7 @@ reasonable coercion is not possible they must raise a field error.
 GraphQL has a constant literal to represent enum input values. GraphQL string
 literals must not be accepted as an enum input and instead raise a request error.
 
-Query variable transport serializations which have a different representation
+Operation variable transport serializations which have a different representation
 for non-string symbolic values (for example, [EDN](https://github.com/edn-format/edn))
 should only allow such values as enum input values. Otherwise, for most
 transport serializations that do not, strings may be interpreted as the enum
@@ -1709,8 +1709,8 @@ exclamation mark is used to denote a field that uses a Non-Null type like this:
 
 **Nullable vs. Optional**
 
-Fields are *always* optional within the context of a query, a field may be
-omitted and the query is still valid. However fields that return Non-Null types
+Fields are *always* optional within the context of a selection set, a field may be
+omitted and the selection set is still valid. However fields that return Non-Null types
 will never return the value {null} if queried.
 
 Inputs (such as field arguments), are always optional by default. However a

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -3,7 +3,7 @@
 A GraphQL service supports introspection over its schema. This schema is queried
 using GraphQL itself, creating a powerful platform for tool-building.
 
-Take an example query for a trivial app. In this case there is a User type with
+Take an example request for a trivial app. In this case there is a User type with
 three fields: id, name, and birthday.
 
 For example, given a service with the following type definition:
@@ -16,7 +16,7 @@ type User {
 }
 ```
 
-The query
+The operation
 
 ```graphql example
 {
@@ -221,11 +221,11 @@ enum __DirectiveLocation {
 ### The __Type Type
 
 `__Type` is at the core of the type introspection system, it represents all
-types in the system: both named types (e.g. Scalars and Object types) and 
-type modifiers (e.g. List and Non-Null types). 
+types in the system: both named types (e.g. Scalars and Object types) and
+type modifiers (e.g. List and Non-Null types).
 
-Type modifiers are used to modify the type presented in the field `ofType`. 
-This modified type may recursively be a modified type, representing lists, 
+Type modifiers are used to modify the type presented in the field `ofType`.
+This modified type may recursively be a modified type, representing lists,
 non-nullables, and combinations thereof, ultimately modifying a named type.
 
 ### Type Kinds
@@ -259,7 +259,7 @@ Fields
 * `kind` must return `__TypeKind.OBJECT`.
 * `name` must return a String.
 * `description` may return a String or {null}.
-* `fields`: The set of fields query-able on this type.
+* `fields`: The set of fields request-able on this type.
   * Accepts the argument `includeDeprecated` which defaults to {false}. If
     {true}, deprecated fields are also returned.
 * `interfaces`: The set of interfaces that an object implements.
@@ -367,8 +367,8 @@ A Non-Null type is a type modifier: it wraps another type instance in the
 `ofType` field. Non-null types do not allow {null} as a response, and indicate
 required inputs for arguments and input object fields.
 
-The modified type in the `ofType` field may itself be a modified List type, 
-allowing the representation of Non-Null of Lists. However it must not be a 
+The modified type in the `ofType` field may itself be a modified List type,
+allowing the representation of Non-Null of Lists. However it must not be a
 modified Non-Null type to avoid a redundant Non-Null of Non-Null.
 
 * `kind` must return `__TypeKind.NON_NULL`.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -16,7 +16,7 @@ type User {
 }
 ```
 
-The operation
+A request containing the operation:
 
 ```graphql example
 {
@@ -32,7 +32,7 @@ The operation
 }
 ```
 
-would return
+would produce the result:
 
 ```json example
 {
@@ -259,7 +259,7 @@ Fields
 * `kind` must return `__TypeKind.OBJECT`.
 * `name` must return a String.
 * `description` may return a String or {null}.
-* `fields`: The set of fields request-able on this type.
+* `fields`: The set of fields that can be selected for this type.
   * Accepts the argument `includeDeprecated` which defaults to {false}. If
     {true}, deprecated fields are also returned.
 * `interfaces`: The set of interfaces that an object implements.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -606,7 +606,8 @@ Conversely the leaf field selections of GraphQL operations
 must be of type scalar or enum. Leaf selections on objects, interfaces,
 and unions without subfields are disallowed.
 
-Let's assume the following additions to the query root operation type of the schema:
+Let's assume the following additions to the query root operation type of
+the schema:
 
 ```graphql example
 extend type Query {
@@ -861,7 +862,7 @@ fragment fragmentOne on Dog {
 
 Fragments must be specified on types that exist in the schema. This
 applies for both named and inline fragments. If they are
-not defined in the schema, the request does not validate.
+not defined in the schema, the fragment is invalid.
 
 For example the following fragments are valid:
 
@@ -1506,7 +1507,8 @@ query ($foo: Boolean = true, $bar: Boolean = false) {
 ```
 
 However the following example is valid because `@skip` has been used only once
-per location, despite being used twice in the document and on the same named field:
+per location, despite being used twice in the operation and on the same
+named field:
 
 ```raw graphql example
 query ($foo: Boolean = true, $bar: Boolean = false) {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -582,7 +582,7 @@ fragment conflictingDifferingResponses on Pet {
 **Explanatory Text**
 
 Field selections on scalars or enums are never allowed, because they
-are the leaf nodes of any GraphQL query.
+are the leaf nodes of any GraphQL operation.
 
 The following is valid.
 
@@ -602,11 +602,11 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 }
 ```
 
-Conversely the leaf field selections of GraphQL queries
+Conversely the leaf field selections of GraphQL operations
 must be of type scalar or enum. Leaf selections on objects, interfaces,
 and unions without subfields are disallowed.
 
-Let's assume the following additions to the query root type of the schema:
+Let's assume the following additions to the query root operation type of the schema:
 
 ```graphql example
 extend type Query {
@@ -761,7 +761,7 @@ fragment goodNonNullArg on Arguments {
 
 The argument can be omitted from a field with a nullable argument.
 
-Therefore the following query is valid:
+Therefore the following fragment is valid:
 
 ```graphql example
 fragment goodBooleanArgDefault on Arguments {
@@ -861,7 +861,7 @@ fragment fragmentOne on Dog {
 
 Fragments must be specified on types that exist in the schema. This
 applies for both named and inline fragments. If they are
-not defined in the schema, the query does not validate.
+not defined in the schema, the request does not validate.
 
 For example the following fragments are valid:
 
@@ -1397,7 +1397,7 @@ which is not defined on the expected type:
 Input objects must not contain more than one field of the same name, otherwise
 an ambiguity would exist which includes an ignored portion of syntax.
 
-For example the following query will not pass validation.
+For example the following document will not pass validation.
 
 ```graphql counter-example
 {
@@ -1466,7 +1466,7 @@ GraphQL services define what directives they support and where they support them
 For each usage of a directive, the directive must be used in a location that the
 service has declared support for.
 
-For example the following query will not pass validation because `@skip` does
+For example the following document will not pass validation because `@skip` does
 not provide `QUERY` as a valid location.
 
 ```graphql counter-example
@@ -1496,7 +1496,7 @@ definition they apply to. When more than one directive of the same name is used,
 the expected metadata or behavior becomes ambiguous, therefore only one of each
 directive is allowed per location.
 
-For example, the following query will not pass validation because `@skip` has
+For example, the following document will not pass validation because `@skip` has
 been used twice for the same field:
 
 ```raw graphql counter-example
@@ -1506,7 +1506,7 @@ query ($foo: Boolean = true, $bar: Boolean = false) {
 ```
 
 However the following example is valid because `@skip` has been used only once
-per location, despite being used twice in the query and on the same named field:
+per location, despite being used twice in the document and on the same named field:
 
 ```raw graphql example
 query ($foo: Boolean = true, $bar: Boolean = false) {
@@ -1596,7 +1596,7 @@ extend type Query {
 }
 ```
 
-The following queries are valid:
+The following operations are valid:
 
 ```graphql example
 query takesBoolean($atOtherHomes: Boolean) {
@@ -1616,7 +1616,7 @@ query TakesListOfBooleanBang($booleans: [Boolean!]) {
 }
 ```
 
-The following queries are invalid:
+The following operations are invalid:
 
 ```graphql counter-example
 query takesCat($cat: Cat) {
@@ -1666,7 +1666,7 @@ query variableIsDefined($atOtherHomes: Boolean) {
 
 is valid. ${atOtherHomes} is defined by the operation.
 
-By contrast the following query is invalid:
+By contrast the following document is invalid:
 
 ```graphql counter-example
 query variableIsNotDefined {
@@ -1702,7 +1702,7 @@ since {isHousetrainedFragment} is used within the context of the operation
 operation.
 
 On the other hand, if a fragment is included within an operation that does
-not define a referenced variable, the query is invalid.
+not define a referenced variable, the document is invalid.
 
 ```graphql counter-example
 query variableIsNotDefinedUsedInSingleFragment {
@@ -1999,7 +1999,7 @@ query booleanArgQueryWithDefault($booleanArg: Boolean) {
 
 In the example below, an optional variable `$booleanArg` is allowed to be used
 in the non-null argument (`nonNullBooleanArg`) because the variable provides
-a default value in the query. This behavior is explicitly supported for
+a default value in the operation. This behavior is explicitly supported for
 compatibility with earlier editions of this specification. GraphQL authoring
 tools may wish to report this as a warning with the suggestion to replace
 `Boolean` with `Boolean!` to avoid ambiguity.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -112,15 +112,15 @@ Note: This algorithm is very similar to {CoerceArgumentValues()}.
 ## Executing Operations
 
 The type system, as described in the "Type System" section of the spec, must
-provide a query root object type. If mutations or subscriptions are supported,
-it must also provide a mutation or subscription root object type, respectively.
+provide a query root operation type. If mutations or subscriptions are supported,
+it must also provide a mutation or subscription root operation type, respectively.
 
 ### Query
 
 If the operation is a query, the result of the operation is the result of
-executing the query’s top level selection set with the query root object type.
+executing the operation’s top level selection set with the query root operation type.
 
-An initial value may be provided when executing a query.
+An initial value may be provided when executing a query operation.
 
 ExecuteQuery(query, schema, variableValues, initialValue):
 
@@ -137,7 +137,7 @@ ExecuteQuery(query, schema, variableValues, initialValue):
 ### Mutation
 
 If the operation is a mutation, the result of the operation is the result of
-executing the mutation’s top level selection set on the mutation root
+executing the operation’s top level selection set on the mutation root
 object type. This selection set should be executed serially.
 
 It is expected that the top level fields in a mutation operation perform
@@ -162,8 +162,8 @@ If the operation is a subscription, the result is an event stream called the
 "Response Stream" where each event in the event stream is the result of
 executing the operation for each new event on an underlying "Source Stream".
 
-Executing a subscription creates a persistent function on the service that
-maps an underlying Source Stream to a returned Response Stream.
+Executing a subscription operation creates a persistent function on the service
+that maps an underlying Source Stream to a returned Response Stream.
 
 Subscribe(subscription, schema, variableValues, initialValue):
 
@@ -335,7 +335,7 @@ ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues):
       * Set {responseValue} as the value for {responseKey} in {resultMap}.
   * Return {resultMap}.
 
-Note: {resultMap} is ordered by which fields appear first in the query. This
+Note: {resultMap} is ordered by which fields appear first in the operation. This
 is explained in greater detail in the Field Collection section below.
 
 **Errors and Non-Null Fields**
@@ -562,7 +562,7 @@ Fields may include arguments which are provided to the underlying runtime in
 order to correctly produce a value. These arguments are defined by the field in
 the type system to have a specific input type.
 
-At each argument position in a query may be a literal {Value}, or a {Variable}
+At each argument position in an operation may be a literal {Value}, or a {Variable}
 to be provided at runtime.
 
 CoerceArgumentValues(objectType, field, variableValues):
@@ -608,7 +608,7 @@ CoerceArgumentValues(objectType, field, variableValues):
   * Return {coercedValues}.
 
 Note: Variable values are not coerced because they are expected to be coerced
-before executing the operation in {CoerceVariableValues()}, and valid queries
+before executing the operation in {CoerceVariableValues()}, and valid operations
 must only allow usage of variables of appropriate types.
 
 
@@ -709,7 +709,7 @@ When more than one field of the same name is executed in parallel, their
 selection sets are merged together when completing the value in order to
 continue execution of the sub-selection sets.
 
-An example query illustrating parallel fields with the same name with
+An example operation illustrating parallel fields with the same name with
 sub-selections.
 
 ```graphql example

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -118,7 +118,8 @@ it must also provide a mutation or subscription root operation type, respectivel
 ### Query
 
 If the operation is a query, the result of the operation is the result of
-executing the operation’s top level selection set with the query root operation type.
+executing the operation’s top level selection set with the query root
+operation type.
 
 An initial value may be provided when executing a query operation.
 
@@ -562,8 +563,8 @@ Fields may include arguments which are provided to the underlying runtime in
 order to correctly produce a value. These arguments are defined by the field in
 the type system to have a specific input type.
 
-At each argument position in an operation may be a literal {Value}, or a {Variable}
-to be provided at runtime.
+At each argument position in an operation may be a literal {Value}, or a
+{Variable} to be provided at runtime.
 
 CoerceArgumentValues(objectType, field, variableValues):
   * Let {coercedValues} be an empty unordered Map.

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -38,8 +38,9 @@ in a response during debugging.
 
 The `data` entry in the response will be the result of the execution of the
 requested operation. If the operation was a query, this output will be an
-object of the schema's query root operation type; if the operation was a mutation, this
-output will be an object of the schema's mutation root operation type.
+object of the schema's query root operation type; if the operation was a
+mutation, this output will be an object of the schema's mutation root
+operation type.
 
 If an error was raised before execution begins, the `data` entry should
 not be present in the result.
@@ -296,8 +297,8 @@ JSON format throughout this document.
 
 Since the result of evaluating a selection set is ordered, the serialized Map of
 results should preserve this order by writing the map entries in the same order
-as those fields were requested as defined by request execution. Producing a
-serialized response where fields are represented in the same order in which
+as those fields were requested as defined by selection set execution. Producing
+a serialized response where fields are represented in the same order in which
 they appear in the request improves human readability during debugging and
 enables more efficient parsing of responses if the order of properties can
 be anticipated.

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -38,8 +38,8 @@ in a response during debugging.
 
 The `data` entry in the response will be the result of the execution of the
 requested operation. If the operation was a query, this output will be an
-object of the schema's query root type; if the operation was a mutation, this
-output will be an object of the schema's mutation root type.
+object of the schema's query root operation type; if the operation was a mutation, this
+output will be an object of the schema's mutation root operation type.
 
 If an error was raised before execution begins, the `data` entry should
 not be present in the result.
@@ -111,10 +111,10 @@ response and ending with the field associated with the error. Path segments
 that represent fields should be strings, and path segments that
 represent list indices should be 0-indexed integers. If the error happens
 in an aliased field, the path to the error should use the aliased name, since
-it represents a path in the response, not in the query.
+it represents a path in the response, not in the request.
 
 For example, if fetching one of the friends' names fails in the following
-query:
+operation:
 
 ```graphql example
 {
@@ -296,7 +296,7 @@ JSON format throughout this document.
 
 Since the result of evaluating a selection set is ordered, the serialized Map of
 results should preserve this order by writing the map entries in the same order
-as those fields were requested as defined by query execution. Producing a
+as those fields were requested as defined by request execution. Producing a
 serialized response where fields are represented in the same order in which
 they appear in the request improves human readability during debugging and
 enables more efficient parsing of responses if the order of properties can


### PR DESCRIPTION
This PR addresses the "query ambiguity" issue raised in #715 and [discussed in the May 2020 GraphQL Working Group](https://github.com/graphql/graphql-wg/blob/master/notes/2020-05-07.md#query-a-query-query-query-query-ambiguity-10m-benjie).

I went through every usage of the word `query`, `queries` and `queried` in the spec and attempted to discern the different terminology we have going on. I've come up with the following definitions which are broadly in line with the terminology the spec already uses in places.

What follows are notes I took whilst doing this work, which also constitutes the beginnings of a glossary. This glossary is probably sufficient for WG members who already understand these concepts, but I'll need to tidy them up and define them more concretely if we want to add them as a glossary to the spec itself. (Also need to populate it with non-`query` terms.) I think if we do decide to add a glossary we should do that as a separate PR.

## Glossary

When usage of these terms may cause ambiguity\* the normally optional
parenthesized "(GraphQL)" should be included for clarity.

_\* example of an ambiguous phrase: "sending a request to a server" may refer to
an HTTP request, network request, or a GraphQL request._

### (GraphQL) operation

**Definition**: an action you wish GraphQL to perform, for example retrieving
data, mutating data or state, or subscribing to events.

Examples:

> A query **operation** should not mutate data or state, for that a mutation
> **operation** should be used.

Used in the GraphQL spec:

> Let {operation} be the result of {GetOperation(document, operationName)}.

### (GraphQL) operation type

**Definition**: a type of operation supported by GraphQL - "query", "mutation", or
"subscription".

Examples:

> GraphQL currently supports 3 **operation types**: `query`, `mutation` and
> `subscription`.

Not to be confused with (GraphQL) root operation type.

Used in the GraphQL spec:

> Schema extensions are used to represent a schema which has been extended from
> an original schema. For example, this might be used by a GraphQL service which
> adds additional operation types, or additional directives to an existing schema.

### (GraphQL) query operation

A GraphQL operation of type `query`.

Used in the GraphQL spec:

> If {operation} is a query operation: ...

### (GraphQL) mutation operation

A GraphQL operation of type `mutation`.

Used in the GraphQL spec:

> Otherwise if {operation} is a mutation operation: ...

### (GraphQL) subscription operation

A GraphQL operation of type `subscription`.

Used in the GraphQL spec:

> Otherwise if {operation} is a subscription operation: ...

### (GraphQL) root operation type

The GraphQL object type associated with a given GraphQL operation type within
the schema.

Used in the GraphQL spec:

> A schema defines the initial root operation type for each kind of operation it
> supports: query, mutation, and subscription; this determines the place in the
> type system where those operations begin.

### (GraphQL) document

**Definition**: the textual representation (using GraphQL query language) of an
operation (or operations) you wish to perform, including selection sets and
fragments as appropriate.

Examples:

> Once a **GraphQL document** is written, it should always mean the same
> thing and return the same shaped result.

> For example, this **document** will receive the name of the user
> with id 4 from the Facebook implementation of GraphQL.

> Clients use the GraphQL query language to make requests to a GraphQL service.
> We refer to these request sources as **GraphQL documents**. A **document**
> may contain operations (queries, mutations, and subscriptions) as
> well as fragments, a common unit of composition allowing for **data
> requirement reuse**.

[Inspired by](https://github.com/graphql/graphql-js/blob/7a327a6e2045e75c577be924694e6642d3e28e14/src/language/source.js#L15).

Alternatives considered:

- GraphQL operation document (could also be expected to include IDL)
- Request document (too confusing with "request")

### (GraphQL) operation variables

**Definition**: variables declared within an operation.

Previously "query variables".

Example: `$devicePicSize` is an operation variable in the following operation:

```graphql example
query getZuckProfile($devicePicSize: Int) {
  user(id: 4) {
    id
    name
    profilePic(size: $devicePicSize)
  }
}
```

Why not "request variables"? The variables are declared in the operation and
there doesn't seem to be a need to push the definition up to request level.

### (GraphQL) request

**Definition**: the full description of what you wish GraphQL to execute,
including the GraphQL schema, document, variables, operation name and initial
value.

> When using GraphQL over HTTP, it's common to encode the **GraphQL request** as
> JSON.

Used in the GraphQL spec:

> ExecuteRequest(schema, document, operationName, variableValues, initialValue):

### (GraphQL) request error

**Definition**: an error which occurs during validating a GraphQL request
(including coercing the variables) resulting in the entire GraphQL request
being aborted.

Previously: consistently "query error" throughout the spec.

Why not "query error"? It also occurs for mutations, subscriptions, and invalid
documents.

Why not "operation error"? It can occur when operationName is not specified,
and thus the operation is indeterminate. Further it may result from invalid
variables which are a GraphQL request concern, not a GraphQL operation concern.




## Unmodified terms

The verb "to query" is left in may places, as is the term "query language". A few of these are noted below:

> GraphQL is a query language designed to build client applications...

> A GraphQL server's type system must be queryable by the GraphQL language itself...

> It describes the language and its grammar, the type system and the introspection system used to query it...

## Questionable terms

### query reuse

"query reuse" w.r.t fragments. "query" seems like the wrong term here (because
of how overloaded/vague it is) but I can't come up with a succinct alternative.
Best I've come up with is "data requirement reuse," but I'm not super happy
with it.

###  queried

> By default, the key in the response object will use the field name
> **queried**. However, you can define a different name by specifying an alias.

### querying

> Inline Fragments can be used directly within a selection to condition upon a
> type condition when **querying** against an interface or union.

> Fragments must specify the type they apply to. In this example, `friendFields`
> can be used in the context of **querying** a `User`.

Can be replaced with 'selecting' / 'selecting fields from', using 'select' as
in 'selection set'.

### query of

> A query of an object value must select at least one field.

### request

In many cases 'request' can be replaced with 'fetch' to avoid ambiguity with
'GraphQL request'.

> If providing JSON for the variables' values, we could run this operation and
> **request** profilePic of size `60` width:

### query root object type

Also mutation/subscription root object type and simply "query root type". These
have the same meaning as query "root operation type", but "root object type" is
more explicit that the root operation type is an _object_ type. We should pick
between them and stick to that throughout.

> The type system, as described in the "Type System" section of the spec, must
> provide a query root object type. If mutations or subscriptions are supported,
> it must also provide a mutation or subscription root object type, respectively.

### query execution

Replaced with "request execution" due to the function being called `ExecuteRequest`

## Interesting terms

### Fetch

> There are three types of operations that GraphQL models:
> 
>   * query - a read-only fetch.
>   * mutation - a write followed by a fetch.
>   * subscription - a long-lived request that fetches data in response to source
>     events.

### Response key

> A field's response key is its alias if an alias is provided, and it is
> otherwise the field's name.

## Ethos

Rather than being conservative with edits and leaving ambiguity I was quite heavy

## Status

This is not ready for merging, it's only a first edit and there's likely inconsistencies where the final rules I applied weren't reapplied to earlier edits. Mostly this is a discovery exercise.

## Next steps

I'll add this to the next GraphQL WG. I have broadly the following questions:

1. in general are we happy with my chosen terms?
1. "root operation type", "root object type" and "root type" term - need to pick one.
1. Is there a better term than "querying" to use when querying a type, e.g. relating to field validity, fragment spreads, etc. Perhaps "selecting" or a derivative, inspired by "selection set"?