### PR TITLE
Provide explicit ref to Value Completion section

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -856,8 +856,7 @@ Produces the ordered result:
 **Result Coercion**
 
 Determining the result of coercing an object is the heart of the GraphQL
-executor, so this is covered in the sub-section 
-[6.4.3 Value Completion](#sec-Value-Completion) in Execution section.
+executor, see [Value Completion](#sec-Value-Completion).
 
 **Input Coercion**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -856,7 +856,8 @@ Produces the ordered result:
 **Result Coercion**
 
 Determining the result of coercing an object is the heart of the GraphQL
-executor, so this is covered in that section of the spec.
+executor, so this is covered in the sub-section 
+[6.4.3 Value Completion](#sec-Value-Completion) in Execution section.
 
 **Input Coercion**
 


### PR DESCRIPTION
the current version mentions executor (what is that by the way?), and then:  
> this is covered in that section 

which section is not clear, we do not have 'executor' section. I suggest some rephrasing, and remove 'executor' - it is not an explained concept in the spec.  