### PR TITLE
Light editorial around delivery agnostic subscriptions

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -236,9 +236,9 @@ connectivity.
 **Delivery Agnostic**
 
 GraphQL subscriptions do not require any specific serialization format or
-transport mechanism. GraphQL specifies algorithms for the creation of a
-subscription stream, the content of each payload on that stream, and the closing
-of that stream. There are intentionally no specifications for message
+transport mechanism. GraphQL specifies algorithms for the creation of the
+response stream, the content of each payload on that stream, and the closing of
+that stream. There are intentionally no specifications for message
 acknowledgement, buffering, resend requests, or any other quality of service
 (QoS) details. Message serialization, transport mechanisms, and quality of
 service details should be chosen by the implementing service.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -236,12 +236,12 @@ connectivity.
 **Delivery Agnostic**
 
 GraphQL subscriptions do not require any specific serialization format or
-transport mechanism. Subscriptions specifies algorithms for the creation of a
-stream, the content of each payload on that stream, and the closing of that
-stream. There are intentionally no specifications for message acknowledgement,
-buffering, resend requests, or any other quality of service (QoS) details.
-Message serialization, transport mechanisms, and quality of service details
-should be chosen by the implementing service.
+transport mechanism. GraphQL specifies algorithms for the creation of a
+subscription stream, the content of each payload on that stream, and the closing
+of that stream. There are intentionally no specifications for message
+acknowledgement, buffering, resend requests, or any other quality of service
+(QoS) details. Message serialization, transport mechanisms, and quality of
+service details should be chosen by the implementing service.
 
 #### Source Stream
 


### PR DESCRIPTION
Previously:

> **Subscriptions** specifies algorithms for the creation of **a stream**, the content of each payload on that stream, and the closing of that stream.

The phrase "Subscriptions specifies" here was confusing, it's the GraphQL spec that does the specification, so I have clarified:

> **GraphQL** specifies algorithms for the creation of **the response stream**, the content of each payload on that stream, and the closing of that stream.

This is an alternative to a change in #957