### PR TITLE
Clarify that Float does not include NaN or infinity

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -450,10 +450,11 @@ encoding integer numbers larger than 32-bit.
 
 ### Float
 
-The Float scalar type represents signed double-precision fractional values
-as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
-Response formats that support an appropriate double-precision number type
-should use that type to represent this scalar.
+The Float scalar type represents signed double-precision finite (i.e., not {NaN}
+or infinity) fractional values as specified by
+[IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).  Response formats
+that support an appropriate double-precision number type should use that type to
+represent this scalar.
 
 **Result Coercion**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -451,8 +451,8 @@ encoding integer numbers larger than 32-bit.
 ### Float
 
 The Float scalar type represents signed double-precision finite (i.e., not {NaN}
-or infinity) fractional values as specified by
-[IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).  Response formats
+or {Infinity}) fractional values as specified by 
+[IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point). Response formats
 that support an appropriate double-precision number type should use that type to
 represent this scalar.
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -450,11 +450,10 @@ encoding integer numbers larger than 32-bit.
 
 ### Float
 
-The Float scalar type represents signed double-precision finite (i.e., not {NaN}
-or {Infinity}) fractional values as specified by 
-[IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point). Response formats
-that support an appropriate double-precision number type should use that type to
-represent this scalar.
+The Float scalar type represents signed double-precision finite values as
+specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
+Response formats that support an appropriate double-precision number type should
+use that type to represent this scalar.
 
 **Result Coercion**
 
@@ -466,14 +465,18 @@ reasonable without losing information, otherwise they must raise a field error.
 Examples of this may include returning `1.0` for the integer number `1`, or
 `123.0` for the string `"123"`.
 
+Non-finite floating-point internal values ({NaN} and {Infinity}) cannot be
+coerced to {Float} and must raise a field error.
+
 **Input Coercion**
 
 When expected as an input type, both integer and float input values are
 accepted. Integer input values are coerced to Float by adding an empty
 fractional part, for example `1.0` for the integer input value `1`. All
 other input values, including strings with numeric content, must raise a query
-error indicating an incorrect type. If the integer input value represents a
-value not representable by IEEE 754, a query error should be raised.
+error indicating an incorrect type. If the input value otherwise represents a
+value not representable by finite IEEE 754 (e.g. {NaN}, {Infinity}, or a value
+outside the available precision), a query error must be raised.
 
 
 ### String

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -648,7 +648,7 @@ CompleteValue(fieldType, fields, result, variableValues):
     * If {completedResult} is {null}, throw a field error.
     * Return {completedResult}.
   * If {result} is {null} (or another internal value similar to {null} such as
-    {undefined} or {NaN}), return {null}.
+    {undefined}), return {null}.
   * If {fieldType} is a List type:
     * If {result} is not a collection of values, throw a field error.
     * Let {innerType} be the inner type of {fieldType}.


### PR DESCRIPTION
Fixes #778.

This matches the fact that you cannot represent these values in text as
FloatValue, as well as the graphql-js
implementation (https://github.com/graphql/graphql-js/blob/16009cbcb0109da03f2157a868817b886801095a/src/type/scalars.js#L108-L112).

This was perhaps already implied by the word "fractional", but "finite" seems to
be a more standard term for "IEEE 754 floats that are not infinity or NaN".
