### PR TITLE
Editorial: Define type definitions

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -620,7 +620,7 @@ object).
 
 Fragments can be specified on object types, interfaces, and unions.
 
-Selections within fragments only return values when the concrete type of the object
+Selections within fragments only return values when the *concrete Object type*
 it is operating on matches the type of the fragment.
 
 For example in this operation using the Facebook data model:
@@ -1154,9 +1154,8 @@ NonNullType :
   - NamedType !
   - ListType !
 
-GraphQL describes the types of data expected by arguments and variables.
-Input types may be lists of another input type, or a non-null variant of any
-other input type.
+GraphQL describes the *input type* of data expected by arguments and variables,
+and the *output type* of fields.
 
 **Semantics**
 
@@ -1170,13 +1169,14 @@ Type : Name
 Type : [ Type ]
 
   * Let {itemType} be the result of evaluating {Type}
-  * Let {type} be a List type where {itemType} is the contained type.
+  * Let {type} be a *List type* where {itemType} is the inner *item type*.
   * Return {type}
 
 Type : Type !
 
   * Let {nullableType} be the result of evaluating {Type}
-  * Let {type} be a Non-Null type where {nullableType} is the contained type.
+  * Let {type} be a *Non-Null type* where {nullableType} is the inner
+    *nullable type*.
   * Return {type}
 
 
@@ -1194,7 +1194,7 @@ behavior in ways field arguments will not suffice, such as conditionally
 including or skipping a field. Directives provide this by describing additional information to the executor.
 
 Directives have a name along with a list of arguments which may accept values
-of any input type.
+of any *input type*.
 
 Directives can be used to describe additional information for types, fields,
 fragments and operations.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -263,74 +263,108 @@ TypeDefinition :
   - InputObjectTypeDefinition
 
 The fundamental unit of any GraphQL Schema is the type. There are six kinds
-of named type definitions in GraphQL, and two wrapping types.
+of *named type* and two kinds of *wrapped type* definitions in GraphQL.
 
-The most basic type is a `Scalar`. A scalar represents a primitive value, like
-a string or an integer. Oftentimes, the possible responses for a scalar field
-are enumerable. GraphQL offers an `Enum` type in those cases, where the type
-specifies the space of valid responses.
-
-Scalars and Enums form the leaves in response trees; the intermediate levels are
-`Object` types, which define a set of fields, where each field is another
-type in the system, allowing the definition of arbitrary type hierarchies.
-
-GraphQL supports two abstract types: interfaces and unions.
-
-An `Interface` defines a list of fields; `Object` types and other Interface
-types which implement this Interface are guaranteed to implement those fields.
-Whenever a field claims it will return an Interface type, it will return a
-valid implementing Object type during execution.
-
-A `Union` defines a list of possible types; similar to interfaces, whenever the
-type system claims a union will be returned, one of the possible types will be
-returned.
-
-Finally, oftentimes it is useful to provide complex structs as inputs to
-GraphQL field arguments or variables; the `Input Object` type allows the schema
-to define exactly what data is expected.
+:: A *named type* is one of the six types defined with a name: *Scalar type*,
+*Enum type*, *Object type*, *Interface type*, *Union type*,
+and *Input Object type*.
 
 
-### Wrapping Types
+### Leaf and Composite Types
+
+:: A *leaf type* is found at the leaves in a response tree. There are two kinds
+of leaf types: *Scalar type* and *Enum type*.
+
+The most basic *leaf type* is the *Scalar type*. A scalar represents a primitive
+value, like a string or an integer. GraphQL defines a set of *built-in scalars*
+and also allows a service to additionally provide any *custom scalar*.
+
+Oftentimes, the possible values for a *leaf type* are enumerable. GraphQL offers
+the *Enum type* in those cases, where the each enum type definition specifies
+the set of possible values.
+
+:: A *composite type* compose together leaf types and other composite types as a
+set of named fields, allowing the composition of arbitrary type hierarchies and
+nested trees of data. There are three composite *output type*: Object,
+Interface, and Union, and one composite *input type*: Input Object.
+
+The *Object type* is the concrete output *composite type* which describes an
+actual concrete value which will a field will resolve during execution, composed
+of other *output type* fields, allowing responses of nested data.
+
+Oftentimes it is useful to provide a *composite type* as an *input type* to a
+field argument or variable; the *Input Object type* composes a set of
+*input type* fields, allowing inputs of nested data.
+
+
+### Abstract Types
+
+:: An *abstract type* defines a set of possible types, one of which will be
+resolved during field execution. There are two kinds of abstract types:
+*Interface type* and *Union type*.
+
+:: The type an abstract type resolves to during execution is referred to as the
+*concrete Object type*, which is always an *Object type*.
+
+An *Interface type* defines a list of fields. An type which implements this
+Interface must also implement those fields. Whenever a field claims it will
+return an *Interface type*, it will return an implementing
+*concrete Object type* during field execution.
+
+A *Union type* defines a list of possible types. Similar to Interfaces,
+whenever a field claims it will return a *Union type*, it will return one of the
+possible types as the *concrete Object type* during field execution.
+
+
+### Wrapped Types
 
 All of the types so far are assumed to be both nullable and singular: e.g. a
-scalar string returns either null or a singular string.
+scalar string returns either {null} or a singular string.
 
-A GraphQL schema may describe that a field represents a list of another type;
-the `List` type is provided for this reason, and wraps another type.
+:: A *wrapped type* wraps another type (its *inner type*) to create a collection
+or variation of that type. There are two kinds of wrapped types: *List type* and
+*Non-Null type*.
 
