### PR TITLE
Clarify that selection sets cannot be empty

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1796,8 +1796,9 @@ to denote a field that uses a Non-Null type like this: `name: String!`.
 **Nullable vs. Optional**
 
 Fields are _always_ optional within the context of a selection set, a field may
-be omitted and the selection set is still valid. However fields that return
-Non-Null types will never return the value {null} if queried.
+be omitted and the selection set is still valid (so long as the selection set
+does not become empty). However fields that return Non-Null types will never
+return the value {null} if queried.
 
 Inputs (such as field arguments), are always optional by default. However a
 non-null input type is required. In addition to not accepting the value {null},


### PR DESCRIPTION
This paragraph is trying to make clear that if you have a type like `type Foo { foo: Int!, bar: Int!, baz: Int! }` that the selection set `{ foo bar }` is valid for it - you do not have to select `baz` even if it's non-nullable, since non-nullable does _not_ mean "required" for output fields.

However, it does read ambiguously, implying that you may remove any field from any selection set and the selection set will still be valid. If you remove the field `foo` from the selection set `{ foo }` then that selection set (`{  }`) is no longer valid, since it is empty.

I've added a clarifying parenthesis to the text.

Fixes #1024

@graphql/tsc Can I get a couple checkmarks please? 😉 