### PR TITLE
RFC: __typename should be valid at subscription root

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -247,13 +247,14 @@ query getName {
 * Let {subscriptionType} be the root Subscription type in {schema}.
 * Let {selectionSet} be the top level selection set on {subscription}.
 * Let {variableValues} be the empty set.
-* Let {groupedFieldSet} be the result of
-  {CollectFields(subscriptionType, selectionSet, variableValues)}.
-* {groupedFieldSet} must have exactly one entry.
+* Let {groupedFieldSetExcludingIntrospection} be the result of
+  {CollectFields(subscriptionType, selectionSet, variableValues, true)}.
+* {groupedFieldSetExcludingIntrospection} must have exactly one entry.
 
 **Explanatory Text**
 
-Subscription operations must have exactly one root field.
+Subscription operations must have exactly one non-introspection root field.
+(Subscription operations may have any number of introspection root fields.)
 
 Valid examples:
 
@@ -276,6 +277,18 @@ fragment newMessageFields on Subscription {
     body
     sender
   }
+}
+```
+
+Introspection fields are not counted. The following example is also valid:
+
+```graphql counter-example
+subscription sub {
+  newMessage {
+    body
+    sender
+  }
+  __typename
 }
 ```
 
@@ -305,22 +318,19 @@ fragment multipleSubscriptions on Subscription {
 }
 ```
 
-Introspection fields are counted. The following example is also invalid:
+Introspection fields are not counted. The following example is also invalid:
 
 ```graphql counter-example
 subscription sub {
-  newMessage {
-    body
-    sender
-  }
   __typename
 }
 ```
 
-Note: While each subscription must have exactly one root field, a document may
-contain any number of operations, each of which may contain different root
-fields. When executed, a document containing multiple subscription operations
-must provide the operation name as described in {GetOperation()}.
+Note: While each subscription must have exactly one non-introspection root
+field, a document may contain any number of operations, each of which may
+contain different root fields. When executed, a document containing multiple
+subscription operations must provide the operation name as described in
+{GetOperation()}.
 
 ## Fields
 


### PR DESCRIPTION
This is an alternative solution to #776 wherein `__typename` is explicitly allowed inspired by @IvanGoncharov's [comment on that PR](https://github.com/graphql/graphql-spec/pull/776#issuecomment-738079711).

## Description of issue

`__typename` does not return an event stream, so it does not make sense to allow for it to be [the source stream](https://spec.graphql.org/draft/#sec-Source-Stream) in a GraphQL subscription operation. As currently specified, the following query passes validation, but it should always produce an error since the [ResolveFieldEventStream](https://spec.graphql.org/draft/#ResolveFieldEventStream()) algorithm cannot resolve a subscription `resolver` for `__typename`:

```graphql
subscription {
  __typename
}
```

Separately; it's valid to add `__typename` to any selection set in any GraphQL operation _except_ the root selection set (including fragments) on a Subscription operation. This exclusion complicates life for various GraphQL tooling; it's desirable that this (currently invalid) GraphQL operation be valid:

```graphql
subscription sub {
  newMessage {
    body
    sender
  }
  __typename
}
```

The current GraphQL algorithm for subscriptions operates in two steps; first it resolves the "source stream" from the root field that will generate the subscription events, and then when an event is received it executes the entire operation (NOTE: not just the selection set of the source stream's field, but the entire selection set of the operation) using this event as the `initialValue`. As such, `__typename` _could_ be valid in the root selection set so long as there is exactly one field capable of providing the source stream.

## Solution outline

- Change validation for subscription operations so that instead of saying the root selection set must include exactly one field, it's now exactly one _non-introspection_ field.
- Change `CreateSourceEventStream` such that it uses this non-introspection field as the event source (i.e. so that it ignores introspection fields).