-Similarly, the `Non-Null` type wraps another type, and denotes that the
-resulting value will never be {null} (and that a field error cannot result in a
-{null} value).
+:: The *inner type* is the type immediately wrapped by a *wrapped type*, which
+itself may be a *wrapped type* allowing for combinations of *wrapped type*. If
+continuously unwrapped, ultimately a *named type* is found.
 
-These two types are referred to as "wrapping types"; non-wrapping types are
-referred to as "named types". A wrapping type has an underlying named type,
-found by continually unwrapping the type until a named type is found.
+A GraphQL schema may describe that a field or argument expects a list of another
+type; the *List type* is provided for this purpose, and wraps an *inner type*
+describing the items in the list.
+
+Similarly, a field or argument may describe that it must never be {null}. The
+*Non-Null type* is provided for this purpose, and wraps an *inner type*
+describing the expected type, if not {null}.
 
 
 ### Input and Output Types
 
 Types are used throughout GraphQL to describe both the values accepted as input
 to arguments and variables as well as the values output by fields. These two
-uses categorize types as *input types* and *output types*. Some kinds of types,
-like Scalar and Enum types, can be used as both input types and output types;
-other kinds of types can only be used in one or the other. Input Object types can
-only be used as input types. Object, Interface, and Union types can only be used
-as output types. Lists and Non-Null types may be used as input types or output
-types depending on how the wrapped type may be used.
+uses categorize types as an *input type* or an *output type*. Some kinds of
+types, like Scalar and Enum types, can be used as both input types and output
+types; other kinds of types can only be used in one or the other.
+
+:: An *input type* is a *Scalar type*, *Enum type*, *Input Object type*, or a
+*wrapped type* of one of these types.
 
 IsInputType(type) :
-  * If {type} is a List type or Non-Null type:
-    * Let {unwrappedType} be the unwrapped type of {type}.
-    * Return IsInputType({unwrappedType})
+  * If {type} is a *wrapped type* (a *List type* or *Non-Null type*):
+    * Let {innerType} be the *inner type* of {type}.
+    * Return IsInputType({innerType})
   * If {type} is a Scalar, Enum, or Input Object type:
     * Return {true}
   * Return {false}
 
+:: An *output type* is a *Scalar type*, *Enum type*, *Object type*,
+*Interface Type*, *Union Type* or a *wrapped type* of one of these types.
+
 IsOutputType(type) :
-  * If {type} is a List type or Non-Null type:
-    * Let {unwrappedType} be the unwrapped type of {type}.
-    * Return IsOutputType({unwrappedType})
-  * If {type} is a Scalar, Object, Interface, Union, or Enum type:
+  * If {type} is a *wrapped type* (a *List type* or *Non-Null type*):
+    * Let {innerType} be the *inner type* of {type}.
+    * Return IsOutputType({innerType})
+  * If {type} is a Scalar, Enum, Object, Interface, or Union type:
     * Return {true}
   * Return {false}
 
@@ -354,35 +388,35 @@ represent additional fields a GraphQL client only accesses locally.
 
 ScalarTypeDefinition : Description? scalar Name Directives[Const]?
 
-Scalar types represent primitive leaf values in a GraphQL type system. GraphQL
-responses take the form of a hierarchical tree; the leaves of this tree are
-typically GraphQL Scalar types (but may also be Enum types or {null} values).
+:: A *Scalar type* represents primitive leaf values in a GraphQL type system.
+GraphQL responses take the form of a hierarchical tree; the leaves of this tree
+are typically GraphQL Scalar types (but may also be Enum types or {null} values).
 
-GraphQL provides a number of built-in scalars which are fully defined in the
-sections below, however type systems may also add additional custom scalars to
-introduce additional semantic meaning.
+GraphQL provides a number of *built-in scalars* which are fully defined in the
+sections below, however type systems may also add any additional
+*custom scalar type* to introduce additional semantic meaning.
 
 **Built-in Scalars**
 
-GraphQL specifies a basic set of well-defined Scalar types: {Int}, {Float},
-{String}, {Boolean}, and {ID}. A GraphQL framework should support all of these
-types, and a GraphQL service which provides a type by these names must adhere to
-the behavior described for them in this document. As an example, a service must
-not include a type called {Int} and use it to represent 64-bit numbers,
-internationalization information, or anything other than what is defined in
-this document.
+:: GraphQL specifies a basic set of well-defined *built-in scalars*: {Int},
+{Float}, {String}, {Boolean}, and {ID}. A GraphQL framework should support all
+of these types, and a GraphQL service which provides a type by these names must
+adhere to the behavior described for them in this document. As an example, a
+service must not include a type called {Int} and use it to represent 64-bit
+numbers, internationalization information, or anything other than what is
+defined in this document.
 
 When returning the set of types from the `__Schema` introspection type, all
-referenced built-in scalars must be included. If a built-in scalar type is not
+referenced *built-in scalars* must be included. If a built-in scalar type is not
 referenced anywhere in a schema (there is no field, argument, or input field of
 that type) then it must not be included.
 
 When representing a GraphQL schema using the type system definition language,
-all built-in scalars must be omitted for brevity.
+all *built-in scalars* must be omitted for brevity.
 
 **Custom Scalars**
 
