### PR TITLE
Prettier pre-work: formatting tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,8 +824,8 @@ Wow, that's a lot of types! What are they? Let's group them:
 defined in our type system.
  - **String, Boolean** - These are built-in scalars that the type system
 provided.
- - **__Schema, __Type, __TypeKind, __Field, __InputValue, __EnumValue,
-__Directive** - These all are preceded with a double underscore, indicating
+ - **`__Schema`, `__Type`, `__TypeKind`, `__Field`, `__InputValue`, `__EnumValue`,
+`__Directive`** - These all are preceded with a double underscore, indicating
 that they are part of the introspection system.
 
 Now, let's try and figure out a good place to start exploring what queries are

--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -1,5 +1,4 @@
-GraphQL
--------
+# GraphQL
 
 *Current Working Draft*
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -647,11 +647,11 @@ will be present and `friends` will not.
   "profiles": [
     {
       "handle": "zuck",
-      "friends": { "count" : 1234 }
+      "friends": { "count": 1234 }
     },
     {
       "handle": "cocacola",
-      "likers": { "count" : 90234512 }
+      "likers": { "count": 90234512 }
     }
   ]
 }
@@ -839,7 +839,7 @@ indentation and blank initial and trailing lines via {BlockStringValue()}.
 
 For example, the following operation containing a block string:
 
