### PR TITLE
Add validation rule that operation types exist

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -148,12 +148,14 @@ type system where those operations begin.
 The {`query`} root operation type must be provided and must be an Object type.
 
 The {`mutation`} root operation type is optional; if it is not provided, the
-service does not support mutations. If it is provided, it must be an Object
-type.
+service does not support mutations (see
+[Operation Type Existence](#sec-Operation-Type-Existence)). If it is provided,
+it must be an Object type.
 
 Similarly, the {`subscription`} root operation type is also optional; if it is
-not provided, the service does not support subscriptions. If it is provided, it
-must be an Object type.
+not provided, the service does not support subscriptions (see
+[Operation Type Existence](#sec-Operation-Type-Existence))s. If it is provided,
+it must be an Object type.
 
 The {`query`}, {`mutation`}, and {`subscription`} root types must all be
 different types if provided.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -129,6 +129,42 @@ extend type Dog {
 
 ## Operations
 
+### All Operation Definitions
+
+#### Operation Type Existence
+
+**Formal Specification**
+
+- For each operation definition {operation} in the document.
+- Let {operationRootType} be the root type in {schema} corresponding to the
+  type of {operation}.
+- {operationRootType} must exist.
+
+**Explanatory Text**
+
+Each operation must reference an operation type which has a valid root type
+in the schema.
+
+For example given the following schema:
+
+```graphql example
+type Query {
+  hello: String
+}
+```
+
+The following operation is valid:
+
+```graphql example
+query helloQuery { hello }
+```
+
+While the following operation is invalid:
+
+```graphql example
+mutation goodbyeMutation { goodbye }
+```
+
 ### Named Operation Definitions
 
 #### Operation Name Uniqueness


### PR DESCRIPTION
Right now the spec says that, for example, if the schema does not define
a mutation root type, then the schema does not support mutations.  But
there's no validation rule for it, which means that many parsers
(including graphql-js) treat a mutation as valid against such a schema.
(Indeed, many end up considering *any* mutation as valid, since they
don't know what type to validate the root selection set against.)  This
commit adds a validation rule to make the schema text explicit.

Slated for discussion at the June 2 working group meeting.
Replaces #947.  See also graphql/graphql-js#3592.