### PR TITLE
Editorial: Clarify meta-fields in introspection

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -89,14 +89,17 @@ warnings.
 
 ## Type Name Introspection
 
-GraphQL supports type name introspection at any point within a query by the
-meta-field `__typename: String!` when querying against any Object, Interface,
-or Union. It returns the name of the object type currently being queried.
+GraphQL supports type name introspection at any selection set within an
+operation with the meta-field `__typename: String!` on any Object,
+Interface, or Union; with the single exception of the subscription root
+operation type. It returns the name of the concrete Object type at that point
+during execution.
 
 This is most often used when querying against Interface or Union types to
-identify which actual type of the possible types has been returned.
+identify which actual Object type of the possible types has been returned.
 
-This field is implicit and does not appear in the fields list in any defined type.
+This meta-field is implicit and does not appear in the fields list in any
+defined type.
 
 
 ## Schema Introspection
@@ -110,8 +113,8 @@ __schema: __Schema!
 __type(name: String!): __Type
 ```
 
-These fields are implicit and do not appear in the fields list in the root type
-of the query operation.
+These meta-fields are implicit and do not appear in the fields list in the root
+type of the query operation.
 
 The schema of the GraphQL schema introspection system:
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -98,8 +98,8 @@ the concrete Object type at that point during execution.
 This is most often used when querying against Interface or Union types to
 identify which actual Object type of the possible types has been returned.
 
-As a meta-field, `__typename` is implicit and does not appear in the fields list in any
-defined type.
+As a meta-field, `__typename` is implicit and does not appear in the fields list
+in any defined type.
 
 
 ## Schema Introspection
@@ -113,8 +113,8 @@ __schema: __Schema!
 __type(name: String!): __Type
 ```
 
-Like all meta-fields, these are implicit and do not appear in the fields list in the root
-type of the query operation.
+Like all meta-fields, these are implicit and do not appear in the fields list in
+the root type of the query operation.
 
 The schema of the GraphQL schema introspection system:
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -98,7 +98,7 @@ during execution.
 This is most often used when querying against Interface or Union types to
 identify which actual Object type of the possible types has been returned.
 
-This meta-field is implicit and does not appear in the fields list in any
+As a meta-field, `__typename` is implicit and does not appear in the fields list in any
 defined type.
 
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -113,7 +113,7 @@ __schema: __Schema!
 __type(name: String!): __Type
 ```
 
-These meta-fields are implicit and do not appear in the fields list in the root
+Like all meta-fields, these are implicit and do not appear in the fields list in the root
 type of the query operation.
 
 The schema of the GraphQL schema introspection system:

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -89,11 +89,11 @@ warnings.
 
 ## Type Name Introspection
 
-GraphQL supports type name introspection at any selection set within an
-operation with the meta-field `__typename: String!` on any Object,
-Interface, or Union; with the single exception of the subscription root
-operation type. It returns the name of the concrete Object type at that point
-during execution.
+GraphQL supports type name introspection within any selection set in an
+operation, with the single exception of selections at the root of a subscription
+operation. Type name introspection is accomplished via the meta-field
+`__typename: String!` on any Object, Interface, or Union. It returns the name of
+the concrete Object type at that point during execution.
 
 This is most often used when querying against Interface or Union types to
 identify which actual Object type of the possible types has been returned.


### PR DESCRIPTION
Derived from #777

Renames "field" to "meta-field" consistently. Adds "with the single exception of the subscription root
operation type". Clarifies some language.