-```graphql example
+```raw graphql example
 mutation {
   sendEmail(message: """
     Hello,
@@ -1200,13 +1200,17 @@ Directives may be provided in a specific syntactic order which may have semantic
 These two type definitions may have different semantic meaning:
 
 ```graphql example
-type Person @addExternalFields(source: "profiles") @excludeField(name: "photo") {
+type Person
+  @addExternalFields(source: "profiles")
+  @excludeField(name: "photo") {
   name: String
 }
 ```
 
 ```graphql example
-type Person @excludeField(name: "photo") @addExternalFields(source: "profiles") {
+type Person
+  @excludeField(name: "photo")
+  @addExternalFields(source: "profiles") {
   name: String
 }
 ```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -59,7 +59,7 @@ self descriptive.
 
 As an example, this simple GraphQL schema is well described:
 
-```graphql example
+```raw graphql example
 """
 A simple GraphQL schema which is well described.
 """
@@ -1071,7 +1071,7 @@ interface. Querying for `age` is only valid when the result of `entity` is a
     ... on Person {
       age
     }
-  },
+  }
   phoneNumber
 }
 ```
@@ -1083,7 +1083,7 @@ interface must define each field that is specified by the implemented interface.
 For example, the interface Resource must define the field id to implement the
 Node interface:
 
-```graphql example
+```raw graphql example
 interface Node {
   id: ID!
 }
@@ -1099,7 +1099,7 @@ that is being implemented) must also be defined on an implementing type or
 interface. For example, `Image` cannot implement `Resource` without also
 implementing `Node`:
 
-```graphql example
+```raw graphql example
 interface Node {
   id: ID!
 }
@@ -1298,7 +1298,7 @@ Instead, the query would be:
 Union members may be defined with an optional leading `|` character to aid
 formatting when representing a longer list of possible types:
 
-```graphql example
+```raw graphql example
 union SearchResult =
   | Photo
   | Person
@@ -1847,7 +1847,7 @@ fragment SomeFragment on SomeType {
 Directive locations may be defined with an optional leading `|` character to aid
 formatting when representing a longer list of possible locations:
 
-```graphql example
+```raw graphql example
 directive @example on
   | FIELD
   | FRAGMENT_SPREAD

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -50,7 +50,7 @@ would return
       {
         "name": "birthday",
         "type": { "name": "Date" }
-      },
+      }
     ]
   }
 }

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -40,7 +40,11 @@ type Query {
   dog: Dog
 }
 
-enum DogCommand { SIT, DOWN, HEEL }
+enum DogCommand {
+  SIT
+  DOWN
+  HEEL
+}
 
 type Dog implements Pet {
   name: String!
@@ -69,7 +73,9 @@ type Human implements Sentient {
   pets: [Pet!]
 }
 
-enum CatCommand { JUMP }
+enum CatCommand {
+  JUMP
+}
 
 type Cat implements Pet {
   name: String!
@@ -952,7 +958,7 @@ Defined fragments must be used within a document.
 
 For example the following is an invalid document:
 
-```graphql counter-example
+```raw graphql counter-example
 fragment nameFragment on Dog { # unused
   name
 }
@@ -1272,7 +1278,7 @@ interface scope which it implements.
 In the example below, the `...resourceFragment` fragments spreads is valid,
 since `Resource` implements `Node`.
 
-```graphql example
+```raw graphql example
 interface Node {
   id: ID!
 }
@@ -1494,7 +1500,7 @@ For example, the following query will not pass validation because `@skip` has
 been used twice for the same field:
 
 ```graphql counter-example
-query ($foo: Boolean = true, $bar: Boolean = false) {
+query($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $foo) @skip(if: $bar)
 }
 ```
@@ -1503,7 +1509,7 @@ However the following example is valid because `@skip` has been used only once
 per location, despite being used twice in the query and on the same named field:
 
 ```graphql example
-query ($foo: Boolean = true, $bar: Boolean = false) {
+query($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $foo) {
     subfieldA
   }
@@ -1579,7 +1585,10 @@ used as inputs.
 For these examples, consider the following typesystem additions:
 
 ```graphql example
-input ComplexInput { name: String, owner: String }
+input ComplexInput {
+  name: String
+  owner: String
+}
 
 extend type Query {
   findDog(complex: ComplexInput): Dog

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1499,8 +1499,8 @@ directive is allowed per location.
 For example, the following query will not pass validation because `@skip` has
 been used twice for the same field:
 
-```graphql counter-example
-query($foo: Boolean = true, $bar: Boolean = false) {
+```raw graphql counter-example
+query ($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $foo) @skip(if: $bar)
 }
 ```
@@ -1508,8 +1508,8 @@ query($foo: Boolean = true, $bar: Boolean = false) {
 However the following example is valid because `@skip` has been used only once
 per location, despite being used twice in the query and on the same named field:
 
-```graphql example
-query($foo: Boolean = true, $bar: Boolean = false) {
+```raw graphql example
+query ($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $foo) {
     subfieldA
   }

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -113,8 +113,8 @@ The response might look like:
   "errors": [
     {
       "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 } ],
-      "path": [ "hero", "heroFriends", 1, "name" ]
+      "locations": [{ "line": 6, "column": 7 }],
+      "path": ["hero", "heroFriends", 1, "name"]
     }
   ],
   "data": {
@@ -153,8 +153,8 @@ be the same:
   "errors": [
     {
       "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 } ],
-      "path": [ "hero", "heroFriends", 1, "name" ]
+      "locations": [{ "line": 6, "column": 7 }],
+      "path": ["hero", "heroFriends", 1, "name"]
     }
   ],
   "data": {
@@ -186,8 +186,8 @@ there are no additional restrictions on its contents.
   "errors": [
     {
       "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 } ],
-      "path": [ "hero", "heroFriends", 1, "name" ],
+      "locations": [{ "line": 6, "column": 7 }],
+      "path": ["hero", "heroFriends", 1, "name"],
       "extensions": {
         "code": "CAN_NOT_FETCH_BY_ID",
         "timestamp": "Fri Feb 9 14:33:09 UTC 2018"
@@ -210,8 +210,8 @@ still discouraged.
   "errors": [
     {
       "message": "Name for character with ID 1002 could not be fetched.",
-      "locations": [ { "line": 6, "column": 7 } ],
-      "path": [ "hero", "heroFriends", 1, "name" ],
+      "locations": [{ "line": 6, "column": 7 }],
+      "path": ["hero", "heroFriends", 1, "name"],
       "code": "CAN_NOT_FETCH_BY_ID",
       "timestamp": "Fri Feb 9 14:33:09 UTC 2018"
     }


### PR DESCRIPTION
In #727 I have been working on `prettier` support for formatting the GraphQL spec. The PR is formed of three commits: one manually applying changes to the markdown to minimize the resulting diff, one adding the prettier tooling, and finally one that runs `prettier` against the codebase.

~~When the following three PRs to spec-md are merged and released, the diff of the generated HTML on that final commit will be very small (mostly whitespace within tables due to the new table formatting):~~

- ~~https://github.com/leebyron/spec-md/pull/53~~
- ~~https://github.com/leebyron/spec-md/pull/54~~
- ~~https://github.com/leebyron/spec-md/pull/55~~
- ~~(and optionally https://github.com/leebyron/spec-md/pull/56)~~

_(Edit: all these have been merged and Lee's advanced spec-md further :raised_hands: this means that final diff is now EMPTY!)_

This PR is the first commit from #727: the manual formatting changes that were required. My hope is that we can merge this now and then reviewing the prettier formatted PR will be significantly less work (because the output HTML will be identical).

The changes in this PR are broadly:

- Change to standard markdown titles ([support added in spec-md](https://github.com/leebyron/spec-md/pull/44))
- Escape special markdown characters that may confuse prettier
- Formatting code blocks more like how prettier will format them
- Marking code blocks that should not be formatted as `raw` ([support added in spec-md](https://github.com/leebyron/spec-md/pull/38))

~~Marking this as draft because I want to validate my changes before others spend time looking at it.~~