### PR TITLE
Editorial: Clarity about subject being a GraphQL service or system

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1,8 +1,8 @@
 # Validation
 
-GraphQL does not just verify if a request is syntactically correct, but also
-ensures that it is unambiguous and mistake-free in the context of a given
-GraphQL schema.
+A GraphQL service does not just verify if a request is syntactically correct,
+but also ensures that it is unambiguous and mistake-free in the context of a
+given GraphQL schema.
 
 An invalid request is still technically executable, and will always produce a
 stable result as defined by the algorithms in the Execution section, however

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1,6 +1,6 @@
 # Execution
 
-GraphQL generates a response from a request via execution.
+A GraphQL service generates a response from a request via execution.
 
 :: A _request_ for execution consists of a few pieces of information:
 
@@ -174,7 +174,7 @@ Subscribe(subscription, schema, variableValues, initialValue):
   {MapSourceToResponseEvent(sourceStream, subscription, schema, variableValues)}
 - Return {responseStream}.
 
-Note: In large scale subscription systems, the {Subscribe()} and
+Note: In a large-scale subscription system, the {Subscribe()} and
 {ExecuteSubscriptionEvent()} algorithms may be run on separate services to
 maintain predictable scaling properties. See the section below on Supporting
 Subscriptions at Scale.


### PR DESCRIPTION
Rather than simply "GraphQL" clarity on "A GraphQL service" or in one case, a system of services.

---

Factoring this localized change from https://github.com/graphql/graphql-spec/pull/957 so it can have a focused commit