### PR TITLE
Fix wording on Leaf Field Selections

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -569,7 +569,7 @@ fragment conflictingDifferingResponses on Pet {
 **Formal Specification**
 
 - For each {selection} in the document
-- Let {selectionType} be the result type of {selection}
+- Let {selectionType} be the return type of {selection}
 - If {selectionType} is a scalar or enum:
   - The subselection set of that selection must be empty
 - If {selectionType} is an interface, union, or object


### PR DESCRIPTION
There's no other reference to "result types" on the specification and the same idea is given the name "return type" on IsValidImplementation, SameResponseShape and ExecuteSelectionSet.

As an aside: Should this wording be changed so field selections are forbidden for NonNull scalars and Lists of scalars but required for NonNull Objects and lists of Objects?