### PR TITLE
Fix normative requirement around `errors` property

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -52,7 +52,7 @@ If an error was raised during the execution that prevented a valid response, the
 The `errors` entry in the response is a non-empty list of errors, where each
 error is a map.
 
-If no errors were raised during the request, the `errors` entry should not be
+If no errors were raised during the request, the `errors` entry must not be
 present in the result.
 
 If the `data` entry in the response is not present, the `errors` entry in the


### PR DESCRIPTION
Whilst reviewing #966 I spotted this; I don't believe this is a breaking change since it can be derived from:

> The `errors` entry in the response is a **non-empty** list of errors, where each
error is a map.

So if no errors occur, then the "errors" key **must not** (rather than "should not") be present, since it's forbidden to be an empty list, it contains errors, and no errors occurred.
