### PR TITLE
P30: Fixed the explanatory text for algorithm checking uniqueness of non-repeatable directives

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1488,13 +1488,13 @@ query @skip(if: $foo) {
 
 **Explanatory Text**
 
-Directives are used to describe some metadata or behavioral change on the
-definition they apply to. When more than one directive of the same name is used,
-the expected metadata or behavior becomes ambiguous, therefore only one of each
-directive is allowed per location.
+GraphQL allows directives that are defined as `repeatable` to be used 
+more than once on the definition they apply to, possibly with different arguments. 
+In contrast, if a directive is not `repeatable`, then only one occurence of it 
+is allowed per location. 
 
-For example, the following document will not pass validation because `@skip` has
-been used twice for the same field:
+For example, the following document will not pass validation because non-repeatable
+`@skip` has been used twice for the same field:
 
 ```raw graphql counter-example
 query ($foo: Boolean = true, $bar: Boolean = false) {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1488,13 +1488,13 @@ query @skip(if: $foo) {
 
 **Explanatory Text**
 
-GraphQL allows directives that are defined as `repeatable` to be used 
-more than once on the definition they apply to, possibly with different arguments. 
-In contrast, if a directive is not `repeatable`, then only one occurence of it 
-is allowed per location.
+GraphQL allows directives that are defined as `repeatable` to be used more than
+once on the definition they apply to, possibly with different arguments. In
+contrast, if a directive is not `repeatable`, then only one occurrence of it is
+allowed per location.
 
-For example, the following document will not pass validation because non-repeatable
-`@skip` has been used twice for the same field:
+For example, the following document will not pass validation because
+non-repeatable `@skip` has been used twice for the same field:
 
 ```raw graphql counter-example
 query ($foo: Boolean = true, $bar: Boolean = false) {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1491,7 +1491,7 @@ query @skip(if: $foo) {
 GraphQL allows directives that are defined as `repeatable` to be used 
 more than once on the definition they apply to, possibly with different arguments. 
 In contrast, if a directive is not `repeatable`, then only one occurence of it 
-is allowed per location. 
+is allowed per location.
 
 For example, the following document will not pass validation because non-repeatable
 `@skip` has been used twice for the same field:


### PR DESCRIPTION
The explanatory text for algorithm had not been updated I guess when repeatable option was added for directives. This is a fix