### PR TITLE
Editorial: Clarify type modifiers text

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -218,12 +218,13 @@ enum __DirectiveLocation {
 ### The __Type Type
 
 `__Type` is at the core of the type introspection system, it represents all
-types in the system: both named types (e.g. Scalars and Object types) and 
-type modifiers (e.g. List and Non-Null types). 
+types in the system: both named types (e.g. Scalars and Object types) and
+type modifiers (e.g. List and Non-Null types).
 
-Type modifiers are used to modify the type presented in the field `ofType`. 
-This modified type may recursively be a modified type, representing lists, 
-non-nullables, and combinations thereof, ultimately modifying a named type.
+Type modifiers are used to modify the type presented in the `ofType` field (the
+"inner type"). This inner type may recursively be a type modifier. In this way
+type modifiers can represent lists, non-nullables, and combinations thereof,
+ultimately modifying a named type.
 
 ### Type Kinds
 


### PR DESCRIPTION
This PR aims to improve the last minute changes to https://github.com/graphql/graphql-spec/pull/775 by improving the readability of the paragraph. The text `This modified type may recursively be a modified type` is hard to grok, and we've referred to `modified type` twice here, whereas I believe we actually mean `This modified type may recursively be a type modifier`. Instead of making this small edit, I've tried to improve readability further by implicitly defining the "inner type" term (see #831 for context on this) and then using this to refer to the modified type.