### PR TITLE
Removed parallel execution requirement for merging fields

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -740,7 +740,7 @@ ResolveAbstractType(abstractType, objectValue):
 
 **Merging Selection Sets**
 
-When multiple fields with the same name or alias are executed, their
+When more than one field of the same response name is executed, their
 selection sets are merged together when completing the value in order to
 continue execution of the sub-selection sets.
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -740,7 +740,7 @@ ResolveAbstractType(abstractType, objectValue):
 
 **Merging Selection Sets**
 
-When more than one field of the same name is executed in parallel, their
+When multiple fields with the same name or alias are executed, their
 selection sets are merged together when completing the value in order to
 continue execution of the sub-selection sets.
 


### PR DESCRIPTION
The main point here is to remove 'when executed in PARALLEL'; service is free to execute the request 'normally' - in any order it wants, parallel or not. But I think the field merge process should always apply. 

As for the final text - suggestions are welcome  