### PR TITLE
Relax SameResponseShape algorithm to be compatible with covariant fields

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -429,10 +429,10 @@ SameResponseShape(fieldA, fieldB):
 
   * Let {typeA} be the return type of {fieldA}.
   * Let {typeB} be the return type of {fieldB}.
-  * If {typeA} or {typeB} is Non-Null.
-    * If {typeA} or {typeB} is nullable, return false.
-    * Let {typeA} be the nullable type of {typeA}
-    * Let {typeB} be the nullable type of {typeB}
+  * If {typeA} is Non-Null.
+    * Let {typeA} be the unwrapped nullable type of {typeA}
+  * If {typeB} is Non-Null.
+    * Let {typeB} be the unwrapped nullable type of {typeB}
   * If {typeA} or {typeB} is List.
     * If {typeA} or {typeB} is not List, return false.
     * Let {typeA} be the item type of {typeA}


### PR DESCRIPTION
At the moment covariance rules for interfaces are incompatible with
validation rule for overlapping fragments.
For example, if we have schema like this:

```graphql
interface AddressInterface {
  country_code: String
}

type Port implements AddressInterface {
  country_code: String!
}

type Warehouse implements AddressInterface {
  country_code: String
}

type Query {
  addressInterface: AddressInterface
}
```

This query is valid:
```graphql
query {
  addressInterface {
    country_code
  }
}
```

But if you expand interface field into inline fragments will cause a
validation error:
```graphql
query {
  addressInterface {
    ... on Port {
      country_code
    }
    ... on Warehouse {
      country_code
    }
  }
}
```

This PR fixes this issue.
