### PR TITLE
Move punctuation outside quotation marks

### DIFF
--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -32,7 +32,7 @@ Copyright © 2015-2018, Facebook, Inc.
 
 Copyright © 2019-present, GraphQL contributors
 
-THESE MATERIALS ARE PROVIDED “AS IS.” The parties expressly disclaim any
+THESE MATERIALS ARE PROVIDED “AS IS”. The parties expressly disclaim any
 warranties (express, implied, or otherwise), including implied warranties of
 merchantability, non-infringement, fitness for a particular purpose, or title,
 related to the materials. The entire risk as to implementing or otherwise using


### PR DESCRIPTION
As discussed in https://github.com/graphql/graphql-over-http/pull/175#discussion_r896551920 - @benjie 

Every variant of the MIT license does it this way, see https://fedoraproject.org/wiki/Licensing:MIT for reference.
