### PR TITLE
Changed 'must NOT BE' to 'must not be'

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -579,7 +579,7 @@ fragment conflictingDifferingResponses on Pet {
   - If {selectionType} is a scalar or enum:
     - The subselection set of that selection must be empty.
   - If {selectionType} is an interface, union, or object:
-    - The subselection set of that selection must NOT BE empty.
+    - The subselection set of that selection must not be empty.
 
 **Explanatory Text**
 


### PR DESCRIPTION
There are 38 occasions of phrase 'must not be' in the spec; this is the only one with such a strange capitalization