### PR TITLE
Make UnionMemberTypes non-optional

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1294,7 +1294,7 @@ defined.
 ## Unions
 
 UnionTypeDefinition : Description? union Name Directives[Const]?
-UnionMemberTypes?
+UnionMemberTypes
 
 UnionMemberTypes :
 


### PR DESCRIPTION
In the Validation section, it is stated:

```A Union type must include one or more unique member types.```
(https://spec.graphql.org/draft/#sec-Unions.Type-Validation)

Thus it seems that UnionMemberTypes are not optional.
