### PR TITLE
added mutation op type to examples 193, 194

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -399,7 +399,7 @@ completion before it continues on to the next item in the grouped field set:
 For example, given the following selection set to be executed serially:
 
 ```graphql example
-{
+mutation {
   changeBirthday(birthday: $newBirthday) {
     month
   }
@@ -421,7 +421,7 @@ As an illustrative example, let's assume we have a mutation field
 we execute the following selection set serially:
 
 ```graphql example
-{
+mutation {
   first: changeTheNumber(newNumber: 1) {
     theNumber
   }


### PR DESCRIPTION
The examples clearly show mutating fields (changeBirthday); since mutating fields are allowed only on top level, we clearly see the 'top' level of mutation request; however, there is no op type 'mutation' before the first opening brace. If op type is missing, it is assumed to be query. 