### PR TITLE
Editorial: Remove inaccurate statement about line terminator within tokens

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -90,7 +90,7 @@ LineTerminator ::
 Like white space, line terminators are used to improve the legibility of source
 text and separate lexical tokens, any amount may appear before or after any
 other token and have no significance to the semantic meaning of a GraphQL
-Document. Line terminators are not found within any other token.
+Document.
 
 Note: Any error reporting which provides the line number in the source of the
 offending syntax should use the preceding amount of {LineTerminator} to produce


### PR DESCRIPTION
This phrase is no longer accurate after the introduction of BlockString, which can include a line terminator

---

Factoring this localized change from #957 so it can have a focused commit