### PR TITLE
Possible reference mistake in subscription execution

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -294,7 +294,7 @@ MapSourceToResponseEvent(sourceStream, subscription, schema, variableValues):
   - Let {response} be the result of running
     {ExecuteSubscriptionEvent(subscription, schema, variableValues, event)}.
   - Yield an event containing {response}.
-- When {responseStream} completes: complete this event stream.
+- When {sourceStream} completes: complete {responseStream}.
 
 ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 


### PR DESCRIPTION
I'm a bit confused about MapSourceToResponseEvent in the execution specification for subscriptions. It explains how to map a `sourceStream` to a `responseStream`. Instead of specifying the behavior in case `sourceStream` completes, it talks about what happens when `responseStream` completes, even though there is no way how `responseStream` could complete on its own.

Am I right that the specification part just confused `sourceStream` and `responseStream` here?

Also, why is the operation called `MapSourceToResponseEvent` when it maps *event streams*? Shouldn't it be called `MapSourceStreamToResponseEventStream`?