### PR TITLE
Update criterion match in input union RFC

### DIFF
--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -902,7 +902,7 @@ A quick glance at the evaluation results. Remember that passing or failing a spe
 | [C][criteria-c] 🥇 | ✅ | ✅⚠️ | 🚫 | ⚠️ | ✅ |
 | [D][criteria-d] 🥇 | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [E][criteria-e] 🥉 | 🚫 | 🚫 | ✅⚠️ | 🚫 | ✅ |
-| [F][criteria-f] 🥉 | ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
+| [F][criteria-f] 🥉 | ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | 🚫 |
 | [G][criteria-g] 🥉 | ❔ | ❔ | ❔ | ❔ | ❔ |
 | [H][criteria-h] 🥉 | ⚠️ | ⚠️ | ✅ | ✅ | ⚠️ |
 | [I][criteria-i] 🥉 | ✅ | ✅ | ✅ | ⚠️ | ✅ |

--- a/rfcs/InputUnion.md
+++ b/rfcs/InputUnion.md
@@ -305,7 +305,7 @@ input union IU = I | { y: Int }
 
 | [1][solution-1] | [2][solution-2] | [3][solution-3] | [4][solution-4] | [5][solution-5] |
 |----|----|----|----|----|
-| ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | ✅ |
+| ✅⚠️ | ✅⚠️ | ✅ | ⚠️ | 🚫 |
 
 Criteria score: 🥉
 
@@ -864,7 +864,7 @@ type Mutation {
 * [E. A member type may be a Leaf type][criteria-e]
   * ✅ Any GraphQL type may be used
 * [F. Migrating a field to a polymorphic input type is non-breaking][criteria-f]
-  * ✅ No migration required, as this pattern is already possible
+  * 🚫 Previously-valid inputs now need to be wrapped in a container object
 * [H. Input unions should accept plain data][criteria-h]
   * ⚠️ The data is wrapped in a (simple) container type
 * [I. Input unions should be easy to upgrade from existing solutions][criteria-i]


### PR DESCRIPTION
Currently for **Criterion F** (`Migrating a field to a polymorphic input type is non-breaking`), the tagged unions option is listed as meeting that criterion on the grounds "No migration required, as this pattern is already possible".

This seems to actually be an answer to **Criterion I** (`Input unions should be easy to upgrade from existing solutions`), which lists the same explanation.

As I understand criterion F (and what the responses for the other proposals seem to be addressing) isn't about migrating from other input union approximations today. Rather, in a world where _some_ input union proposal is a part of the spec, it examines migrating an input that currently only accepts a single type to one that accepts a union.

For example, given these types:

```gql
input CatInput {
  name: String!
  age: Int!
  livesLeft: Int
}

input DogInput {
  name: String!
  age: Int!
  breed: DogBreed
}

input AnimalInput @oneOf {
  cat: CatInput
  dog: DogInput
}
```

Consider migrating to an input union for the `animals` argument:

```gql
type Mutation {
  # From this:
  logAnimalDropOff(location: String, animals: [CatInput!]!): Int

  # To this:
  logAnimalDropOff(location: String, animals: [AnimalInput!]!): Int
}
```

This kind of situation is what the other proposals appear to be addressing in their explanations of how they do (or don't) meet Criterion F. With tagged unions, a valid `CatInput` is not a valid `AnimalInput`, so changing `pet` from a simple input type to a polymorphic one is a breaking change.