### PR TITLE
Change example for directive order to use Query or Mutation, not type system

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1287,9 +1287,13 @@ any additional _custom directive_ beyond those described here.
 Directives may be provided in a specific syntactic order which may have semantic
 interpretation.
 
-These two type definitions may have different semantic meaning:
+These two queries may have different semantic meaning:
 
 ```graphql example
+
+# Need example for query or mutation with dirs like @skip or @include
+# not type system language 
+ 
 type Person
   @addExternalFields(source: "profiles")
   @excludeField(name: "photo") {


### PR DESCRIPTION
[Directives Order Is Significant](https://spec.graphql.org/draft/#sec-Language.Directives.Directive-order-is-significant) sub-section is in section "2. Language", which talks about Query language. The directive order example surprisingly uses a type definition, while type system and its SDL had not been introduced yet, they are coming in chapter 3. 

Suggest to change it to Query or Mutation example with multiple directives. I could not come up with decent example, just put a comment there, suggestions are welcome. 

Note: even if we change chapters order (SDL first, Query language after), it is still better to have an example matching the area that is chapter's focus

