### PR TITLE
Editorial: Refine design principles

### DIFF
--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -36,35 +36,35 @@ platform for tool-building.
 
 GraphQL has a number of design principles:
 
- * **Hierarchical**: Most product development today involves the creation and
-   manipulation of view hierarchies. To achieve congruence with the structure
-   of these applications, a GraphQL query itself is structured hierarchically.
-   The query is shaped just like the data it returns. It is a natural
-   way for clients to describe data requirements.
-
  * **Product-centric**: GraphQL is unapologetically driven by the requirements
    of views and the front-end engineers that write them. GraphQL starts with
    their way of thinking and requirements and builds the language and runtime
    necessary to enable that.
 
+ * **Hierarchical**: Most product development today involves the creation and
+   manipulation of view hierarchies. To achieve congruence with the structure
+   of these applications, a GraphQL request itself is structured hierarchically.
+   The request is shaped just like the data in its response. It is a natural way
+   for clients to describe data requirements.
+
  * **Strong-typing**: Every GraphQL service defines an application-specific
-   type system. Queries are executed within the context of that type system.
-   Given a query, tools can ensure that the query is both syntactically
-   correct and valid within the GraphQL type system before execution, i.e. at
+   type system. Requests are executed within the context of that type system.
+   Given a GraphQL operation, tools can ensure that it is both syntactically
+   correct and valid within that type system before execution, i.e. at
    development time, and the service can make certain guarantees about the shape
    and nature of the response.
 
- * **Client-specified queries**: Through its type system, a GraphQL service
+ * **Client-specified response**: Through its type system, a GraphQL service
    publishes the capabilities that its clients are allowed to consume. It is
    the client that is responsible for specifying exactly how it will consume
-   those published capabilities. These queries are specified at field-level
-   granularity. In the majority of client-server applications written
-   without GraphQL, the service determines the data returned in its various
-   scripted endpoints. A GraphQL query, on the other hand, returns exactly what
-   a client asks for and no more.
+   those published capabilities. These requests are specified at field-level
+   granularity. In the majority of client-server applications written without
+   GraphQL, the service determines the shape of data returned from its various
+   endpoints. A GraphQL response, on the other hand, contains exactly what a
+   client asks for and no more.
 
  * **Introspective**: GraphQL is introspective. A GraphQL service's type system
-   must be queryable by the GraphQL language itself, as will be described in this
+   can be queryable by the GraphQL language itself, as will be described in this
    specification. GraphQL introspection serves as a powerful platform for
    building common tools and client software libraries.
 


### PR DESCRIPTION
Updates design principles to use more generalized language, and slightly reorders to put product-centric first.

Factored out of #777 