-GraphQL services may use custom scalar types in addition to the built-in
+:: GraphQL services may use a *custom scalar type* in addition to the built-in
 scalars. For example, a GraphQL service could define a scalar called `UUID`
 which, while serialized as a string, conforms to [RFC 4122](https://tools.ietf.org/html/rfc4122).
 When querying a field of type `UUID`, you can then rely on the ability to parse
@@ -487,7 +521,7 @@ greater than or equal to 2<sup>31</sup>, a field error should be raised.
 
 **Input Coercion**
 
-When expected as an input type, only integer input values are accepted. All
+When expected as an *input type*, only integer input values are accepted. All
 other input values, including strings with numeric content, must raise a request
 error indicating an incorrect type. If the integer input value represents a
 value less than -2<sup>31</sup> or greater than or equal to 2<sup>31</sup>, a
@@ -520,7 +554,7 @@ coerced to {Float} and must raise a field error.
 
 **Input Coercion**
 
-When expected as an input type, both integer and float input values are
+When expected as an *input type*, both integer and float input values are
 accepted. Integer input values are coerced to Float by adding an empty
 fractional part, for example `1.0` for the integer input value `1`. All
 other input values, including strings with numeric content, must raise a request
@@ -549,7 +583,7 @@ string `"1"` for the integer `1`.
 
 **Input Coercion**
 
-When expected as an input type, only valid Unicode string input values are
+When expected as an *input type*, only valid Unicode string input values are
 accepted. All other input values must raise a request error indicating an
 incorrect type.
 
@@ -570,7 +604,7 @@ this may include returning `true` for non-zero numbers.
 
 **Input Coercion**
 
-When expected as an input type, only boolean input values are accepted. All
+When expected as an *input type*, only boolean input values are accepted. All
 other input values must raise a request error indicating an incorrect type.
 
 
@@ -593,7 +627,7 @@ When coercion is not possible they must raise a field error.
 
 **Input Coercion**
 
-When expected as an input type, any string (such as `"4"`) or integer (such as
+When expected as an *input type*, any string (such as `"4"`) or integer (such as
 `4` or `-4`) input value should be coerced to ID as appropriate for the ID
 formats a given GraphQL service expects. Any other input value, including float
 input values (such as `4.0`), must raise a request error indicating an incorrect
@@ -636,10 +670,10 @@ GraphQL operations are hierarchical and composed, describing a tree of
 information. While Scalar types describe the leaf values of these hierarchical
 operations, Objects describe the intermediate levels.
 
-GraphQL Objects represent a list of named fields, each of which yield a value of
-a specific type. Object values should be serialized as ordered maps, where the
-selected field names (or aliases) are the keys and the result of evaluating
-the field is the value, ordered by the order in which they appear in
+:: An *Object type* represents a list of named fields, each of which yield a
+value of a specific type. Object values should be serialized as ordered maps,
+where the selected field names (or aliases) are the keys and the result of
+evaluating the field is the value, ordered by the order in which they appear in
 the selection set.
 
 All fields defined within an Object type must not have a name which begins with
@@ -704,9 +738,7 @@ Must only yield exactly that subset:
 }
 ```
 
-A field of an Object type may be a Scalar, Enum, another Object type,
-an Interface, or a Union. Additionally, it may be any wrapping type whose
-underlying base type is one of those five.
+A field of an Object type must be an *output type*.
 
 For example, the `Person` type might include a `relationship`:
 
@@ -906,24 +938,23 @@ IsValidImplementation(type, implementedType):
             must be {true}.
 
 IsValidImplementationFieldType(fieldType, implementedFieldType):
-  1. If {fieldType} is a Non-Null type:
-     1. Let {nullableType} be the unwrapped nullable type of {fieldType}.
-     2. Let {implementedNullableType} be the unwrapped nullable type
-        of {implementedFieldType} if it is a Non-Null type, otherwise let it be
-        {implementedFieldType} directly.
+  1. If {fieldType} is a *Non-Null type*:
+     1. Let {nullableType} be the *nullable type* of {fieldType}.
+     2. Let {implementedNullableType} be the *nullable type*
+        of {implementedFieldType} if it is a *Non-Null type*, otherwise let it
+        be {implementedFieldType} directly.
      3. Return {IsValidImplementationFieldType(nullableType, implementedNullableType)}.
-  2. If {fieldType} is a List type and {implementedFieldType} is also a List type:
-     1. Let {itemType} be the unwrapped item type of {fieldType}.
-     2. Let {implementedItemType} be the unwrapped item type
-        of {implementedFieldType}.
+  2. If {fieldType} is and {implementedFieldType} are both a *List type*:
+     1. Let {itemType} be the *item type* of {fieldType}.
+     2. Let {implementedItemType} be the *item type* of {implementedFieldType}.
      3. Return {IsValidImplementationFieldType(itemType, implementedItemType)}.
   3. If {fieldType} is the same type as {implementedFieldType} then return {true}.
-  4. If {fieldType} is an Object type and {implementedFieldType} is
-     a Union type and {fieldType} is a possible type of {implementedFieldType}
+  4. If {fieldType} is an *Object type* and {implementedFieldType} is
+     a *Union type* and {fieldType} is a possible type of {implementedFieldType}
      then return {true}.
-  5. If {fieldType} is an Object or Interface type and {implementedFieldType}
-     is an Interface type and {fieldType} declares it implements
-     {implementedFieldType} then return {true}.
+  5. If {fieldType} is an *Object type* or *Interface type* and
+     {implementedFieldType} is an *Interface type* and {fieldType} declares it
+     implements {implementedFieldType} then return {true}.
   6. Otherwise return {false}.
 
 
@@ -935,8 +966,8 @@ InputValueDefinition : Description? Name : Type DefaultValue? Directives[Const]?
 
 Object fields are conceptually functions which yield values. Occasionally object
 fields can accept arguments to further specify the return value. Object field
-arguments are defined as a list of all possible argument names and their
-expected input types.
+arguments are defined as a list of all possible argument names and each of their
+expected *input type*.
 
 All arguments defined within a field must not have a name which begins with
 {"__"} (two underscores), as this is used exclusively by GraphQL's
@@ -973,8 +1004,7 @@ May return the result:
 }
 ```
 
-The type of an object field argument must be an input type (any type except an
-Object, Interface, or Union type).
+The type of an object field argument must be an *input type*.
 
 
 ### Field Deprecation
@@ -1045,13 +1075,12 @@ InterfaceTypeDefinition :
   - Description? interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition
   - Description? interface Name ImplementsInterfaces? Directives[Const]? [lookahead != `{`]
 
-GraphQL interfaces represent a list of named fields and their arguments. GraphQL
-objects and interfaces can then implement these interfaces which requires that
-the implementing type will define all fields defined by those interfaces.
+:: An *Interface type* represents a list of named fields and their arguments.
+An *object type* or another *interface type* can then implement these interfaces
+which requires that they define all fields defined by those interfaces.
 
 Fields on a GraphQL interface have the same rules as fields on a GraphQL object;
-their type can be Scalar, Object, Enum, Interface, or Union, or any wrapping
-type whose base type is one of those five.
+their type must be an *output type*.
 
 For example, an interface `NamedEntity` may describe a required field and types
 such as `Person` or `Business` may then implement this interface to guarantee
@@ -1294,8 +1323,8 @@ UnionMemberTypes :
   - UnionMemberTypes | NamedType
   - = `|`? NamedType
 
-GraphQL Unions represent an object that could be one of a list of GraphQL
-Object types, but provides for no guaranteed fields between those types.
+:: A *Union type* represents an value that could be one of a list of potential
+*Object type*, but provides for no guaranteed fields between those types.
 They also differ from interfaces in that Object types declare what interfaces
 they implement, but are not aware of what unions contain them.
 
@@ -1378,9 +1407,9 @@ Unions are never valid inputs.
 Union types have the potential to be invalid if incorrectly defined.
 
 1. A Union type must include one or more unique member types.
-2. The member types of a Union type must all be Object base types;
+2. The member types of a Union type must each be an *Object type*;
    Scalar, Interface and Union types must not be member types of a Union.
-   Similarly, wrapping types must not be member types of a Union.
+   Similarly, *wrapped types* must not be member types of a Union.
 
 
 ### Union Extensions
@@ -1399,9 +1428,9 @@ extension of another GraphQL service.
 Union type extensions have the potential to be invalid if incorrectly defined.
 
 1. The named type must already be defined and must be a Union type.
-2. The member types of a Union type extension must all be Object base types;
+2. The member types of a Union type extension must each be an *Object type*;
    Scalar, Interface and Union types must not be member types of a Union.
-   Similarly, wrapping types must not be member types of a Union.
+   Similarly, *wrapped types* must not be member types of a Union.
 3. All member types of a Union type extension must be unique.
 4. All member types of a Union type extension must not already be a member of
    the original Union type.
@@ -1418,7 +1447,7 @@ EnumValuesDefinition : { EnumValueDefinition+ }
 
 EnumValueDefinition : Description? EnumValue Directives[Const]?
 
-GraphQL Enum types, like Scalar types, also represent leaf values in a GraphQL
+:: An *Enum type*, like a *Scalar type*, also represent leaf values in a GraphQL
 type system. However Enum types describe the set of possible values.
 
 Enums are not references for a numeric value, but are unique values in their own
@@ -1492,9 +1521,9 @@ InputFieldsDefinition : { InputValueDefinition+ }
 Fields may accept arguments to configure their behavior. These inputs are often
 scalars or enums, but they sometimes need to represent more complex values.
 
-A GraphQL Input Object defines a set of input fields; the input fields are either
-scalars, enums, or other input objects. This allows arguments to accept
-arbitrarily complex structs.
+:: An *Input object type* defines a set of input fields; the input fields are
+any *input type* (Scalars, Enums, or Input Objects). This allows arguments to
+accept arbitrarily complex data.
 
 In this example, an Input Object called `Point2D` describes `x` and `y` inputs:
 
@@ -1672,13 +1701,17 @@ Input object type extensions have the potential to be invalid if incorrectly def
 
 ## List
 
-A GraphQL list is a special collection type which declares the type of each
-item in the List (referred to as the *item type* of the list). List values are
-serialized as ordered lists, where each item in the list is serialized as per
-the item type.
+:: By default, all types in GraphQL are singular. A *List type* is a
+*wrapped type* which defines an ordered collection of its *inner type*.
 
-To denote that a field uses a List type the item type is wrapped in square brackets
-like this: `pets: [Pet]`. Nesting lists is allowed: `matrix: [[Int]]`.
+:: Each instance of a List type wraps a *item type*, its *inner type*,
+describing the type of each item in the List. List values are serialized as
+ordered lists, where each item in the list is serialized as per the item type.
+An *item type* field may itself be a *wrapped type*, allowing the representation
+of Lists of Lists, or Lists of Non-Nulls.
+
+To denote that a type is a *List type* the *item type* is wrapped in square
+brackets like this: `pets: [Pet]`. Nesting lists is allowed: `matrix: [[Int]]`.
 
 **Result Coercion**
 
@@ -1729,13 +1762,18 @@ Expected Type | Provided Value   | Coerced Value
 
 ## Non-Null
 
-By default, all types in GraphQL are nullable; the {null} value is a valid
-response for all of the above types. To declare a type that disallows null,
-the GraphQL Non-Null type can be used. This type wraps an underlying type,
-and this type acts identically to that wrapped type, with the exception
-that {null} is not a valid response for the wrapping type. A trailing
-exclamation mark is used to denote a field that uses a Non-Null type like this:
-`name: String!`.
+:: By default, all types in GraphQL are nullable; the {null} value is a valid
+response for all of the above types. A *Non-Null type* is a *wrapped type* which
+defines a variation of its *inner type* which must not be {null}.
+
+:: Each instance of a Non-Null type has a *nullable type*, its *inner type*.
+The Non-Null type acts identically to its nullable type, with the exception that
+{null} is not a valid response. A *nullable type* field may be a *List type*,
+allowing the representation of Non-Null of Lists. However it must not be another
+*Non-Null type* to avoid a redundant Non-Null of Non-Null.
+
+To denote that a type is a *Non-Null type* the *nullable type* is followed by an
+exclamation mark like this: `required: String!`.
 
 **Nullable vs. Optional**
 
@@ -1751,7 +1789,7 @@ are always optional and non-null types are always required.
 **Result Coercion**
 
 In all of the above result coercions, {null} was considered a valid value.
-To coerce the result of a Non-Null type, the coercion of the wrapped type
+To coerce the result of a Non-Null type, the coercion of the *inner type*
 should be performed. If that result was not {null}, then the result of coercing
 the Non-Null type is that result. If that result was {null}, then a field error
 must be raised.
@@ -1769,7 +1807,7 @@ a request error must be raised.
 
 If the value provided to the Non-Null type is provided with a literal value
 other than {null}, or a Non-Null variable value, it is coerced using the input
-coercion for the wrapped type.
+coercion for the *inner type*.
 
 A non-null argument cannot be omitted:
 
@@ -1800,19 +1838,20 @@ a non-null input type as invalid.
 
 **Type Validation**
 
-1. A Non-Null type must not wrap another Non-Null type.
+1. A *Non-Null type* must not wrap another *Non-Null type*.
 
 
 ### Combining List and Non-Null
 
-The List and Non-Null wrapping types can compose, representing more complex
-types. The rules for result coercion and input coercion of Lists and Non-Null
+The *List type* and *Non-Null types* can compose, representing more complex
+types. The rules for result coercion and input coercion of List and Non-Null
 types apply in a recursive fashion.
 
-For example if the inner item type of a List is Non-Null (e.g. `[T!]`), then
-that List may not contain any {null} items. However if the inner type of a
-Non-Null is a List (e.g. `[T]!`), then {null} is not accepted however an empty
-list is accepted.
+For example if the inner *item type* of a *List type* is a *Non-Null type*
+(e.g. `[T!]`), then that List value may not contain any {null} items. However if
+the inner *nullable type* of a *Non-Null type* is a *List type* (e.g. `[T]!`),
+then {null} is not accepted as a value, however a List containing {null} as an
+item is accepted.
 
 Following are examples of result coercion with various types and values:
 
@@ -2067,9 +2106,9 @@ directive @specifiedBy(url: String!) on SCALAR
 
 The `@specifiedBy` *built-in directive* is used within the type system
 definition language to provide a *scalar specification URL* for specifying the
-behavior of [custom scalar types](#sec-Scalars.Custom-Scalars). The URL should
-point to a human-readable specification of the data format, serialization, and
-coercion rules. It must not appear on built-in scalar types.
+behavior of a *custom scalar type*. The URL should point to a human-readable
+specification of the data format, serialization, and coercion rules. It must not
+appear on *built-in scalars*.
 
 In this example, a custom scalar type for `UUID` is defined with a URL pointing
 to the relevant IETF specification.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -72,10 +72,11 @@ GraphQL supports type name introspection within any selection set in an
 operation, with the single exception of selections at the root of a subscription
 operation. Type name introspection is accomplished via the meta-field
 `__typename: String!` on any Object, Interface, or Union. It returns the name of
-the concrete Object type at that point during execution.
+the *concrete Object type* at that point during execution.
 
-This is most often used when querying against Interface or Union types to
-identify which actual Object type of the possible types has been returned.
+This is most often used when querying against a Interface or Union
+*abstract type* to identify which actual *concrete Object type* of the possible
+types has been returned.
 
 As a meta-field, `__typename` is implicit and does not appear in the fields list
 in any defined type.
@@ -230,7 +231,7 @@ Fields\:
   Otherwise {null}.
 * `subscriptionType` is the root type of a subscription operation, if supported.
   Otherwise {null}.
-* `types` must return the set of all named types contained within this schema.
+* `types` must return the set of all *named type* contained within this schema.
   Any named type which can be found through a field of any introspection type
   must be included in this set.
 * `directives` must return the set of all directives available within
@@ -240,12 +241,8 @@ Fields\:
 ### The __Type Type
 
 `__Type` is at the core of the type introspection system, it represents all
-types in the system: both named types (e.g. Scalars and Object types) and
-type modifiers (e.g. List and Non-Null types).
-
-Type modifiers are used to modify the type presented in the field `ofType`.
-This modified type may recursively be a modified type, representing lists,
-non-nullables, and combinations thereof, ultimately modifying a named type.
+types in the system: both *named types* (e.g. *Scalar type* or *Object type*)
+and *wrapped types* (e.g. *List type* or *Non-Null type*).
 
 There are several different kinds of type. In each kind, different fields are
 actually valid. All possible kinds are listed in the `__TypeKind` enum.
@@ -264,10 +261,11 @@ possible value of the `__TypeKind` enum:
 
 **Scalar**
 
-Represents scalar types such as Int, String, and Boolean. Scalars cannot have fields.
+Represents a *scalar type* such as Int, String, and Boolean. Scalars cannot have
+fields.
 
-Also represents [Custom scalars](#sec-Scalars.Custom-Scalars) which may provide
-`specifiedByURL` as a *scalar specification URL*.
+Also represents a *custom scalar type* which may provide `specifiedByURL` as a
+*scalar specification URL*.
 
 Fields\:
 
@@ -281,8 +279,9 @@ Fields\:
 
 **Object**
 
-Object types represent concrete instantiations of sets of fields. The
-introspection types (e.g. `__Type`, `__Field`, etc) are examples of objects.
+An *Object type* represents concrete instantiations of sets of fields. The
+introspection types (e.g. `__Type`, `__Field`, etc) are themselves examples of
+object types.
 
 Fields\:
 
@@ -297,28 +296,12 @@ Fields\:
 * All other fields must return {null}.
 
 
-**Union**
-
-Unions are an abstract type where no common fields are declared. The possible
-types of a union are explicitly listed out in `possibleTypes`. Types can be
-made parts of unions without modification of that type.
-
-Fields\:
-
-* `kind` must return `__TypeKind.UNION`.
-* `name` must return a String.
-* `description` may return a String or {null}.
-* `possibleTypes` returns the list of types that can be represented within this
-  union. They must be object types.
-* All other fields must return {null}.
-
-
 **Interface**
 
-Interfaces are an abstract type where there are common fields declared. Any type
-that implements an interface must define all the fields with names and types
-exactly matching. The implementations of this interface are explicitly listed
-out in `possibleTypes`.
+An *Interface type* is an *abstract type* where there are common fields
+declared. Any type that implements an interface must define all the fields with
+names and types exactly matching. The implementations of this interface are
+explicitly listed out in `possibleTypes`.
 
 Fields\:
 
@@ -331,13 +314,30 @@ Fields\:
 * `interfaces` must return the set of interfaces that an object implements
   (if none, `interfaces` must return the empty set).
 * `possibleTypes` returns the list of types that implement this interface.
-  They must be object types.
+  They must each be an *Object type*.
+* All other fields must return {null}.
+
+
+**Union**
+
+A *Union type* is an *abstract type* where no common fields are declared. The
+possible types of a union are explicitly listed out in `possibleTypes`. The
+possible types of a union do not directly reference the union type.
+
+Fields\:
+
+* `kind` must return `__TypeKind.UNION`.
+* `name` must return a String.
+* `description` may return a String or {null}.
+* `possibleTypes` returns the list of types that can be represented within this
+  union. They must each be an *Object type*.
 * All other fields must return {null}.
 
 
 **Enum**
 
-Enums are special scalars that can only have a defined set of values.
+An *Enum type* is a *leaf type* that represents a defined set of possible
+values.
 
 Fields\:
 
@@ -353,9 +353,9 @@ Fields\:
 
 **Input Object**
 
-Input objects are composite types defined as a list of named input values. They
-are only used as inputs to arguments and variables and cannot be a field
-return type.
+An *Input Object type* is a composite *input type* defined as a set of
+*input type* fields. They are only used as inputs to arguments and variables and
+cannot be a field return type.
 
 For example the input object `Point` could be defined as:
 
@@ -377,12 +377,12 @@ Fields\:
 
 **List**
 
-Lists represent sequences of values in GraphQL. A List type is a type modifier:
-it wraps another type instance in the `ofType` field, which defines the type of
+A *List type* is a *wrapped type* which represents an ordered collection of
+values. It wraps an *item type* in the `ofType` field which defines the type of
 each item in the list.
 
-The modified type in the `ofType` field may itself be a modified type, allowing
-the representation of Lists of Lists, or Lists of Non-Nulls.
+A List type's *item type* in the `ofType` field may itself be a *wrapped type*,
+allowing the representation of Lists of Lists, or Lists of Non-Nulls.
 
 Fields\:
 
@@ -393,15 +393,13 @@ Fields\:
 
 **Non-Null**
 
-GraphQL types are nullable. The value {null} is a valid response for field type.
+A *Non-Null type* is a *wrapped type* which represents a value which must not be
+{null}. It wraps a *nullable type* in the `ofType` field which defines the
+expected type of a value if not {null}.
 
-A Non-Null type is a type modifier: it wraps another type instance in the
-`ofType` field. Non-null types do not allow {null} as a response, and indicate
-required inputs for arguments and input object fields.
-
-The modified type in the `ofType` field may itself be a modified List type,
-allowing the representation of Non-Null of Lists. However it must not be a
-modified Non-Null type to avoid a redundant Non-Null of Non-Null.
+A Non-Null type's *nullable type* in the `ofType` field may be a *List type*,
+allowing the representation of Non-Null of Lists. However it must not be another
+*Non-Null type* to avoid a redundant Non-Null of Non-Null.
 
 Fields\:
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -429,19 +429,19 @@ SameResponseShape(fieldA, fieldB):
 
   * Let {typeA} be the return type of {fieldA}.
   * Let {typeB} be the return type of {fieldB}.
-  * If {typeA} or {typeB} is Non-Null.
-    * If {typeA} or {typeB} is nullable, return false.
-    * Let {typeA} be the nullable type of {typeA}
-    * Let {typeB} be the nullable type of {typeB}
-  * If {typeA} or {typeB} is List.
-    * If {typeA} or {typeB} is not List, return false.
-    * Let {typeA} be the item type of {typeA}
-    * Let {typeB} be the item type of {typeB}
+  * If {typeA} or {typeB} is a *Non-Null type*.
+    * If {typeA} or {typeB} is not a *Non-Null type*, return false.
+    * Let {typeA} be the *nullable type* of {typeA}
+    * Let {typeB} be the *nullable type* of {typeB}
+  * If {typeA} or {typeB} is a *List type*.
+    * If {typeA} or {typeB} is not a *List type*, return false.
+    * Let {typeA} be the *item type* of {typeA}
+    * Let {typeB} be the *item type* of {typeB}
     * Repeat from step 3.
-  * If {typeA} or {typeB} is Scalar or Enum.
+  * If {typeA} or {typeB} is *Scalar type* or *Enum type*.
     * If {typeA} and {typeB} are the same type return true, otherwise return
       false.
-  * Assert: {typeA} and {typeB} are both composite types.
+  * Assert: {typeA} and {typeB} are both a *composite type*.
   * Let {mergedSet} be the result of adding the selection set of {fieldA} and
     the selection set of {fieldB}.
   * Let {fieldsForName} be the set of selections with a given response name in
@@ -1579,8 +1579,8 @@ fragment HouseTrainedFragment on Query {
 
 **Explanatory Text**
 
-Variables can only be input types. Objects, unions, and interfaces cannot be
-used as inputs.
+Variables can only be an *input type*. Objects, unions, interfaces and other
+*output types* cannot be used as the type of a variable.
 
 For these examples, consider the following type system additions:
 
@@ -1882,33 +1882,33 @@ IsVariableUsageAllowed(variableDefinition, variableUsage):
   * Let {variableType} be the expected type of {variableDefinition}.
   * Let {locationType} be the expected type of the {Argument}, {ObjectField},
     or {ListValue} entry where {variableUsage} is located.
-  * If {locationType} is a non-null type AND {variableType} is NOT a non-null type:
+  * If {locationType} is a *Non-Null type* AND {variableType} is NOT a *Non-Null type*:
     * Let {hasNonNullVariableDefaultValue} be {true} if a default value exists
       for {variableDefinition} and is not the value {null}.
     * Let {hasLocationDefaultValue} be {true} if a default value exists for
       the {Argument} or {ObjectField} where {variableUsage} is located.
     * If {hasNonNullVariableDefaultValue} is NOT {true} AND
       {hasLocationDefaultValue} is NOT {true}, return {false}.
-    * Let {nullableLocationType} be the unwrapped nullable type of {locationType}.
+    * Let {nullableLocationType} be the inner *nullable type* of {locationType}.
     * Return {AreTypesCompatible(variableType, nullableLocationType)}.
   * Return {AreTypesCompatible(variableType, locationType)}.
 
 AreTypesCompatible(variableType, locationType):
 
-  * If {locationType} is a non-null type:
-    * If {variableType} is NOT a non-null type, return {false}.
-    * Let {nullableLocationType} be the unwrapped nullable type of {locationType}.
-    * Let {nullableVariableType} be the unwrapped nullable type of {variableType}.
+  * If {locationType} is a *non-null type*:
+    * If {variableType} is NOT a *non-null type*, return {false}.
+    * Let {nullableLocationType} be the inner *nullable type* of {locationType}.
+    * Let {nullableVariableType} be the inner *nullable type* of {variableType}.
     * Return {AreTypesCompatible(nullableVariableType, nullableLocationType)}.
-  * Otherwise, if {variableType} is a non-null type:
+  * Otherwise, if {variableType} is a *non-null type*:
     * Let {nullableVariableType} be the nullable type of {variableType}.
     * Return {AreTypesCompatible(nullableVariableType, locationType)}.
-  * Otherwise, if {locationType} is a list type:
-    * If {variableType} is NOT a list type, return {false}.
-    * Let {itemLocationType} be the unwrapped item type of {locationType}.
-    * Let {itemVariableType} be the unwrapped item type of {variableType}.
+  * Otherwise, if {locationType} is a *list type*:
+    * If {variableType} is NOT a *list type*, return {false}.
+    * Let {itemLocationType} be the inner *item type* of {locationType}.
+    * Let {itemVariableType} be the inner *item type* of {variableType}.
     * Return {AreTypesCompatible(itemVariableType, itemLocationType)}.
-  * Otherwise, if {variableType} is a list type, return {false}.
+  * Otherwise, if {variableType} is a *list type*, return {false}.
   * Return {true} if {variableType} and {locationType} are identical, otherwise {false}.
 
 **Explanatory Text**
@@ -1917,7 +1917,7 @@ Variable usages must be compatible with the arguments they are passed to.
 
 Validation failures occur when variables are used in the context of types
 that are complete mismatches, or if a nullable type in a variable is passed to
-a non-null argument type.
+an argument with a *Non-Null type*.
 
 Types must match:
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -91,7 +91,7 @@ CoerceVariableValues(schema, operation, variableValues):
     * If {hasValue} is not {true} and {defaultValue} exists (including {null}):
       * Add an entry to {coercedValues} named {variableName} with the
         value {defaultValue}.
-    * Otherwise if {variableType} is a Non-Nullable type, and either {hasValue}
+    * Otherwise if {variableType} is a *Non-Null type*, and either {hasValue}
       is not {true} or {value} is {null}, raise a request error.
     * Otherwise if {hasValue} is true:
       * If {value} is {null}:
@@ -561,7 +561,7 @@ ExecuteField(objectType, objectValue, fieldType, fields, variableValues):
 
 Fields may include arguments which are provided to the underlying runtime in
 order to correctly produce a value. These arguments are defined by the field in
-the type system to have a specific input type.
+the type system to have a specific *input type*.
 
 At each argument position in an operation may be a literal {Value}, or a
 {Variable} to be provided at runtime.
@@ -590,7 +590,7 @@ CoerceArgumentValues(objectType, field, variableValues):
     * If {hasValue} is not {true} and {defaultValue} exists (including {null}):
       * Add an entry to {coercedValues} named {argumentName} with the
         value {defaultValue}.
-    * Otherwise if {argumentType} is a Non-Nullable type, and either {hasValue}
+    * Otherwise if {argumentType} is a *Non-Null type*, and either {hasValue}
       is not {true} or {value} is {null}, raise a field error.
     * Otherwise if {hasValue} is true:
       * If {value} is {null}:
@@ -642,26 +642,26 @@ to the expected return type. If the return type is another Object type, then
 the field execution process continues recursively.
 
 CompleteValue(fieldType, fields, result, variableValues):
-  * If the {fieldType} is a Non-Null type:
-    * Let {innerType} be the inner type of {fieldType}.
+  * If the {fieldType} is a *Non-Null type*:
+    * Let {nullableType} be the *nullable type* of {fieldType}.
     * Let {completedResult} be the result of calling
-      {CompleteValue(innerType, fields, result, variableValues)}.
+      {CompleteValue(nullableType, fields, result, variableValues)}.
     * If {completedResult} is {null}, raise a field error.
     * Return {completedResult}.
   * If {result} is {null} (or another internal value similar to {null} such as
     {undefined}), return {null}.
-  * If {fieldType} is a List type:
+  * If {fieldType} is a *List type*:
     * If {result} is not a collection of values, raise a field error.
-    * Let {innerType} be the inner type of {fieldType}.
+    * Let {itemType} be the *item type* of {fieldType}.
     * Return a list where each list item is the result of calling
-      {CompleteValue(innerType, fields, resultItem, variableValues)}, where
+      {CompleteValue(itemType, fields, resultItem, variableValues)}, where
       {resultItem} is each item in {result}.
-  * If {fieldType} is a Scalar or Enum type:
+  * If {fieldType} is a *leaf type* (a *Scalar type* or *Enum type*):
     * Return the result of {CoerceResult(fieldType, result)}.
-  * If {fieldType} is an Object, Interface, or Union type:
-    * If {fieldType} is an Object type.
+  * If {fieldType} is a *composite type* (an *Object type*, *Interface type*, or *Union type*):
+    * If {fieldType} is an *Object type*.
       * Let {objectType} be {fieldType}.
-    * Otherwise if {fieldType} is an Interface or Union type.
+    * Otherwise if {fieldType} is an *abstract type* (an *Interface type* or *Union type*):
       * Let {objectType} be {ResolveAbstractType(fieldType, result)}.
     * Let {subSelectionSet} be the result of calling {MergeSelectionSets(fields)}.
     * Return the result of evaluating {ExecuteSelectionSet(subSelectionSet, objectType, result, variableValues)} *normally* (allowing for parallelization).
@@ -674,7 +674,7 @@ schema. This "dynamic type checking" allows GraphQL to provide consistent
 guarantees about returned types atop any service's internal runtime.
 
 See the Scalars [Result Coercion and Serialization](#sec-Scalars.Result-Coercion-and-Serialization)
-sub-section for more detailed information about how GraphQL's built-in scalars
+sub-section for more detailed information about how GraphQL's *built-in scalars*
 coerce result values.
 
 CoerceResult(leafType, value):
@@ -690,10 +690,9 @@ and output of {CoerceResult()} must not be {null}.
 
 **Resolving Abstract Types**
 
-When completing a field with an abstract return type, that is an Interface or
-Union return type, first the abstract type must be resolved to a relevant Object
-type. This determination is made by the internal system using whatever
-means appropriate.
+When completing a value of an *abstract type* (an Interface or Union type),
+first the abstract type must be resolved to a *concrete Object type*. This
+determination is made by the internal system using whatever means appropriate.
 
 Note: A common method of determining the Object type for an {objectValue} in
 object-oriented environments, such as Java or C#, is to use the class name of
@@ -701,8 +700,8 @@ the {objectValue}.
 
 ResolveAbstractType(abstractType, objectValue):
   * Return the result of calling the internal method provided by the type
-    system for determining the Object type of {abstractType} given the
-    value {objectValue}.
+    system for determining the *concrete Object type* of {abstractType} given
+    the value {objectValue}.
 
 **Merging Selection Sets**
 
@@ -752,24 +751,24 @@ the response.
 
 If the result of resolving a field is {null} (either because the function to
 resolve the field returned {null} or because a field error was raised), and that
-field is of a `Non-Null` type, then a field error is raised. The
-error must be added to the {"errors"} list in the response.
+field is of a *Non-Null type*, then a field error is raised. The error must be
+added to the {"errors"} list in the response.
 
 If the field returns {null} because of a field error which has already been
 added to the {"errors"} list in the response, the {"errors"} list must not be
 further affected. That is, only one error should be added to the errors list per
 field.
 
-Since `Non-Null` type fields cannot be {null}, field errors are propagated to be
+Since *Non-Null type* fields cannot be {null}, field errors are propagated to be
 handled by the parent field. If the parent field may be {null} then it resolves
-to {null}, otherwise if it is a `Non-Null` type, the field error is further
+to {null}, otherwise if it is a *Non-Null type*, the field error is further
 propagated to it's parent field.
 
-If a `List` type wraps a `Non-Null` type, and one of the elements of that list
+If a *List type* wraps a *Non-Null type*, and one of the elements of that list
 resolves to {null}, then the entire list must resolve to {null}.
-If the `List` type is also wrapped in a `Non-Null`, the field error continues
-to propagate upwards.
+If the *List type* is also wrapped by a *Non-Null type*, the field error
+continues to propagate upwards.
 
 If all fields from the root of the request to the source of the field error
-return `Non-Null` types, then the {"data"} entry in the response should
+return a *Non-Null type*, then the {"data"} entry in the response should
 be {null}.


### PR DESCRIPTION
This broad change uses definition phrases to define each type, as well as expands the set of sub-sections at the top of the "Types" section which define *kinds* of types. In doing so applies the definitions arrived at in #845 for "wrapped types".

Makes editorial improvements throughout, removing duplicate language or attempting to improve correctness or legibility.