### PR TITLE
State that built-in mandatory directives must be omitted

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1818,6 +1818,10 @@ GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of
 the schema.
 
+When representing a GraphQL schema using the type system definition language,
+built in mandatory directives should be omitted for brevity, but optional
+and custom directives must be specified.
+
 **Custom Directives**
 
 GraphQL services and client tooling may provide additional directives beyond

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1882,8 +1882,8 @@ provide the `@specifiedBy` directive if representing custom scalar
 definitions.
 
 When representing a GraphQL schema using the type system definition language,
-built in mandatory directives should be omitted for brevity, but optional
-and custom directives must be specified.
+built in directives (any defined in this specification) should be omitted for
+brevity. Custom directives in use must be specified.
 
 **Custom Directives**
 


### PR DESCRIPTION
Following on from https://github.com/graphql/graphql-spec/pull/815#issuecomment-760944471, this aims to state that built-in directives must be omitted from the SDL.

cc @benjie @IvanGoncharov 