### PR TITLE
fixed introspection field "specifiedBy" to "specifiedByURL"

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -395,7 +395,7 @@ URL via the `@specifiedBy` directive or the `specifiedByURL` introspection field
 This URL must link to a human-readable specification of the data format,
 serialization, and coercion rules for the scalar. For example, a GraphQL service
 providing a `UUID` scalar may link to RFC 4122, or some custom document defining
-a reasonable subset of that RFC. If a scalar `specifiedByURL` is present,
+a reasonable subset of that RFC. If a scalar specification URL is present,
 systems and tools that are aware of it should conform to its described rules.
 
 ```graphql example
@@ -411,7 +411,7 @@ Custom scalar specification URLs should not be changed once defined. Doing so
 would likely disrupt tooling or could introduce breaking changes within the
 linked specification's contents.
 
-Built-in scalar types must not provide a `specifiedByURL` as they are specified
+Built-in scalar types must not provide a specification URL as they are specified
 by this document.
 
 Note: Custom scalars should also summarize the specified format and provide

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -395,7 +395,7 @@ URL via the `@specifiedBy` directive or the `specifiedByURL` introspection field
 This URL must link to a human-readable specification of the data format,
 serialization, and coercion rules for the scalar. For example, a GraphQL service
 providing a `UUID` scalar may link to RFC 4122, or some custom document defining
-a reasonable subset of that RFC. If a scalar `specifiedByURL` URL is present,
+a reasonable subset of that RFC. If a scalar `specifiedByURL` is present,
 systems and tools that are aware of it should conform to its described rules.
 
 ```graphql example
@@ -411,7 +411,7 @@ Custom scalar specification URLs should not be changed once defined. Doing so
 would likely disrupt tooling or could introduce breaking changes within the
 linked specification's contents.
 
-Built-in scalar types must not provide a `specifiedByURL` URL as they are specified
+Built-in scalar types must not provide a `specifiedByURL` as they are specified
 by this document.
 
 Note: Custom scalars should also summarize the specified format and provide

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -391,11 +391,11 @@ useful custom scalar is `URL`, which serializes as a string, but is guaranteed
 by the server to be a valid URL.
 
 When defining a custom scalar, GraphQL services should provide a specification
-URL via the `@specifiedBy` directive or the `specifiedBy` introspection field.
+URL via the `@specifiedBy` directive or the `specifiedByURL` introspection field.
 This URL must link to a human-readable specification of the data format,
 serialization, and coercion rules for the scalar. For example, a GraphQL service
 providing a `UUID` scalar may link to RFC 4122, or some custom document defining
-a reasonable subset of that RFC. If a scalar `specifiedBy` URL is present,
+a reasonable subset of that RFC. If a scalar `specifiedByURL` URL is present,
 systems and tools that are aware of it should conform to its described rules.
 
 ```graphql example
@@ -411,7 +411,7 @@ Custom scalar specification URLs should not be changed once defined. Doing so
 would likely disrupt tooling or could introduce breaking changes within the
 linked specification's contents.
 
-Built-in scalar types must not provide a `specifiedBy` URL as they are specified
+Built-in scalar types must not provide a `specifiedByURL` URL as they are specified
 by this document.
 
 Note: Custom scalars should also summarize the specified format and provide

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -152,7 +152,7 @@ type __Type {
   ofType: __Type
 
   # should be non-null for custom SCALAR only, must be null for the others
-  specifiedBy: String
+  specifiedByURL: String
 }
 
 type __Field {
@@ -242,13 +242,13 @@ actually valid. These kinds are listed in the `__TypeKind` enumeration.
 Represents scalar types such as Int, String, and Boolean. Scalars cannot have fields.
 
 Also represents [Custom scalars](#sec-Scalars.Custom-Scalars) which may provide 
-`specifiedBy` as a scalar specification URL.
+`specifiedByURL` as a scalar specification URL.
 
 Fields
 
 * `kind` must return `__TypeKind.SCALAR`.
 * `name` must return a String.
-* `specifiedBy` may return a String (in the form of a URL) for custom scalars, 
+* `specifiedByURL` may return a String (in the form of a URL) for custom scalars, 
    otherwise must be {null}.
 * `description` may return a String or {null}.
 * All other fields must return {null}.


### PR DESCRIPTION
- I've sent PR to graphql/graphql-js is modified introspection field according to "[[RFC] Custom Scalar Specification URLs](https://github.com/graphql/graphql-spec/pull/649)".
  - But I have got a reply from @IvanGoncharov and I understand `specifiedBy` should be `specifiedByURL` to be consistent with `deprecatedReason` representing `@deprecated(reason: "")` directive. (I agreed this direction)
  - https://github.com/graphql/graphql-js/pull/3032#issuecomment-817857967