### PR TITLE
Define request, note it is transport independent

### DIFF
--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -4,7 +4,7 @@ GraphQL is a query language designed to build client applications by providing
 an intuitive and flexible syntax and system for describing their data
 requirements and interactions.
 
-For example, this GraphQL request will receive the name of the user with id 4
+For example, this GraphQL _request_ will receive the name of the user with id 4
 from the Facebook implementation of GraphQL.
 
 ```graphql example

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1,7 +1,7 @@
 # Language
 
 Clients use the GraphQL query language to make requests to a GraphQL service. We
-refer to these request sources as documents. A document may contain operations
+refer to these _request_ sources as documents. A document may contain operations
 (queries, mutations, and subscriptions) as well as fragments, a common unit of
 composition allowing for data requirement reuse.
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -2,7 +2,7 @@
 
 GraphQL generates a response from a request via execution.
 
-A request for execution consists of a few pieces of information:
+:: A _request_ for execution consists of a few pieces of information:
 
 - The schema to use, typically solely provided by the GraphQL service.
 - A {Document} which must contain GraphQL {OperationDefinition} and may contain
@@ -16,6 +16,10 @@ A request for execution consists of a few pieces of information:
 
 Given this information, the result of {ExecuteRequest()} produces the response,
 to be formatted according to the Response section below.
+
+Note: GraphQL requests do not require any specific serialization format or
+transport mechanism. Message serialization and transport mechanisms should be
+chosen by the implementing service.
 
 ## Executing Requests
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -1,6 +1,6 @@
 # Response
 
-When a GraphQL service receives a request, it must return a well-formed
+When a GraphQL service receives a _request_, it must return a well-formed
 response. The service's response describes the result of executing the requested
 operation if successful, and describes any errors raised during the request.
 


### PR DESCRIPTION
Closes https://github.com/graphql/graphql-wg/issues/643 ("Add a non-normative note that GraphQL request != HTTP request")

I didn't specifically mention "HTTP" but I think this gets the point across.