### PR TITLE
Editorial: Clarify intro for inline fragments

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -667,10 +667,13 @@ be present and `likers` will not. Conversely when the result is a `Page`,
 
 InlineFragment : ... TypeCondition? Directives? SelectionSet
 
-Fragments can be defined inline within a selection set. This is done to
-conditionally include fields based on their runtime type. This feature of
-standard fragment inclusion was demonstrated in the `query FragmentTyping`
-example. We could accomplish the same thing using inline fragments.
+Fragments can also be defined inline within a selection set. This is useful for
+conditionally including fields based on a type condition or applying a directive
+to a selection set.
+
+This feature of standard fragment inclusion was demonstrated in the
+`query FragmentTyping` example above. We could accomplish the same thing using
+inline fragments.
 
 ```graphql example
 query inlineFragmentTyping {


### PR DESCRIPTION
Avoid repeating phase about type conditions and refer to prior section. Improve phrasing and include reference to directive application

Alternative to phrasing in #957