### PR TITLE
add note about selection sets in serial execution examples

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -452,6 +452,9 @@ A correct executor must generate the following result for that selection set:
 }
 ```
 
+Note: The previous two examples depict only a selection set and _not_ a full
+document using the query shorthand.
+
 ### Field Collection
 
 Before execution, the selection set is converted to a grouped field set by


### PR DESCRIPTION
The examples for serial execution in the section `Normal and Serial Execution` actually use a query as operation type. This PR proposes to change these examples to mutations (which are actually required to be executed serially).

I also added in the variables in the first of these examples for the operation to be valid.