### PR TITLE
Leaf field selections clarification

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -583,8 +583,8 @@ fragment conflictingDifferingResponses on Pet {
 
 **Explanatory Text**
 
-Field subselections are never allowed on leaf fields. A leaf field is any
-field with a scalar or enum result type.
+Field subselections are never allowed on leaf fields. A leaf field is any field
+with a scalar or enum result type.
 
 The following is valid.
 
@@ -637,7 +637,6 @@ query directQueryOnUnionWithoutSubFields {
 ```
 
 However the following example is valid since it includes a field subselection.
-
 
 ```graphql example
 query directQueryOnObjectWithSubFields {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -605,8 +605,8 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 ```
 
 Conversely the underlying type of leaf field selections of GraphQL operations
-must be scalar or enum. Leaf selections on fields whose underlying type is
-object, interface, or union are disallowed.
+must be scalar or enum. Leaf selections without subfields on fields whose
+underlying type is object, interface, or union are disallowed.
 
 Let's assume the following additions to the query root operation type of the
 schema:

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -583,8 +583,8 @@ fragment conflictingDifferingResponses on Pet {
 
 **Explanatory Text**
 
-Field selections on scalars or enums are never allowed, because they are the
-leaf nodes of any GraphQL operation.
+Scalars and enums are the underlying type of leaf nodes of any GraphQL
+operation. Field selections are never allowed on leaf nodes.
 
 The following is valid.
 
@@ -604,9 +604,9 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 }
 ```
 
-Conversely the leaf field selections of GraphQL operations must be of type
-scalar or enum. Leaf selections on objects, interfaces, and unions without
-subfields are disallowed.
+Conversely the underlying type of leaf field selections of GraphQL operations
+must be scalar or enum. Leaf selections on fields whose underlying type is
+object, interface, or union are disallowed.
 
 Let's assume the following additions to the query root operation type of the
 schema:

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -584,7 +584,7 @@ fragment conflictingDifferingResponses on Pet {
 **Explanatory Text**
 
 A field subselection is not allowed on leaf fields. A leaf field is any field
-with a scalar or enum result type.
+with a scalar or enum unwrapped type.
 
 The following is valid.
 
@@ -605,7 +605,7 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 ```
 
 Conversely, non-leaf fields must have a field subselection. A non-leaf field is
-any field with an object, interface, or union result type.
+any field with an object, interface, or union unwrapped type.
 
 Let's assume the following additions to the query root operation type of the
 schema:

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -583,7 +583,7 @@ fragment conflictingDifferingResponses on Pet {
 
 **Explanatory Text**
 
-Field subselections are never allowed on leaf fields. A leaf field is any field
+A field subselection is not allowed on leaf fields. A leaf field is any field
 with a scalar or enum result type.
 
 The following is valid.
@@ -619,7 +619,7 @@ extend type Query {
 ```
 
 The following examples are invalid because they include non-leaf fields without
-field subselections.
+a field subselection.
 
 ```graphql counter-example
 query directQueryOnObjectWithoutSubFields {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -604,9 +604,8 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 }
 ```
 
-Conversely, any field without subselections must be a leaf field. That is,
-fields with an object, interface, or union result type must have a field
-subselection.
+Conversely, non-leaf fields must have a field subselection. A non-leaf field is
+any field with an object, interface, or union result type.
 
 Let's assume the following additions to the query root operation type of the
 schema:

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -583,8 +583,8 @@ fragment conflictingDifferingResponses on Pet {
 
 **Explanatory Text**
 
-Scalars and enums are the underlying type of leaf nodes of any GraphQL
-operation. Field selections are never allowed on leaf nodes.
+Field subselections are never allowed on leaf fields. A leaf field is any
+field with a scalar or enum result type.
 
 The following is valid.
 
@@ -604,9 +604,9 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 }
 ```
 
-Conversely the underlying type of leaf field selections of GraphQL operations
-must be scalar or enum. Leaf selections without subfields on fields whose
-underlying type is object, interface, or union are disallowed.
+Conversely, any field without subselections must be a leaf field. That is,
+fields with an object, interface, or union result type must have a field
+subselection.
 
 Let's assume the following additions to the query root operation type of the
 schema:
@@ -619,7 +619,8 @@ extend type Query {
 }
 ```
 
-The following examples are invalid
+The following examples are invalid because they include non-leaf fields without
+field subselections.
 
 ```graphql counter-example
 query directQueryOnObjectWithoutSubFields {
@@ -632,6 +633,17 @@ query directQueryOnInterfaceWithoutSubFields {
 
 query directQueryOnUnionWithoutSubFields {
   catOrDog
+}
+```
+
+However the following example is valid since it includes a field subselection.
+
+
+```graphql example
+query directQueryOnObjectWithSubFields {
+  human {
+    name
+  }
 }
 ```
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -575,7 +575,7 @@ fragment conflictingDifferingResponses on Pet {
 **Formal Specification**
 
 - For each {selection} in the document:
-  - Let {selectionType} be the result type of {selection}.
+  - Let {selectionType} be the unwrapped result type of {selection}.
   - If {selectionType} is a scalar or enum:
     - The subselection set of that selection must be empty.
   - If {selectionType} is an interface, union, or object:


### PR DESCRIPTION
An alternative proposal to one of the changes in #957, this clarifies that we're talking about the "unwrapped type" or "underlying type" of the fields/selections.