### PR TITLE
Add table how to decode JSON values for deserialization

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -289,6 +289,20 @@ values should be used to encode the related GraphQL values:
 | Float         | Number            |
 | Enum Value    | String            |
 
+In the same way the following GraphQL values should be used to decode JSON
+variables when a GraphQL request is deserialized:
+
+| JSON Value        | GraphQL Value        |
+| ----------------- | -------------------- |
+| Object            | Input Object         |
+| Array             | List                 |
+| {null}            | Null                 |
+| String            | String or Enum Value |
+| {true} or {false} | Boolean              |
+| Number            | Int or Float         |
+
+Additionally, any JSON value can be an accepted value for a custom Scalar.
+
 Note: For consistency and ease of notation, examples of responses are given in
 JSON format throughout this document.
 


### PR DESCRIPTION
This is small addition to the JSON serialization section with the goal to clarify how JSON values should be decoded into GraphQL values for variable values.

I believe we have not yet really specified how JSON should be decoded for request, we only talk about response encoding. This aim to simply document the reality of what we do today, not to introduce anything new or modify any existing behaviour. 

Especially for the custom scalars work at https://github.com/graphql/graphql-scalars it is important that the spec also talks about JSON deseralization, not only serialization. 

cc @leebyron @dondonz @benjie 