### PR TITLE
Editorial: Type kinds

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -357,9 +357,11 @@ piece of information available to request within a selection set.
 
 Some fields describe complex data or relationships to other data. In order to
 further explore this data, a field may itself contain a selection set, allowing
-for deeply nested requests. All GraphQL operations must specify their selections
-down to fields which return scalar values to ensure an unambiguously shaped
-response.
+for deeply nested requests.
+
+:: A _leaf field_ is a field whose unwrapped type is a Scalar or Enum _leaf
+type_. All GraphQL operations must specify their selections down to leaf fields
+to ensure an unambiguously shaped response.
 
 For example, this operation selects fields of complex data and relationships
 down to scalar values.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -300,7 +300,7 @@ Fields\:
 
 **Union**
 
-Unions are an abstract type where no common fields are declared. The possible
+Unions are an _abstract type_ where no common fields are declared. The possible
 types of a union are explicitly listed out in `possibleTypes`. Types can be made
 parts of unions without modification of that type.
 
@@ -315,10 +315,10 @@ Fields\:
 
 **Interface**
 
-Interfaces are an abstract type where there are common fields declared. Any type
-that implements an interface must define all the fields with names and types
-exactly matching. The implementations of this interface are explicitly listed
-out in `possibleTypes`.
+Interfaces are an _abstract type_ where there are common fields declared. Any
+type that implements an interface must define all the fields with names and
+types exactly matching. The implementations of this interface are explicitly
+listed out in `possibleTypes`.
 
 Fields\:
 
@@ -351,9 +351,9 @@ Fields\:
 
 **Input Object**
 
-Input objects are composite types defined as a list of named input values. They
-are only used as inputs to arguments and variables and cannot be a field return
-type.
+Input Objects are a _composite type_ defined as a list of named input field
+values. They are only used as inputs to arguments and variables and cannot be a
+field return type.
 
 For example the input object `Point` could be defined as:
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -446,7 +446,7 @@ SameResponseShape(fieldA, fieldB):
 - If {typeA} or {typeB} is Scalar or Enum:
   - If {typeA} and {typeB} are the same type return true, otherwise return
     false.
-- Assert: {typeA} and {typeB} are both composite types.
+- Assert: {typeA} and {typeB} are both Object, Interface or Union.
 - Let {mergedSet} be the result of adding the selection set of {fieldA} and the
   selection set of {fieldB}.
 - Let {fieldsForName} be the set of selections with a given response name in
@@ -555,8 +555,8 @@ fragment safeDifferingArgs on Pet {
 }
 ```
 
-However, the field responses must be shapes which can be merged. For example,
-scalar values must not differ. In this example, `someValue` might be a `String`
+However, the field responses must be shapes which can be merged, and _leaf
+field_ types must not differ. In this example, `someValue` might be a `String`
 or an `Int`:
 
 ```graphql counter-example
@@ -583,8 +583,8 @@ fragment conflictingDifferingResponses on Pet {
 
 **Explanatory Text**
 
-A field subselection is not allowed on leaf fields. A leaf field is any field
-with a scalar or enum unwrapped type.
+A field subselection is not allowed on a _leaf field_, a field with a Scalar or
+Enum unwrapped type.
 
 The following is valid.
 
@@ -1145,8 +1145,9 @@ fragment catInDogFragmentInvalid on Dog {
 
 ##### Abstract Spreads in Object Scope
 
-In scope of an object type, unions or interface spreads can be used if the
-object type implements the interface or is a member of the union.
+In scope of an object type, a fragment spread of an _abstract type_ (interface
+or union) can be used if the object type is one of the possible types of that
+abstract type (it implements the interface or is a member of the union).
 
 For example
 
@@ -1183,9 +1184,9 @@ invalid because we only consider the fragment declaration, not its body.
 
 ##### Object Spreads In Abstract Scope
 
-Union or interface spreads can be used within the context of an object type
-fragment, but only if the object type is one of the possible types of that
-interface or union.
+In the scope of an _abstract type_ (interface or union), a fragment spread of an
+object type can be used if the object type is one of the possible types of that
+abstract type (it implements the interface or is a member of the union).
 
 For example, the following fragments are valid:
 
@@ -1230,9 +1231,10 @@ can also never return meaningful results, making it invalid.
 
 ##### Abstract Spreads in Abstract Scope
 
-Union or interfaces fragments can be used within each other. As long as there
-exists at least _one_ object type that exists in the intersection of the
-possible types of the scope and the spread, the spread is considered valid.
+In the scope of an _abstract type_ (interface or union), a fragment spread of
+another _abstract type_ can be used as long as there exists at least _one_
+object type that exists in the intersection of the possible types of the scope
+and the spread.
 
 So for example
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -700,9 +700,9 @@ CompleteValue(fieldType, fields, result, variableValues):
 **Coercing Results**
 
 The primary purpose of value completion is to ensure that the values returned by
-field resolvers are valid according to the GraphQL type system and a service's
-schema. This "dynamic type checking" allows GraphQL to provide consistent
-guarantees about returned types atop any service's internal runtime.
+_leaf type_ field resolvers are valid according to the GraphQL type system and a
+service's schema. This "dynamic type checking" allows GraphQL to provide
+consistent guarantees about returned types atop any service's internal runtime.
 
 See the Scalars
 [Result Coercion and Serialization](#sec-Scalars.Result-Coercion-and-Serialization)
@@ -723,9 +723,9 @@ and output of {CoerceResult()} must not be {null}.
 
 **Resolving Abstract Types**
 
-When completing a field with an abstract return type, that is an Interface or
-Union return type, first the abstract type must be resolved to a relevant Object
-type. This determination is made by the internal system using whatever means
+When completing a field with an _abstract type_, that is an Interface or Union
+return type, first the abstract type must be resolved to a relevant Object type.
+This determination is made by the internal system using whatever means
 appropriate.
 
 Note: A common method of determining the Object type for an {objectValue} in


### PR DESCRIPTION
This provides definitions at the introduction of "Type System" for _leaf type_, _composite type_, and _abstract type_. Then, these definitions are used throughout the spec.

---

Inspired by #957 which had included clarifications around "leaf" types and fields. This uses definition syntax to formally define the terms so they can be used.

This ended up being a pretty big change, so I'd love a review