### PR TITLE
Add 'extensions' to request

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -18,10 +18,11 @@ A GraphQL service generates a response from a request via execution.
 - {extensions} (optional): A map reserved for implementers to extend the
   protocol however they see fit.
 
-Note: Since {extensions} is reserved for implementers, the only requirement is
-that, if present, it is a map. There are no additional restrictions on its
-contents. It is recommended that implementers use prefixes in {extensions} keys
-to avoid conflicts with other implementers.
+Note: {extensions} exists to provide implementers with a reserved location to
+include additional information in requests without risking conflicts with future
+versions of this specification. If present, {extensions} must be a map, but
+there are no additional restrictions on its contents. To avoid conflicts, we
+recommended implementers use unique prefixes for keys within {extensions}.
 
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -18,11 +18,12 @@ A GraphQL service generates a response from a request via execution.
 - {extensions} (optional): A map reserved for implementers to extend the
   protocol however they see fit.
 
-Note: {extensions} exists to provide implementers with a reserved location to
-include additional information in requests without risking conflicts with future
-versions of this specification. If present, {extensions} must be a map, but
-there are no additional restrictions on its contents. To avoid conflicts, we
-recommended implementers use unique prefixes for keys within {extensions}.
+Note: Since future versions of the specification may add more information,
+implementers should not add top level keys to requests; instead, {extensions}
+provides implementers a reserved location to include additional information. If
+present, {extensions} must be a map, but there are no additional restrictions on
+its contents. To avoid conflicts, we recommended implementers use unique
+prefixes for keys within {extensions}.
 
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -15,11 +15,13 @@ A GraphQL service generates a response from a request via execution.
   being executed. Conceptually, an initial value represents the "universe" of
   data available via a GraphQL Service. It is common for a GraphQL Service to
   always use the same initial value for every request.
+- {extensions} (optional): A map reserved for implementers to extend the
+  protocol however they see fit.
 
-The request may also contain an `extensions` entry. This entry, if set, must
-have a map as its value. This entry is reserved for implementors to extend the
-protocol however they see fit, and hence there are no additional restrictions on
-its contents.
+Note: Since {extensions} is reserved for implementers, the only requirement is
+that, if present, it is a map. There are no additional restrictions on its
+contents. It is recommended that implementers use prefixes in {extensions} keys
+to avoid conflicts with other implementers.
 
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -19,8 +19,8 @@ A GraphQL service generates a response from a request via execution.
   protocol however they see fit.
 
 Note: Since future versions of the specification may add more information,
-implementers should not add top level keys to requests; instead, {extensions}
-provides implementers a reserved location to include additional information. If
+implementers should not extend requests directly; instead, {extensions} provides
+a reserved location for implementers to include additional information. If
 present, {extensions} must be a map, but there are no additional restrictions on
 its contents. To avoid conflicts, we recommended implementers use unique
 prefixes for keys within {extensions}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -16,6 +16,11 @@ A GraphQL service generates a response from a request via execution.
   data available via a GraphQL Service. It is common for a GraphQL Service to
   always use the same initial value for every request.
 
+The request may also contain an `extensions` entry. This entry, if set, must
+have a map as its value. This entry is reserved for implementors to extend the
+protocol however they see fit, and hence there are no additional restrictions on
+its contents.
+
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be
 formatted according to the Response section below.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -15,19 +15,19 @@ A GraphQL service generates a response from a request via execution.
   being executed. Conceptually, an initial value represents the "universe" of
   data available via a GraphQL Service. It is common for a GraphQL Service to
   always use the same initial value for every request.
-- {extensions} (optional): A map reserved for implementers to extend the
-  protocol however they see fit.
-
-Note: Since future versions of the specification may add more information,
-implementers should not extend requests directly; instead, {extensions} provides
-a reserved location for implementers to include additional information. If
-present, {extensions} must be a map, but there are no additional restrictions on
-its contents. To avoid conflicts, we recommended implementers use unique
-prefixes for keys within {extensions}.
+- {extensions} (optional): A map reserved for implementation-specific additional
+  information.
 
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be
 formatted according to the Response section below.
+
+Implementations should not add additional properties to a _request_, which may
+conflict with future editions of the GraphQL specification. Instead,
+{extensions} provides a reserved location for implementation-specific additional
+information. If present, {extensions} must be a map, but there are no additional
+restrictions on its contents. To avoid conflicts, keys should use unique
+prefixes.
 
 Note: GraphQL requests do not require any specific serialization format or
 transport mechanism. Message serialization and transport mechanisms should be


### PR DESCRIPTION
It's common in the ecosystem to use `extensions` on a GraphQL request to share additional information with the server; for example Apollo Persisted Queries uses it to indicate the hash of the document to execute.

Currently the GraphQL Spec specifies an "extensions" field on Response but not on Request; I'm trying to determine if this is a purely transport-level concern (i.e. should be specified in GraphQL-over-HTTP, etc), or if it should be specified in the spec proper. IMO the spec should have _at least_ a note indicating the use of the "extensions" field.

The specification of the format of a request is somewhat fuzzier than the format of a response; this is not unexpected because GraphQL is so flexible in how it is consumed, and persisted operations/etc should be spec compliant without having to be specified therein. So the request doesn't really speak of _specific keys_, more *here's the information we need to execute*, and "extensions" is not amongst that information. Nonetheless, standardising extensions as a key for expansion would be beneficial to the community.

It's worth noting that GraphQL.js does not include `extensions` amongst the arguments to `graphql()`: https://github.com/graphql/graphql-js/blob/699ec58547c34bfeef866a2a4458615d39b16964/src/graphql.ts#L20-L68 . Nor does express-graphql look at `extensions` on a request as far as I can tell.

