### PR TITLE
RFC: incremental delivery with deduplication + concurrent execution

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -11,7 +11,6 @@ words:
   - openwebfoundation
   - parallelization
   - structs
-  - sublist
   - subselection
   # Fictional characters / examples
   - alderaan

--- a/cspell.yml
+++ b/cspell.yml
@@ -12,6 +12,7 @@ words:
   - parallelization
   - structs
   - subselection
+  - errored
   # Fictional characters / examples
   - alderaan
   - hagrid

--- a/cspell.yml
+++ b/cspell.yml
@@ -4,12 +4,14 @@ ignoreRegExpList:
   - /[a-z]{2,}'s/
 words:
   # Terms of art
+  - deprioritization
   - endianness
   - interoperation
   - monospace
   - openwebfoundation
   - parallelization
   - structs
+  - sublist
   - subselection
   # Fictional characters / examples
   - alderaan

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2163,8 +2163,8 @@ fragment someFragment on User {
   omitted.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding defer directive. If
-  provided, the GraphQL Server must add it to the corresponding payload. `label`
-  must be unique label across all `@defer` and `@stream` directives in a
+  provided, the GraphQL service must add it to the corresponding payload.
+  `label` must be unique label across all `@defer` and `@stream` directives in a
   document. `label` must not be provided as a variable.
 
 ### @stream
@@ -2200,19 +2200,19 @@ query myQuery($shouldStream: Boolean) {
   when omitted.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding stream directive. If
-  provided, the GraphQL Server must add it to the corresponding payload. `label`
-  must be unique label across all `@defer` and `@stream` directives in a
+  provided, the GraphQL service must add it to the corresponding payload.
+  `label` must be unique label across all `@defer` and `@stream` directives in a
   document. `label` must not be provided as a variable.
-- `initialCount: Int` - The number of list items the server should return as
+- `initialCount: Int` - The number of list items the service should return as
   part of the initial response. If omitted, defaults to `0`. A field error will
   be raised if the value of this argument is less than `0`.
 
 Note: The ability to defer and/or stream parts of a response can have a
 potentially significant impact on application performance. Developers generally
 need clear, predictable control over their application's performance. It is
-highly recommended that GraphQL servers honor the `@defer` and `@stream`
+highly recommended that GraphQL services honor the `@defer` and `@stream`
 directives on each execution. However, the specification allows advanced use
-cases where the server can determine that it is more performant to not defer
+cases where the service can determine that it is more performant to not defer
 and/or stream. Therefore, GraphQL clients _must_ be able to process a response
 that ignores the `@defer` and/or `@stream` directives. This also applies to the
 `initialCount` argument on the `@stream` directive. Clients _must_ be able to

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2157,9 +2157,10 @@ fragment someFragment on User {
 
 #### @defer Arguments
 
-- `if: Boolean! = true` - When `true`, fragment _should_ be deferred. When
-  `false`, fragment will not be deferred and data will be included in the
-  initial response. Defaults to `true` when omitted.
+- `if: Boolean! = true` - When `true`, fragment _should_ be deferred (See
+  [related note](#note-088b7)). When `false`, fragment will not be deferred and
+  data will be included in the initial response. Defaults to `true` when
+  omitted.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding defer directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`
@@ -2193,9 +2194,10 @@ query myQuery($shouldStream: Boolean) {
 
 #### @stream Arguments
 
-- `if: Boolean! = true` - When `true`, field _should_ be streamed. When `false`,
-  the field will not be streamed and all list items will be included in the
-  initial response. Defaults to `true` when omitted.
+- `if: Boolean! = true` - When `true`, field _should_ be streamed (See
+  [related note](#note-088b7)). When `false`, the field will not be streamed and
+  all list items will be included in the initial response. Defaults to `true`
+  when omitted.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding stream directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2159,7 +2159,7 @@ fragment someFragment on User {
 
 - `if: Boolean! = true` - When `true`, fragment _should_ be deferred. When
   `false`, fragment will not be deferred and data will be included in the
-  initial response. If omitted, defaults to `true`.
+  initial response. Defaults to `true` when omitted or null.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding defer directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`
@@ -2195,7 +2195,7 @@ query myQuery($shouldStream: Boolean) {
 
 - `if: Boolean! = true` - When `true`, field _should_ be streamed. When `false`,
   the field will not be streamed and all list items will be included in the
-  initial response. If omitted, defaults to `true`.
+  initial response. Defaults to `true` when omitted or null.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding stream directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2128,7 +2128,7 @@ scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 ```graphql
 directive @defer(
   label: String
-  if: Boolean
+  if: Boolean! = true
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 ```
 
@@ -2157,9 +2157,9 @@ fragment someFragment on User {
 
 #### @defer Arguments
 
-- `if: Boolean` - When `true`, fragment _should_ be deferred. When `false`,
-  fragment will not be deferred and data will be included in the initial
-  response. If omitted, defaults to `true`.
+- `if: Boolean! = true` - When `true`, fragment _should_ be deferred. When
+  `false`, fragment will not be deferred and data will be included in the
+  initial response. If omitted, defaults to `true`.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding defer directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`
@@ -2169,7 +2169,11 @@ fragment someFragment on User {
 ### @stream
 
 ```graphql
-directive @stream(label: String, initialCount: Int = 0, if: Boolean) on FIELD
+directive @stream(
+  label: String
+  if: Boolean! = true
+  initialCount: Int = 0
+) on FIELD
 ```
 
 The `@stream` directive may be provided for a field of `List` type so that the
@@ -2189,15 +2193,14 @@ query myQuery($shouldStream: Boolean) {
 
 #### @stream Arguments
 
-- `if: Boolean` - When `true`, field _should_ be streamed. When `false`, the
-  field will not be streamed and all list items will be included in the initial
-  response. If omitted, defaults to `true`.
+- `if: Boolean! = true` - When `true`, field _should_ be streamed. When `false`,
+  the field will not be streamed and all list items will be included in the
+  initial response. If omitted, defaults to `true`.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding stream directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`
   must be unique label across all `@defer` and `@stream` directives in a
   document. `label` must not be provided as a variable.
-
 - `initialCount: Int` - The number of list items the server should return as
   part of the initial response. If omitted, defaults to `0`. A field error will
   be raised if the value of this argument is less than `0`.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2160,10 +2160,11 @@ fragment someFragment on User {
 - `if: Boolean` - When `true`, fragment _should_ be deferred. When `false`,
   fragment will not be deferred and data will be included in the initial
   response. If omitted, defaults to `true`.
-- `label: String` - A unique label across all `@defer` and `@stream` directives
-  in an operation. This label should be used by GraphQL clients to identify the
-  data from patch responses and associate it with the correct fragments. If
-  provided, the GraphQL Server must add it to the payload.
+- `label: String` - May be used by GraphQL clients to identify the data from
+  responses and associate it with the corresponding defer directive. If
+  provided, the GraphQL Server must add it to the corresponding payload. `label`
+  must be unique label across all `@defer` and `@stream` directives in a
+  document. `label` must not be provided as a variable.
 
 ### @stream
 
@@ -2191,10 +2192,12 @@ query myQuery($shouldStream: Boolean) {
 - `if: Boolean` - When `true`, field _should_ be streamed. When `false`, the
   field will not be streamed and all list items will be included in the initial
   response. If omitted, defaults to `true`.
-- `label: String` - A unique label across all `@defer` and `@stream` directives
-  in an operation. This label should be used by GraphQL clients to identify the
-  data from patch responses and associate it with the correct fragments. If
-  provided, the GraphQL Server must add it to the payload.
+- `label: String` - May be used by GraphQL clients to identify the data from
+  responses and associate it with the corresponding stream directive. If
+  provided, the GraphQL Server must add it to the corresponding payload. `label`
+  must be unique label across all `@defer` and `@stream` directives in a
+  document. `label` must not be provided as a variable.
+
 - `initialCount: Int` - The number of list items the server should return as
   part of the initial response. If omitted, defaults to `0`. A field error will
   be raised if the value of this argument is less than `0`.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -758,8 +758,9 @@ And will yield the subset of each object type queried:
 When querying an Object, the resulting mapping of fields are conceptually
 ordered in the same order in which they were encountered during execution,
 excluding fragments for which the type does not apply and fields or fragments
-that are skipped via `@skip` or `@include` directives. This ordering is
-correctly produced when using the {CollectFields()} algorithm.
+that are skipped via `@skip` or `@include` directives or temporarily skipped via
+`@defer`. This ordering is correctly produced when using the {CollectFields()}
+algorithm.
 
 Response serialization formats capable of representing ordered maps should
 maintain this ordering. Serialization formats which can only represent unordered
@@ -1901,6 +1902,11 @@ by a validator, executor, or client tool such as a code generator.
 
 GraphQL implementations should provide the `@skip` and `@include` directives.
 
+GraphQL implementations are not required to implement the `@defer` and `@stream`
+directives. If they are implemented, they must be implemented according to this
+specification. GraphQL implementations that do not support these directives must
+not make them available via introspection.
+
 GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of the
 schema.
@@ -2115,4 +2121,57 @@ to the relevant IETF specification.
 
 ```graphql example
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
+```
+
+### @defer
+
+```graphql
+directive @defer(
+  label: String
+  if: Boolean
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+```
+
+The `@defer` directive may be provided for fragment spreads and inline fragments
+to inform the executor to delay the execution of the current fragment to
+indicate deprioritization of the current fragment. A query with `@defer`
+directive will cause the request to potentially return multiple responses, where
+non-deferred data is delivered in the initial response and data deferred is
+delivered in a subsequent response. `@include` and `@skip` take precedence over
+`@defer`.
+
+```graphql example
+query myQuery($shouldDefer: Boolean) {
+   user {
+     name
+     ...someFragment @defer(label: 'someLabel', if: $shouldDefer)
+   }
+}
+fragment someFragment on User {
+  id
+  profile_picture {
+    uri
+  }
+}
+```
+
+### @stream
+
+```graphql
+directive @stream(label: String, initialCount: Int = 0, if: Boolean) on FIELD
+```
+
+The `@stream` directive may be provided for a field of `List` type so that the
+backend can leverage technology such as asynchronous iterators to provide a
+partial list in the initial response, and additional list items in subsequent
+responses. `@include` and `@skip` take precedence over `@stream`.
+
+```graphql example
+query myQuery($shouldStream: Boolean) {
+  user {
+    friends(first: 10) {
+      nodes @stream(label: "friendsStream", initialCount: 5, if: $shouldStream)
+    }
+  }
+}
 ```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2155,6 +2155,15 @@ fragment someFragment on User {
 }
 ```
 
+#### @defer Arguments
+
+- `if: Boolean` - When true, fragment may be deferred. If omitted, defaults to
+  `true`.
+- `label: String` - A unique label across all `@defer` and `@stream` directives
+  in an operation. This label should be used by GraphQL clients to identify the
+  data from patch responses and associate it with the correct fragments. If
+  provided, the GraphQL Server must add it to the payload.
+
 ### @stream
 
 ```graphql
@@ -2175,3 +2184,14 @@ query myQuery($shouldStream: Boolean) {
   }
 }
 ```
+
+#### @stream Arguments
+
+- `if: Boolean` - When true, field may be streamed. If omitted, defaults to
+  `true`.
+- `label: String` - A unique label across all `@defer` and `@stream` directives
+  in an operation. This label should be used by GraphQL clients to identify the
+  data from patch responses and associate it with the correct fragments. If
+  provided, the GraphQL Server must add it to the payload.
+- `initialCount: Int` - The number of list items the server should return as
+  part of the initial response. If omitted, defaults to `0`.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2159,7 +2159,7 @@ fragment someFragment on User {
 
 - `if: Boolean! = true` - When `true`, fragment _should_ be deferred. When
   `false`, fragment will not be deferred and data will be included in the
-  initial response. Defaults to `true` when omitted or null.
+  initial response. Defaults to `true` when omitted.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding defer directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`
@@ -2195,7 +2195,7 @@ query myQuery($shouldStream: Boolean) {
 
 - `if: Boolean! = true` - When `true`, field _should_ be streamed. When `false`,
   the field will not be streamed and all list items will be included in the
-  initial response. Defaults to `true` when omitted or null.
+  initial response. Defaults to `true` when omitted.
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding stream directive. If
   provided, the GraphQL Server must add it to the corresponding payload. `label`

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2209,8 +2209,8 @@ Note: The ability to defer and/or stream parts of a response can have a
 potentially significant impact on application performance. Developers generally
 need clear, predictable control over their application's performance. It is
 highly recommended that GraphQL servers honor the `@defer` and `@stream`
-directives on each execution. However, the specification allows advanced
-use-cases where the server can determine that it is more performant to not defer
+directives on each execution. However, the specification allows advanced use
+cases where the server can determine that it is more performant to not defer
 and/or stream. Therefore, GraphQL clients _must_ be able to process a response
 that ignores the `@defer` and/or `@stream` directives. This also applies to the
 `initialCount` argument on the `@stream` directive. Clients _must_ be able to

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2142,10 +2142,10 @@ delivered in a subsequent response. `@include` and `@skip` take precedence over
 
 ```graphql example
 query myQuery($shouldDefer: Boolean) {
-   user {
-     name
-     ...someFragment @defer(label: 'someLabel', if: $shouldDefer)
-   }
+  user {
+    name
+    ...someFragment @defer(label: "someLabel", if: $shouldDefer)
+  }
 }
 fragment someFragment on User {
   id

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2196,8 +2196,8 @@ query myQuery($shouldStream: Boolean) {
   data from patch responses and associate it with the correct fragments. If
   provided, the GraphQL Server must add it to the payload.
 - `initialCount: Int` - The number of list items the server should return as
-  part of the initial response. If omitted, defaults to `0`. If the value of
-  this argument is less than `0`, it is treated the same as `0`.
+  part of the initial response. If omitted, defaults to `0`. A field error will
+  be raised if the value of this argument is less than `0`.
 
 Note: The ability to defer and/or stream parts of a response can have a
 potentially significant impact on application performance. Developers generally

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2157,8 +2157,9 @@ fragment someFragment on User {
 
 #### @defer Arguments
 
-- `if: Boolean` - When true, fragment may be deferred. If omitted, defaults to
-  `true`.
+- `if: Boolean` - When `true`, fragment may be deferred. When `false`, fragment
+  will not be deferred and data will be included in the initial response. If
+  omitted, defaults to `true`.
 - `label: String` - A unique label across all `@defer` and `@stream` directives
   in an operation. This label should be used by GraphQL clients to identify the
   data from patch responses and associate it with the correct fragments. If
@@ -2187,8 +2188,9 @@ query myQuery($shouldStream: Boolean) {
 
 #### @stream Arguments
 
-- `if: Boolean` - When true, field may be streamed. If omitted, defaults to
-  `true`.
+- `if: Boolean` - When `true`, field may be streamed. When `false`, the field
+  will not be streamed and all list items will be included in the initial
+  response. If omitted, defaults to `true`.
 - `label: String` - A unique label across all `@defer` and `@stream` directives
   in an operation. This label should be used by GraphQL clients to identify the
   data from patch responses and associate it with the correct fragments. If

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2196,7 +2196,8 @@ query myQuery($shouldStream: Boolean) {
   data from patch responses and associate it with the correct fragments. If
   provided, the GraphQL Server must add it to the payload.
 - `initialCount: Int` - The number of list items the server should return as
-  part of the initial response. If omitted, defaults to `0`.
+  part of the initial response. If omitted, defaults to `0`. If the value of
+  this argument is less than `0`, it is treated the same as `0`.
 
 Note: The ability to defer and/or stream parts of a response can have a
 potentially significant impact on application performance. Developers generally

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2157,9 +2157,9 @@ fragment someFragment on User {
 
 #### @defer Arguments
 
-- `if: Boolean` - When `true`, fragment may be deferred. When `false`, fragment
-  will not be deferred and data will be included in the initial response. If
-  omitted, defaults to `true`.
+- `if: Boolean` - When `true`, fragment _should_ be deferred. When `false`,
+  fragment will not be deferred and data will be included in the initial
+  response. If omitted, defaults to `true`.
 - `label: String` - A unique label across all `@defer` and `@stream` directives
   in an operation. This label should be used by GraphQL clients to identify the
   data from patch responses and associate it with the correct fragments. If
@@ -2188,8 +2188,8 @@ query myQuery($shouldStream: Boolean) {
 
 #### @stream Arguments
 
-- `if: Boolean` - When `true`, field may be streamed. When `false`, the field
-  will not be streamed and all list items will be included in the initial
+- `if: Boolean` - When `true`, field _should_ be streamed. When `false`, the
+  field will not be streamed and all list items will be included in the initial
   response. If omitted, defaults to `true`.
 - `label: String` - A unique label across all `@defer` and `@stream` directives
   in an operation. This label should be used by GraphQL clients to identify the
@@ -2197,3 +2197,15 @@ query myQuery($shouldStream: Boolean) {
   provided, the GraphQL Server must add it to the payload.
 - `initialCount: Int` - The number of list items the server should return as
   part of the initial response. If omitted, defaults to `0`.
+
+Note: The ability to defer and/or stream parts of a response can have a
+potentially significant impact on application performance. Developers generally
+need clear, predictable control over their application's performance. It is
+highly recommended that GraphQL servers honor the `@defer` and `@stream`
+directives on each execution. However, the specification allows advanced
+use-cases where the server can determine that it is more performant to not defer
+and/or stream. Therefore, GraphQL clients _must_ be able to process a response
+that ignores the `@defer` and/or `@stream` directives. This also applies to the
+`initialCount` argument on the `@stream` directive. Clients _must_ be able to
+process a streamed response that contains a different number of initial list
+items than what was specified in the `initialCount` argument.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1903,9 +1903,9 @@ by a validator, executor, or client tool such as a code generator.
 GraphQL implementations should provide the `@skip` and `@include` directives.
 
 GraphQL implementations are not required to implement the `@defer` and `@stream`
-directives. If they are implemented, they must be implemented according to this
-specification. GraphQL implementations that do not support these directives must
-not make them available via introspection.
+directives. If either or both of these directives are implemented, they must be
+implemented according to this specification. GraphQL implementations that do not
+support these directives must not make them available via introspection.
 
 GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of the

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1528,6 +1528,34 @@ query ($foo: Boolean = true, $bar: Boolean = false) {
 }
 ```
 
+### Defer And Stream Directives Are Used On Valid Root Field
+
+** Formal Specification **
+
+- For every {directive} in a document.
+- Let {directiveName} be the name of {directive}.
+- Let {mutationType} be the root Mutation type in {schema}.
+- Let {subscriptionType} be the root Subscription type in {schema}.
+- If {directiveName} is "defer" or "stream":
+  - The parent type of {directive} must not be {mutationType} or
+    {subscriptionType}.
+
+**Explanatory Text**
+
+The defer and stream directives are not allowed to be used on root fields of the
+mutation or subscription type.
+
+For example, the following document will not pass validation because `@defer`
+has been used on a root mutation field:
+
+```raw graphql counter-example
+mutation {
+  ... @defer {
+    mutationField
+  }
+}
+```
+
 ### Stream Directives Are Used On List Fields
 
 **Formal Specification**

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -474,7 +474,7 @@ unambiguous. Therefore any two field selections which might both be encountered
 for the same object are only valid if they are equivalent.
 
 During execution, the simultaneous execution of fields with the same response
-name is accomplished by {MergeSelectionSets()} and {CollectFields()}.
+name is accomplished by {CollectFields()}.
 
 For simple hand-written GraphQL, this rule is obviously a clear developer error,
 however nested fragments can make this difficult to detect manually.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1556,6 +1556,55 @@ mutation {
 }
 ```
 
+### Defer And Stream Directives Are Used On Valid Operations
+
+** Formal Specification **
+
+- Let {subscriptionFragments} be the empty set.
+- For each {operation} in a document:
+  - If {operation} is a subscription operation:
+    - Let {fragments} be every fragment referenced by that {operation}
+      transitively.
+    - For each {fragment} in {fragments}:
+      - Let {fragmentName} be the name of {fragment}.
+      - Add {fragmentName} to {subscriptionFragments}.
+- For every {directive} in a document:
+  - If {directiveName} is not "defer" or "stream":
+    - Continue to the next {directive}.
+  - Let {ancestor} be the ancestor operation or fragment definition of
+    {directive}.
+  - If {ancestor} is a fragment definition:
+    - If the fragment name of {ancestor} is not present in
+      {subscriptionFragments}:
+      - Continue to the next {directive}.
+  - If {ancestor} is not a subscription operation:
+    - Continue to the next {directive}.
+  - Let {if} be the argument named "if" on {directive}.
+  - {if} must be defined.
+  - Let {argumentValue} be the value passed to {if}.
+  - {argumentValue} must be a variable, or the boolean value "false".
+
+**Explanatory Text**
+
+The defer and stream directives can not be used to defer or stream data in
+subscription operations. If these directives appear in a subscription operation
+they must be disabled using the "if" argument. This rule will not permit any
+defer or stream directives on a subscription operation that cannot be disabled
+using the "if" argument.
+
+For example, the following document will not pass validation because `@defer`
+has been used in a subscription operation with no "if" argument defined:
+
+```raw graphql counter-example
+subscription sub {
+  newMessage {
+    ... @defer {
+      body
+    }
+  }
+}
+```
+
 ### Defer And Stream Directive Labels Are Unique
 
 ** Formal Specification **

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1556,6 +1556,71 @@ mutation {
 }
 ```
 
+### Defer And Stream Directive Labels Are Unique
+
+** Formal Specification **
+
+- For every {directive} in a document.
+- Let {directiveName} be the name of {directive}.
+- If {directiveName} is "defer" or "stream":
+  - For every {argument} in {directive}:
+    - Let {argumentName} be the name of {argument}.
+    - Let {argumentValue} be the value passed to {argument}.
+    - If {argumentName} is "label":
+      - {argumentValue} must not be a variable.
+    - Let {labels} be all label values passed to defer or stream directive label
+      arguments.
+    - {labels} must be a set of one.
+
+**Explanatory Text**
+
+The `@defer` and `@stream` directives each accept an argument "label". This
+label may be used by GraphQL clients to uniquely identify response payloads. If
+a label is passed, it must not be a variable and it must be unique within all
+other `@defer` and `@stream` directives in the document.
+
+For example the following document is valid:
+
+```graphql example
+{
+  dog {
+    ...fragmentOne
+    ...fragmentTwo @defer(label: "dogDefer")
+  }
+  pets @stream(label: "petStream") {
+    name
+  }
+}
+
+fragment fragmentOne on Dog {
+  name
+}
+
+fragment fragmentTwo on Dog {
+  owner {
+    name
+  }
+}
+```
+
+For example, the following document will not pass validation because the same
+label is used in different `@defer` and `@stream` directives.:
+
+```raw graphql counter-example
+{
+  dog {
+    ...fragmentOne @defer(label: "MyLabel")
+  }
+  pets @stream(label: "MyLabel") {
+    name
+  }
+}
+
+fragment fragmentOne on Dog {
+  name
+}
+```
+
 ### Stream Directives Are Used On List Fields
 
 **Formal Specification**

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -422,6 +422,7 @@ FieldsInSetCanMerge(set):
   {set} including visiting fragments and inline fragments.
 - Given each pair of members {fieldA} and {fieldB} in {fieldsForName}:
   - {SameResponseShape(fieldA, fieldB)} must be true.
+  - {SameStreamDirective(fieldA, fieldB)} must be true.
   - If the parent types of {fieldA} and {fieldB} are equal or if either is not
     an Object Type:
     - {fieldA} and {fieldB} must have identical field names.
@@ -454,6 +455,16 @@ SameResponseShape(fieldA, fieldB):
 - Given each pair of members {subfieldA} and {subfieldB} in {fieldsForName}:
   - If {SameResponseShape(subfieldA, subfieldB)} is false, return false.
 - Return true.
+
+SameStreamDirective(fieldA, fieldB):
+
+- If neither {fieldA} nor {fieldB} has a directive named `stream`.
+  - Return true.
+- If both {fieldA} and {fieldB} have a directive named `stream`.
+  - Let {streamA} be the directive named `stream` on {fieldA}.
+  - Let {streamB} be the directive named `stream` on {fieldB}.
+  - If {streamA} and {streamB} have identical sets of arguments, return true.
+- Return false.
 
 **Explanatory Text**
 
@@ -1514,6 +1525,32 @@ query ($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $bar) {
     subfieldB
   }
+}
+```
+
+### Stream Directives Are Used On List Fields
+
+**Formal Specification**
+
+- For every {directive} in a document.
+- Let {directiveName} be the name of {directive}.
+- If {directiveName} is "stream":
+  - Let {adjacent} be the AST node the directive affects.
+  - {adjacent} must be a List type.
+
+**Explanatory Text**
+
+GraphQL directive locations do not provide enough granularity to distinguish the
+type of fields used in a GraphQL document. Since the stream directive is only
+valid on list fields, an additional validation rule must be used to ensure it is
+used correctly.
+
+For example, the following document will only pass validation if `field` is
+defined as a List type in the associated schema.
+
+```graphql counter-example
+query {
+  field @stream(initialCount: 0)
 }
 ```
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1560,17 +1560,17 @@ mutation {
 
 ** Formal Specification **
 
-- For every {directive} in a document.
-- Let {directiveName} be the name of {directive}.
-- If {directiveName} is "defer" or "stream":
-  - For every {argument} in {directive}:
-    - Let {argumentName} be the name of {argument}.
-    - Let {argumentValue} be the value passed to {argument}.
-    - If {argumentName} is "label":
-      - {argumentValue} must not be a variable.
-    - Let {labels} be all label values passed to defer or stream directive label
-      arguments.
-    - {labels} must be a set of one.
+- Let {labelValues} be an empty set.
+- For every {directive} in the document:
+  - Let {directiveName} be the name of {directive}.
+  - If {directiveName} is "defer" or "stream":
+    - For every {argument} in {directive}:
+      - Let {argumentName} be the name of {argument}.
+      - Let {argumentValue} be the value passed to {argument}.
+      - If {argumentName} is "label":
+        - {argumentValue} must not be a variable.
+        - {argumentValue} must not be present in {labelValues}.
+        - Append {argumentValue} to {labelValues}.
 
 **Explanatory Text**
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -429,8 +429,7 @@ subsequentPayloads, asyncRecord):
 - If {path} is not provided, initialize it to an empty list.
 - If {subsequentPayloads} is not provided, initialize it to the empty set.
 - Let {groupedFieldSet} and {deferredGroupedFieldsList} be the result of
-  {CollectFields(objectType, objectValue, selectionSet, variableValues, path,
-  asyncRecord)}.
+  {CollectFields(objectType, selectionSet, variableValues, path, asyncRecord)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -662,8 +661,8 @@ The depth-first-search order of the field groups produced by {CollectFields()}
 is maintained through execution, ensuring that fields appear in the executed
 response in a stable and predictable order.
 
-CollectFields(objectType, objectValue, selectionSet, variableValues, path,
-asyncRecord, visitedFragments, deferredGroupedFieldsList):
+CollectFields(objectType, selectionSet, variableValues, path, asyncRecord,
+visitedFragments, deferredGroupedFieldsList):
 
 - If {visitedFragments} is not provided, initialize it to the empty set.
 - Initialize {groupedFields} to an empty ordered map of lists.
@@ -708,16 +707,14 @@ asyncRecord, visitedFragments, deferredGroupedFieldsList):
       - Let {label} be the value or the variable to {deferDirective}'s {label}
         argument.
       - Let {deferredGroupedFields} be the result of calling
-        {CollectFields(objectType, objectValue, fragmentSelectionSet,
-        variableValues, path, asyncRecord, visitedFragments,
-        deferredGroupedFieldsList)}.
+        {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
+        asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
       - Append a record containing {label} and {deferredGroupedFields} to
         {deferredGroupedFieldsList}.
       - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, objectValue, fragmentSelectionSet,
-      variableValues, path, asyncRecord, visitedFragments,
-      deferredGroupedFieldsList)}.
+      {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
+      asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
@@ -738,16 +735,14 @@ asyncRecord, visitedFragments, deferredGroupedFieldsList):
       - Let {label} be the value or the variable to {deferDirective}'s {label}
         argument.
       - Let {deferredGroupedFields} be the result of calling
-        {CollectFields(objectType, objectValue, fragmentSelectionSet,
-        variableValues, path, asyncRecord, visitedFragments,
-        deferredGroupedFieldsList)}.
+        {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
+        asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
       - Append a record containing {label} and {deferredGroupedFields} to
         {deferredGroupedFieldsList}.
       - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, objectValue, fragmentSelectionSet,
-      variableValues, path, asyncRecord, visitedFragments,
-      deferredGroupedFieldsList)}.
+      {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
+      asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
@@ -965,8 +960,8 @@ directive.
 
 #### Execute Stream Field
 
-ExecuteStreamField(label, iterator, index, fields, innerType, path streamRecord,
-variableValues, subsequentPayloads):
+ExecuteStreamField(label, iterator, index, fields, innerType, path,
+streamRecord, variableValues, subsequentPayloads):
 
 - Let {streamRecord} be an async payload record created from {label}, {path},
   and {iterator}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -30,6 +30,7 @@ request is determined by the result of executing this operation according to the
 "Executing Operations” section below.
 
 ExecuteRequest(schema, document, operationName, variableValues, initialValue):
+
 Note: the execution assumes implementing language supports coroutines.
 Alternatively, the socket can provide a write buffer pointer to allow
 {ExecuteRequest()} to directly write payloads into the buffer.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -605,9 +605,10 @@ subsequentPayloads, asyncRecord, visitedFragments):
       argument is {true} or is a variable in {variableValues} with the value
       {true}:
       - Let {deferDirective} be that directive.
-    - If {fragmentSpreadName} is in {visitedFragments} and {deferDirective} is
-      not defined, continue with the next {selection} in {selectionSet}.
-    - Add {fragmentSpreadName} to {visitedFragments}.
+    - If {deferDirective} is not defined:
+      - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
+        {selection} in {selectionSet}.
+      - Add {fragmentSpreadName} to {visitedFragments}.
     - Let {fragment} be the Fragment in the current Document whose name is
       {fragmentSpreadName}.
     - If no such {fragment} exists, continue with the next {selection} in

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -801,7 +801,8 @@ variableValues, parentRecord, subsequentPayloads):
     - Add an entry to {payload} named `data` with the value {null}.
   - Otherwise:
     - Add an entry to {payload} named `data` with the value {resultMap}.
-  - Add an entry to {payload} named `label` with the value {label}.
+  - If {label} is defined:
+    - Add an entry to {payload} named `label` with the value {label}.
   - Add an entry to {payload} named `path` with the value {path}.
   - Return {payload}.
 - Set {dataExecution} on {deferredFragmentRecord}.
@@ -961,7 +962,8 @@ streamRecord, variableValues, subsequentPayloads):
         {data}.
   - If {errors} is not empty:
     - Add an entry to {payload} named `errors` with the value {errors}.
-  - Add an entry to {payload} named `label` with the value {label}.
+  - If {label} is defined:
+    - Add an entry to {payload} named `label` with the value {label}.
   - Add an entry to {payload} named `path` with the value {itemPath}.
   - If {parentRecord} is defined:
     - Wait for the result of {dataExecution} on {parentRecord}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -554,6 +554,11 @@ A correct executor must generate the following result for that selection set:
 }
 ```
 
+When subsections contain a `@stream` or `@defer` directive, these subsections
+are no longer required to execute serially. Exeuction of the deferred or
+streamed sections of the subsection may be executed in parallel, as defined in
+{ExecuteStreamField} and {ExecuteDeferredFragment}.
+
 ### Field Collection
 
 Before execution, the selection set is converted to a grouped field set by

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -921,6 +921,7 @@ parentPath):
     - Let {streamDirective} be the `@stream` directive provided on {field}.
     - Let {initialCount} be the value or variable provided to
       {streamDirective}'s {initialCount} argument.
+    - If {initialCount} is less than zero, raise a _field error_.
     - Let {label} be the value or variable provided to {streamDirective}'s
       {label} argument.
     - Let {resolvedItems} be an empty list

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -388,26 +388,30 @@ YieldSubsequentPayloads(initialResponse, subsequentPayloads):
     {incremental}.
 - Yield {initialResponse}.
 - While {subsequentPayloads} is not empty:
-- If a termination signal is received:
-  - For each {record} in {subsequentPayloads}:
-    - If {record} contains {iterator}:
-      - Send a termination signal to {iterator}.
-  - Return.
-- Wait for at least one record in {subsequentPayloads} to have a completed
-  {dataExecution}.
-- Let {subsequentResponse} be an unordered map with an entry {incremental}
-  initialized to an empty list.
-- Let {records} be the items in {subsequentPayloads} with a completed
-  {dataExecution}.
+  - If a termination signal is received:
+    - For each {record} in {subsequentPayloads}:
+      - If {record} contains {iterator}:
+        - Send a termination signal to {iterator}.
+    - Return.
+  - Wait for at least one record in {subsequentPayloads} to have a completed
+    {dataExecution}.
+  - Let {subsequentResponse} be an unordered map with an entry {incremental}
+    initialized to an empty list.
+  - Let {records} be the items in {subsequentPayloads} with a completed
+    {dataExecution}.
   - For each {record} in {records}:
     - Remove {record} from {subsequentPayloads}.
     - If {isCompletedIterator} on {record} is {true}:
       - Continue to the next record in {records}.
     - Let {payload} be the completed result returned by {dataExecution}.
-    - Append {payload} to {incremental}.
+    - Append {payload} to the {incremental} entry on {subsequentResponse}.
   - If {subsequentPayloads} is empty:
-    - Add an entry to {response} named `hasNext` with the value {false}.
-  - Yield {response}
+    - Add an entry to {subsequentResponse} named `hasNext` with the value
+      {false}.
+  - Otherwise, if {subsequentPayloads} is not empty:
+    - Add an entry to {subsequentResponse} named `hasNext` with the value
+      {true}.
+  - Yield {subsequentResponse}
 
 ## Executing Selection Sets
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -39,13 +39,8 @@ Alternatively, the socket can provide a write buffer pointer to allow
 - Let {coercedVariableValues} be the result of {CoerceVariableValues(schema,
   operation, variableValues)}.
 - If {operation} is a query operation:
-  - Let {executionResult} be the result of calling {ExecuteQuery(operation,
-    schema, coercedVariableValues, initialValue, subsequentPayloads)}.
-  - If {executionResult} is an iterator:
-    - For each {payload} in {executionResult}:
-      - Yield {payload}.
-  - Otherwise:
-    - Return {executionResult}.
+  - Return {ExecuteQuery(operation, schema, coercedVariableValues,
+    initialValue)}.
 - Otherwise if {operation} is a mutation operation:
   - Return {ExecuteMutation(operation, schema, coercedVariableValues,
     initialValue)}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -456,11 +456,16 @@ If during {ExecuteSelectionSet()} a field with a non-null {fieldType} raises a
 _field error_ then that error must propagate to this entire selection set,
 either resolving to {null} if allowed or further propagated to a parent field.
 
-If this occurs, any defer or stream executions with a path that starts with the
-same path as the resolved {null} must not return their results to the client.
-These defer or stream executions or any sibling fields which have not yet
-executed or have not yet yielded a value may be cancelled to avoid unnecessary
-work.
+If this occurs, any sibling fields which have not yet executed or have not yet
+yielded a value may be cancelled to avoid unnecessary work.
+
+Additionally, the path of each {asyncRecord} in {subsequentPayloads} must be
+compared with the path of the field that ultimately resolved to {null}. If the
+path of any {asyncRecord} starts with, but is not equal to, the path of the
+resolved {null}, the {asyncRecord} must be removed from {subsequentPayloads} and
+its result must not be sent to clients. If these async records have not yet
+executed or have not yet yielded a value they may also be cancelled to avoid
+unnecessary work.
 
 Note: See [Handling Field Errors](#sec-Handling-Field-Errors) for more about
 this behavior.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -904,7 +904,9 @@ subsequentPayloads, asyncRecord):
     - Let {field} be the first entry in {fields}.
     - Let {innerType} be the inner type of {fieldType}.
     - If {field} provides the directive `@stream` and its {if} argument is
-      {true} or is a variable in {variableValues} with the value {true} and :
+      {true} or is a variable in {variableValues} with the value {true} and
+      {innerType} is the outermost return type of the list type defined for
+      {field}:
       - Let {streamDirective} be that directive.
     - Let {initialCount} be the value or variable provided to
       {streamDirective}'s {initialCount} argument.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -863,7 +863,7 @@ variableValues, subsequentPayloads):
 - Let {streamRecord} be an async payload record created from {label}, {path},
   and {iterator}.
 - Initialize {errors} on {streamRecord} to an empty list.
-- Let {indexPath} be {path} with {index} appended.
+- Let {itemPath} be {path} with {index} appended.
 - Let {dataExecution} be the asynchronous future value of:
   - Wait for the next item from {iterator}.
   - If an item is not retrieved because {iterator} has completed:
@@ -872,7 +872,7 @@ variableValues, subsequentPayloads):
   - Let {payload} be an unordered map.
   - Let {item} be the item retrieved from {iterator}.
   - Let {data} be the result of calling {CompleteValue(innerType, fields, item,
-    variableValues, indexPath, subsequentPayloads, parentRecord)}.
+    variableValues, itemPath, subsequentPayloads, parentRecord)}.
   - Append any encountered field errors to {errors}.
   - Increment {index}.
   - Call {ExecuteStreamField(label, iterator, index, fields, innerType, path,
@@ -883,7 +883,7 @@ variableValues, subsequentPayloads):
     - Add an entry to {payload} named `errors` with the value {errors}.
   - Add an entry to {payload} named `data` with the value {data}.
   - Add an entry to {payload} named `label` with the value {label}.
-  - Add an entry to {payload} named `path` with the value {indexPath}.
+  - Add an entry to {payload} named `path` with the value {itemPath}.
   - Return {payload}.
 - Set {dataExecution} on {streamRecord}.
 - Append {streamRecord} to {subsequentPayloads}.
@@ -903,7 +903,9 @@ subsequentPayloads, asyncRecord):
   - If {result} is an iterator:
     - Let {field} be the first entry in {fields}.
     - Let {innerType} be the inner type of {fieldType}.
-    - Let {streamDirective} be the `@stream` directive provided on {field}.
+    - If {field} provides the directive `@stream` and its {if} argument is
+      {true} or is a variable in {variableValues} with the value {true} and :
+      - Let {streamDirective} be that directive.
     - Let {initialCount} be the value or variable provided to
       {streamDirective}'s {initialCount} argument.
     - If {initialCount} is less than zero, raise a _field error_.
@@ -912,18 +914,18 @@ subsequentPayloads, asyncRecord):
     - Let {initialItems} be an empty list
     - Let {index} be zero.
     - While {result} is not closed:
-      - If {streamDirective} was not provided or {index} is not greater than or
+      - If {streamDirective} is not defined or {index} is not greater than or
         equal to {initialCount}:
         - Wait for the next item from {result}.
         - Let {resultItem} be the item retrieved from {result}.
-        - Let {indexPath} be {path} with {index} appended.
+        - Let {itemPath} be {path} with {index} appended.
         - Let {resolvedItem} be the result of calling {CompleteValue(innerType,
-          fields, resultItem, variableValues, indexPath, subsequentPayloads,
+          fields, resultItem, variableValues, itemPath, subsequentPayloads,
           asyncRecord)}.
         - Append {resolvedItem} to {initialItems}.
         - Increment {index}.
-      - If {streamDirective} was provided and {index} is greater than or equal
-        to {initialCount}:
+      - If {streamDirective} is defined and {index} is greater than or equal to
+        {initialCount}:
         - Call {ExecuteStreamField(label, result, index, fields, innerType,
           path, asyncRecord, subsequentPayloads)}.
         - Let {result} be {initialItems}.
@@ -932,9 +934,9 @@ subsequentPayloads, asyncRecord):
   - If {result} is not a collection of values, raise a _field error_.
   - Let {innerType} be the inner type of {fieldType}.
   - Return a list where each list item is the result of calling
-    {CompleteValue(innerType, fields, resultItem, variableValues, indexPath,
+    {CompleteValue(innerType, fields, resultItem, variableValues, itemPath,
     subsequentPayloads, asyncRecord)}, where {resultItem} is each item in
-    {result} and {indexPath} is {path} with the index of the item appended.
+    {result} and {itemPath} is {path} with the index of the item appended.
 - If {fieldType} is a Scalar or Enum type:
   - Return the result of {CoerceResult(fieldType, result)}.
 - If {fieldType} is an Object, Interface, or Union type:

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -387,13 +387,13 @@ YieldSubsequentPayloads(subsequentPayloads):
 - Let {record} be the first item in {subsequentPayloads} with a completed
   {dataExecution}.
   - Remove {record} from {subsequentPayloads}.
-  - Let {payload} be the completed result returned by {dataExecution}.
-  - If {payload} is {null}:
+  - If {isCompletedIterator} on {record} is {true}:
     - If {subsequentPayloads} is empty:
       - Yield a map containing a field `hasNext` with the value {false}.
       - Return.
     - If {subsequentPayloads} is not empty:
       - Continue to the next record in {subsequentPayloads}.
+  - Let {payload} be the completed result returned by {dataExecution}.
   - If {record} is not the final element in {subsequentPayloads}:
     - Add an entry to {payload} named `hasNext` with the value {true}.
   - If {record} is the final element in {subsequentPayloads}:
@@ -682,6 +682,8 @@ All Async Payload Records are structures containing:
 - {path}: a list of field names and indices from root to the location of the
   corresponding `@defer` or `@stream` directive.
 - {iterator}: The underlying iterator if created from a `@stream` directive.
+- {isCompletedIterator}: a boolean indicating the payload record was generated
+  from an iterator that has completed.
 - {errors}: a list of field errors encountered during execution.
 - {dataExecution}: A result that can notify when the corresponding execution has
   completed.
@@ -864,6 +866,7 @@ variableValues, subsequentPayloads):
 - Let {dataExecution} be the asynchronous future value of:
   - Wait for the next item from {iterator}.
   - If an item is not retrieved because {iterator} has completed:
+    - Set {isCompletedIterator} to {true} on {streamRecord}.
     - Return {null}.
   - Let {payload} be an unordered map.
   - Let {item} be the item retrieved from {iterator}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -418,13 +418,13 @@ First, the selection set is turned into a grouped field set; then, each
 represented field in the grouped field set produces an entry into a response
 map.
 
-ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues,
-subsequentPayloads, parentPath):
+ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues, path,
+subsequentPayloads, asyncRecord):
 
+- If {path} is not provided, initialize it to an empty list.
 - If {subsequentPayloads} is not provided, initialize it to the empty set.
-- If {parentPath} is not provided, initialize it to an empty list.
 - Let {groupedFieldSet} be the result of {CollectFields(objectType, objectValue,
-  selectionSet, variableValues, subsequentPayloads, parentPath)}.
+  selectionSet, variableValues, path subsequentPayloads, asyncRecord)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -433,7 +433,7 @@ subsequentPayloads, parentPath):
     {objectType}.
   - If {fieldType} is defined:
     - Let {responseValue} be {ExecuteField(objectType, objectValue, fieldType,
-      fields, variableValues, subsequentPayloads, parentPath)}.
+      fields, variableValues, path, subsequentPayloads, asyncRecord)}.
     - Set {responseValue} as the value for {responseKey} in {resultMap}.
 - Return {resultMap}.
 
@@ -585,8 +585,8 @@ The depth-first-search order of the field groups produced by {CollectFields()}
 is maintained through execution, ensuring that fields appear in the executed
 response in a stable and predictable order.
 
-CollectFields(objectType, objectValue, selectionSet, variableValues,
-deferredFragments, parentPath, visitedFragments):
+CollectFields(objectType, objectValue, selectionSet, variableValues, path,
+subsequentPayloads, asyncRecord, visitedFragments):
 
 - If {visitedFragments} is not provided, initialize it to the empty set.
 - Initialize {groupedFields} to an empty ordered map of lists.
@@ -625,14 +625,16 @@ deferredFragments, parentPath, visitedFragments):
       with the next {selection} in {selectionSet}.
     - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
     - If {deferDirective} is defined:
-      - Let {deferredFragment} be the result of calling
-        {DeferFragment(objectType, objectValue, fragmentSelectionSet,
-        parentPath)}.
-      - Append {deferredFragment} to {deferredFragments}.
+      - Let {label} be the value or the variable to {deferDirective}'s {label}
+        argument.
+      - Let {deferredFragmentRecord} be the result of calling
+        {CreateDeferredFragmentRecord(label, objectType, objectValue,
+        fragmentSelectionSet, path, asyncRecord)}.
+      - Append {deferredFragmentRecord} to {subsequentPayloads}.
       - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments)}.
+      {CollectFields(objectType, objectValue, fragmentSelectionSet,
+      variableValues, path, subsequentPayloads, asyncRecord, visitedFragments)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
@@ -649,14 +651,16 @@ deferredFragments, parentPath, visitedFragments):
       be that directive.
       - If {deferDirective}'s {if} argument is {true} or is a variable in
         {variableValues} with the value {true}:
-        - Let {deferredFragment} be the result of calling
-          {DeferFragment(objectType, objectValue, fragmentSelectionSet,
-          parentPath)}.
-        - Append {deferredFragment} to {deferredFragments}.
+        - Let {label} be the value or the variable to {deferDirective}'s {label}
+          argument.
+        - Let {deferredFragmentRecord} be the result of calling
+          {CreateDeferredFragmentRecord(label, objectType, objectValue,
+          fragmentSelectionSet, path, asyncRecord)}.
+        - Append {deferredFragmentRecord} to {subsequentPayloads}.
         - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments, parentPath)}.
+      {CollectFields(objectType, objectValue, fragmentSelectionSet,
+      variableValues, path, subsequentPayloads, asyncRecord, visitedFragments)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
@@ -680,44 +684,53 @@ DoesFragmentTypeApply(objectType, fragmentType):
   - if {objectType} is a possible type of {fragmentType}, return {true}
     otherwise return {false}.
 
-DeferFragment(objectType, objectValue, fragmentSelectionSet, parentPath):
+#### Async Payload Record
 
-- Let {label} be the value or the variable to {deferDirective}'s {label}
-  argument.
-- Let {deferredFragmentRecord} be the result of calling
-  {CreateDeferredFragmentRecord(label, objectType, objectValue,
-  fragmentSelectionSet, parentPath)}.
-- return {deferredFragmentRecord}.
+An Async Payload Record is either a Deferred Fragment Record or a Stream Record.
+All Async Payload Records are structures containing:
+
+- {label}: value derived from the corresponding `@defer` or `@stream` directive.
+- {parentRecord}: optionally an Async Payload Record.
+- {errors}: a list of field errors encountered during execution.
+- {dataExecution}: A result that can notify when the corresponding execution has
+  completed.
+- {path}: a list of field names and indices from root to the location of the
+  corresponding `@defer` or `@stream` directive.
 
 #### Deferred Fragment Record
 
 Let {deferredFragmentRecord} be an inline fragment or fragment spread with
 `@defer` provided.
 
-Deferred Fragment Record is a structure containing:
+Deferred Fragment Record is a structure containing all the entries of Async
+Payload Record, and additionally:
 
-- {label}: value derived from the `@defer` directive.
 - {objectType}: of the {deferredFragmentRecord}.
 - {objectValue}: of the {deferredFragmentRecord}.
 - {fragmentSelectionSet}: the top level selection set of
   {deferredFragmentRecord}.
-- {path}: a list of field names and indices from root to
-  {deferredFragmentRecord}.
 
 CreateDeferredFragmentRecord(label, objectType, objectValue,
-fragmentSelectionSet, path):
+fragmentSelectionSet, path, parentRecord):
 
-- If {path} is not provided, initialize it to an empty list.
 - Construct a deferred fragment record based on the parameters passed in.
+- Initialize {errors} to an empty list.
 
 ResolveDeferredFragmentRecord(deferredFragmentRecord, variableValues,
 subsequentPayloads):
 
-- Let {label}, {objectType}, {objectValue}, {fragmentSelectionSet}, {path} be
-  the corresponding fields in the deferred fragment record structure.
-- Let {payload} be the result of calling
-  {ExecuteSelectionSet(fragmentSelectionSet, objectType, objectValue,
-  variableValues, subsequentPayloads, path)}.
+- Let {label}, {objectType}, {objectValue}, {fragmentSelectionSet}, {path},
+  {parentRecord} be the corresponding fields in the deferred fragment record
+  structure.
+- Let {dataExecution} be the asynchronous future value of:
+  - Let {payload} be the result of {ExecuteSelectionSet(fragmentSelectionSet,
+    objectType, objectValue, variableValues, path, subsequentPayloads,
+    deferredFragmentRecord)}.
+  - If {parentRecord} is defined:
+    - Wait for the result of {dataExecution} on {parentRecord}.
+  - Return {payload}.
+- Set {dataExecution} on {deferredFragmentRecord}.
+- Let {payload} be the result of waiting for {dataExecution}.
 - Add an entry to {payload} named `label` with the value {label}.
 - Add an entry to {payload} named `path` with the value {path}.
 - Return {payload}.
@@ -730,11 +743,12 @@ coerces any provided argument values, then resolves a value for the field, and
 finally completes that value either by recursively executing another selection
 set or coercing a scalar value.
 
-ExecuteField(objectType, objectValue, fieldType, fields, variableValues,
-subsequentPayloads, parentPath):
+ExecuteField(objectType, objectValue, fieldType, fields, variableValues, path,
+subsequentPayloads, asyncRecord):
 
 - Let {field} be the first entry in {fields}.
 - Let {fieldName} be the field name of {field}.
+- Append {fieldName} to {path}.
 - Let {argumentValues} be the result of {CoerceArgumentValues(objectType, field,
   variableValues)}
 - If {field} provides the directive `@stream`, let {streamDirective} be that
@@ -742,16 +756,14 @@ subsequentPayloads, parentPath):
   - Let {initialCount} be the value or variable provided to {streamDirective}'s
     {initialCount} argument.
   - Let {resolvedValue} be {ResolveFieldGenerator(objectType, objectValue,
-    fieldName, argumentValues, initialCount)}.
+    fieldName, argumentValues)}.
   - Let {result} be the result of calling {CompleteValue(fieldType, fields,
-    resolvedValue, variableValues, subsequentPayloads, parentPath)}.
-  - Append {fieldName} to the {path} field of every {subsequentPayloads}.
+    resolvedValue, variableValues, path, subsequentPayloads, asyncRecord)}.
   - Return {result}.
 - Let {resolvedValue} be {ResolveFieldValue(objectType, objectValue, fieldName,
   argumentValues)}.
 - Let {result} be the result of calling {CompleteValue(fieldType, fields,
-  resolvedValue, variableValues, subsequentPayloads)}.
-- Append {fieldName} to the {path} for every {subsequentPayloads}.
+  resolvedValue, variableValues, path, subsequentPayloads, asyncRecord)}.
 - Return {result}.
 
 ### Coercing Field Arguments
@@ -837,14 +849,13 @@ ResolveFieldValue(objectType, objectValue, fieldName, argumentValues):
 - Return the result of calling {resolver}, providing {objectValue} and
   {argumentValues}.
 
-ResolveFieldGenerator(objectType, objectValue, fieldName, argumentValues,
-initialCount):
+ResolveFieldGenerator(objectType, objectValue, fieldName, argumentValues):
 
 - If {objectType} provide an internal function {generatorResolver} for
   generating partially resolved value of a list field named {fieldName}:
   - Let {generatorResolver} be the internal function.
   - Return the iterator from calling {generatorResolver}, providing
-    {objectValue}, {argumentValues} and {initialCount}.
+    {objectValue} and {argumentValues}.
 - Create {generator} from {ResolveFieldValue(objectType, objectValue, fieldName,
   argumentValues)}.
 - Return {generator}.
@@ -864,52 +875,58 @@ field execution process continues recursively. In the case where a value
 returned for a list type field is an iterator due to `@stream` specified on the
 field, value completion iterates over the iterator until the number of items
 yield by the iterator satisfies `initialCount` specified on the `@stream`
-directive. Unresolved items in the iterator will be stored in a stream record
-which the executor resumes to execute after the initial execution finishes.
+directive.
 
 #### Stream Record
 
 Let {streamField} be a list field with a `@stream` directive provided.
 
-A Stream Record is a structure containing:
+A Stream Record is a structure containing all the entries of Async Payload
+Record, and additionally:
 
-- {label}: value derived from the `@stream` directive's `label` argument.
 - {iterator}: created by {ResolveFieldGenerator}.
-- {resolvedItems}: items resolved from the {iterator} but not yet delivered.
 - {index}: indicating the position of the item in the complete list.
-- {path}: a list of field names and indices from root to {streamField}.
 - {fields}: the group of fields grouped by CollectFields() for {streamField}.
 - {innerType}: inner type of {streamField}'s type.
 
-CreateStreamRecord(label, initialCount, iterator, resolvedItems, index, fields,
-innerType):
+CreateStreamRecord(label, iterator, index, fields, innerType, path,
+parentRecord):
 
 - Construct a stream record based on the parameters passed in.
+- Initialize {errors} to an empty list.
 
 ResolveStreamRecord(streamRecord, variableValues, subsequentPayloads):
 
-- Let {label}, {iterator}, {resolvedItems}, {index}, {path}, {fields},
+- Let {label}, {parentRecord}, {iterator}, {index}, {path}, {fields},
   {innerType} be the correspondent fields on the Stream Record structure.
-- Wait for the next item from {iterator}.
-- If an item is not retrieved because {iterator} has completed:
-  - Return {null}
-- Let {item} be the item retrieved from {iterator}.
-- Append {index} to {path}.
-- Increment {index}.
-- Let {payload} be the result of calling CompleteValue(innerType, fields, item,
-  variableValues, subsequentPayloads, path)}.
+- Let {indexPath} be {path} with {index} appended.
+- Let {dataExecution} be the asynchronous future value of:
+  - Wait for the next item from {iterator}.
+  - If an item is not retrieved because {iterator} has completed:
+    - Return {null}.
+  - Let {item} be the item retrieved from {iterator}.
+  - Let {payload} be the result of calling {CompleteValue(innerType, fields,
+    item, variableValues, indexPath, subsequentPayloads, parentRecord)}.
+  - Increment {index}.
+  - Let {nextStreamRecord} be the result of calling {CreateStreamRecord(label,
+    iterator, index, fields, innerType, path, streamRecord)}.
+  - Append {nextStreamRecord} to {subsequentPayloads}.
+  - If {parentRecord} is defined:
+    - Wait for the result of {dataExecution} on {parentRecord}.
+  - Return {payload}.
+- Set {dataExecution} on {streamRecord}.
+- Let {payload} be the result of waiting for {dataExecution}.
 - Add an entry to {payload} named `label` with the value {label}.
-- Add an entry to {payload} named `path` with the value {path}.
-- Append {streamRecord} to {subsequentPayloads}.
+- Add an entry to {payload} named `path` with the value {indexPath}.
 - Return {payload}.
 
-CompleteValue(fieldType, fields, result, variableValues, subsequentPayloads,
-parentPath):
+CompleteValue(fieldType, fields, result, variableValues, path,
+subsequentPayloads, asyncRecord):
 
 - If the {fieldType} is a Non-Null type:
   - Let {innerType} be the inner type of {fieldType}.
   - Let {completedResult} be the result of calling {CompleteValue(innerType,
-    fields, result, variableValues)}.
+    fields, result, variableValues, path)}.
   - If {completedResult} is {null}, raise a _field error_.
   - Return {completedResult}.
 - If {result} is {null} (or another internal value similar to {null} such as
@@ -924,26 +941,33 @@ parentPath):
     - If {initialCount} is less than zero, raise a _field error_.
     - Let {label} be the value or variable provided to {streamDirective}'s
       {label} argument.
-    - Let {resolvedItems} be an empty list
-    - For each {members} in {result}:
-      - Append all items from {members} to {resolvedItems}.
-      - If the length of {resolvedItems} is greater or equal to {initialCount}:
-        - Let {initialItems} be the sublist of the first {initialCount} items
-          from {resolvedItems}.
-        - Let {remainingItems} be the sublist of the items in {resolvedItems}
-          after the first {initialCount} items.
+    - Let {initialItems} be an empty list
+    - Let {index} be zero.
+    - While {result} is not closed:
+      - If {streamDirective} was not provided or {index} is not greater than or
+        equal to {initialCount}:
+        - Wait for the next item from {result}.
+        - Let {resultItem} be the item retrieved from {result}.
+        - Let {indexPath} be {path} with {index} appended.
+        - Let {resolvedItem} be the result of calling {CompleteValue(innerType,
+          fields, resultItem, variableValues, indexPath, subsequentPayloads,
+          asyncRecord)}.
+        - Append {resolvedItem} to {initialItems}.
+        - Increment {index}.
+      - If {streamDirective} was provided and {index} is greater than or equal
+        to {initialCount}:
         - Let {streamRecord} be the result of calling {CreateStreamRecord(label,
-          initialCount, result, remainingItems, initialCount, fields, innerType,
-          parentPath)}
+          result, index, fields, innerType, path, asyncRecord)}.
         - Append {streamRecord} to {subsequentPayloads}.
         - Let {result} be {initialItems}.
-        - Exit for each loop.
+        - Exit while loop.
+    - Return {initialItems}.
   - If {result} is not a collection of values, raise a _field error_.
   - Let {innerType} be the inner type of {fieldType}.
   - Return a list where each list item is the result of calling
-    {CompleteValue(innerType, fields, resultItem, variableValues,
-    subsequentPayloads, parentPath)}, where {resultItem} is each item in
-    {result}.
+    {CompleteValue(innerType, fields, resultItem, variableValues, indexPath,
+    subsequentPayloads, asyncRecord)}, where {resultItem} is each item in
+    {result} and {indexPath} is {path} with the index of the item appended.
 - If {fieldType} is a Scalar or Enum type:
   - Return the result of {CoerceResult(fieldType, result)}.
 - If {fieldType} is an Object, Interface, or Union type:
@@ -953,7 +977,7 @@ parentPath):
     - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
   - Let {subSelectionSet} be the result of calling {MergeSelectionSets(fields)}.
   - Return the result of evaluating {ExecuteSelectionSet(subSelectionSet,
-    objectType, result, variableValues, subsequentPayloads, parentPath)}
+    objectType, result, variableValues, path, subsequentPayloads, asyncRecord)}
     _normally_ (allowing for parallelization).
 
 **Coercing Results**

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -144,10 +144,10 @@ ExecuteQuery(query, schema, variableValues, initialValue):
 - If {subsequentPayloads} is empty:
   - Return an unordered map containing {data} and {errors}.
 - If {subsequentPayloads} is not empty:
-  - Yield an unordered map containing {data}, {errors}, and an entry named
-    {hasNext} with the value {true}.
+  - Let {intialResponse} be an unordered map containing {data}, {errors}, and an
+    entry named {hasNext} with the value {true}.
   - Let {iterator} be the result of running
-    {YieldSubsequentPayloads(subsequentPayloads)}.
+    {YieldSubsequentPayloads(intialResponse, subsequentPayloads)}.
   - For each {payload} yielded by {iterator}:
     - If a termination signal is received:
       - Send a termination signal to {iterator}.
@@ -178,10 +178,10 @@ ExecuteMutation(mutation, schema, variableValues, initialValue):
 - If {subsequentPayloads} is empty:
   - Return an unordered map containing {data} and {errors}.
 - If {subsequentPayloads} is not empty:
-  - Yield an unordered map containing {data}, {errors}, and an entry named
-    {hasNext} with the value {true}.
+  - Let {intialResponse} be an unordered map containing {data}, {errors}, and an
+    entry named {hasNext} with the value {true}.
   - Let {iterator} be the result of running
-    {YieldSubsequentPayloads(subsequentPayloads)}.
+    {YieldSubsequentPayloads(intialResponse, subsequentPayloads)}.
   - For each {payload} yielded by {iterator}:
     - If a termination signal is received:
       - Send a termination signal to {iterator}.
@@ -341,10 +341,10 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 - If {subsequentPayloads} is empty:
   - Return an unordered map containing {data} and {errors}.
 - If {subsequentPayloads} is not empty:
-  - Yield an unordered map containing {data}, {errors}, and an entry named
-    {hasNext} with the value {true}.
+  - Let {intialResponse} be an unordered map containing {data}, {errors}, and an
+    entry named {hasNext} with the value {true}.
   - Let {iterator} be the result of running
-    {YieldSubsequentPayloads(subsequentPayloads)}.
+    {YieldSubsequentPayloads(intialResponse, subsequentPayloads)}.
   - For each {payload} yielded by {iterator}:
     - If a termination signal is received:
       - Send a termination signal to {iterator}.
@@ -372,29 +372,42 @@ If an operation contains subsequent payload records resulting from `@stream` or
 `@defer` directives, the {YieldSubsequentPayloads} algorithm defines how the
 payloads should be processed.
 
-YieldSubsequentPayloads(subsequentPayloads):
+YieldSubsequentPayloads(intialResponse, subsequentPayloads):
 
+- Let {initialRecords} be any items in {subsequentPayloads} with a completed
+  {dataExecution}.
+- Initialize {initialIncremental} to an empty list.
+- For each {record} in {initialRecords}:
+  - Remove {record} from {subsequentPayloads}.
+  - If {isCompletedIterator} on {record} is {true}:
+    - Continue to the next record in {records}.
+  - Let {payload} be the completed result returned by {dataExecution}.
+  - Append {payload} to {initialIncremental}.
+- If {initialIncremental} is not empty:
+  - Add an entry to {intialResponse} named `incremental` containing the value
+    {incremental}.
+- Yield {intialResponse}.
 - While {subsequentPayloads} is not empty:
 - If a termination signal is received:
   - For each {record} in {subsequentPayloads}:
     - If {record} contains {iterator}:
       - Send a termination signal to {iterator}.
   - Return.
-- Let {record} be the first item in {subsequentPayloads} with a completed
+- Wait for at least one record in {subsequentPayloads} to have a completed
   {dataExecution}.
-  - Remove {record} from {subsequentPayloads}.
-  - If {isCompletedIterator} on {record} is {true}:
-    - If {subsequentPayloads} is empty:
-      - Yield a map containing a field `hasNext` with the value {false}.
-      - Return.
-    - If {subsequentPayloads} is not empty:
-      - Continue to the next record in {subsequentPayloads}.
-  - Let {payload} be the completed result returned by {dataExecution}.
-  - If {record} is not the final element in {subsequentPayloads}:
-    - Add an entry to {payload} named `hasNext` with the value {true}.
-  - If {record} is the final element in {subsequentPayloads}:
-    - Add an entry to {payload} named `hasNext` with the value {false}.
-  - Yield {payload}
+- Let {subsequentResponse} be an unordered map with an entry {incremental}
+  initialized to an empty list.
+- Let {records} be the items in {subsequentPayloads} with a completed
+  {dataExecution}.
+  - For each {record} in {records}:
+    - Remove {record} from {subsequentPayloads}.
+    - If {isCompletedIterator} on {record} is {true}:
+      - Continue to the next record in {records}.
+    - Let {payload} be the completed result returned by {dataExecution}.
+    - Append {payload} to {incremental}.
+  - If {subsequentPayloads} is empty:
+    - Add an entry to {response} named `hasNext` with the value {false}.
+  - Yield {response}
 
 ## Executing Selection Sets
 
@@ -900,7 +913,8 @@ variableValues, subsequentPayloads):
     - Wait for the result of {dataExecution} on {parentRecord}.
   - If {errors} is not empty:
     - Add an entry to {payload} named `errors` with the value {errors}.
-  - Add an entry to {payload} named `data` with the value {data}.
+  - Add an entry to {payload} named `items` with a list containing the value
+    {data}.
   - Add an entry to {payload} named `label` with the value {label}.
   - Add an entry to {payload} named `path` with the value {itemPath}.
   - Return {payload}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -459,12 +459,45 @@ either resolving to {null} if allowed or further propagated to a parent field.
 If this occurs, any sibling fields which have not yet executed or have not yet
 yielded a value may be cancelled to avoid unnecessary work.
 
-Additionally, the path of each {asyncRecord} in {subsequentPayloads} must be
-compared with the path of the field that ultimately resolved to {null}. If the
-path of any {asyncRecord} starts with the path of the resolved {null}, the
-{asyncRecord} must be removed from {subsequentPayloads} and its result must not
-be sent to clients. If these async records have not yet executed or have not yet
-yielded a value they may also be cancelled to avoid unnecessary work.
+Additionally, async payload records in {subsequentPayloads} must be filtered if
+their path points to a location that has resolved to {null} due to propagation
+of a field error. This is described in
+[Filter Subsequent Payloads](#sec-Filter-Subsequent-Payloads). These async
+payload records must be removed from {subsequentPayloads} and their result must
+not be sent to clients. If these async records have not yet executed or have not
+yet yielded a value they may also be cancelled to avoid unnecessary work.
+
+Note: See [Handling Field Errors](#sec-Handling-Field-Errors) for more about
+this behavior.
+
+### Filter Subsequent Payloads
+
+When a field error is raised, there may be async payload records in
+{subsequentPayloads} with a path that points to a location that has been removed
+or set to null due to null propagation. These async payload records must be
+removed from subsequent payloads and their results must not be sent to clients.
+
+In {FilterSubsequentPayloads}, {nullPath} is the path which has resolved to null
+after propagation as a result of a field error. {currentAsyncRecord} is the
+async payload record where the field error was raised. {currentAsyncRecord} will
+not be set for field errors that were raised during the initial execution
+outside of {ExecuteDeferredFragment} or {ExecuteStreamField}.
+
+FilterSubsequentPayloads(subsequentPayloads, nullPath, currentAsyncRecord):
+
+- For each {asyncRecord} in {subsequentPayloads}:
+  - If {asyncRecord} is the same record as {currentAsyncRecord}:
+    - Continue to the next record in {subsequentPayloads}.
+  - Initialize {index} to zero.
+  - While {index} is less then the length of {nullPath}:
+    - Initialize {nullPathItem} to the element at {index} in {nullPath}.
+    - Initialize {asyncRecordPathItem} to the element at {index} in the {path}
+      of {asyncRecord}.
+    - If {nullPathItem} is not equivalent to {asyncRecordPathItem}:
+      - Continue to the next record in {subsequentPayloads}.
+    - Increment {index} by one.
+  - Remove {asyncRecord} from {subsequentPayloads}. Optionally, cancel any
+    incomplete work in the execution of {asyncRecord}.
 
 For example, assume the field `alwaysThrows` is a `Non-Null` type that always
 raises a field error:
@@ -490,9 +523,6 @@ be cancelled.
   "hasNext": false
 }
 ```
-
-Note: See [Handling Field Errors](#sec-Handling-Field-Errors) for more about
-this behavior.
 
 ### Normal and Serial Execution
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -411,8 +411,9 @@ subsequentPayloads, asyncRecord):
 
 - If {path} is not provided, initialize it to an empty list.
 - If {subsequentPayloads} is not provided, initialize it to the empty set.
-- Let {groupedFieldSet} be the result of {CollectFields(objectType, objectValue,
-  selectionSet, variableValues, path subsequentPayloads, asyncRecord)}.
+- Let {groupedFieldSet} and {deferredGroupedFieldsList} be the result of
+  {CollectFields(objectType, objectValue, selectionSet, variableValues, path,
+  asyncRecord)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -423,6 +424,10 @@ subsequentPayloads, asyncRecord):
     - Let {responseValue} be {ExecuteField(objectType, objectValue, fieldType,
       fields, variableValues, path, subsequentPayloads, asyncRecord)}.
     - Set {responseValue} as the value for {responseKey} in {resultMap}.
+- For each {deferredGroupFieldSet} and {label} in {deferredGroupedFieldsList}
+  - Call {ExecuteDeferredFragment(label, objectType, objectValue,
+    deferredGroupFieldSet, path, variableValues, asyncRecord,
+    subsequentPayloads)}
 - Return {resultMap}.
 
 Note: {resultMap} is ordered by which fields appear first in the operation. This
@@ -574,10 +579,12 @@ is maintained through execution, ensuring that fields appear in the executed
 response in a stable and predictable order.
 
 CollectFields(objectType, objectValue, selectionSet, variableValues, path,
-subsequentPayloads, asyncRecord, visitedFragments):
+asyncRecord, visitedFragments, deferredGroupedFieldsList):
 
 - If {visitedFragments} is not provided, initialize it to the empty set.
 - Initialize {groupedFields} to an empty ordered map of lists.
+- If {deferredGroupedFieldsList} is not provided, initialize it to an empty
+  list.
 - For each {selection} in {selectionSet}:
   - If {selection} provides the directive `@skip`, let {skipDirective} be that
     directive.
@@ -616,13 +623,17 @@ subsequentPayloads, asyncRecord, visitedFragments):
     - If {deferDirective} is defined:
       - Let {label} be the value or the variable to {deferDirective}'s {label}
         argument.
-      - Call {ExecuteDeferredFragment(label, objectType, objectValue,
-        fragmentSelectionSet, path, variableValues, asyncRecord,
-        subsequentPayloads)}.
+      - Let {deferredGroupedFields} be the result of calling
+        {CollectFields(objectType, objectValue, fragmentSelectionSet,
+        variableValues, path, asyncRecord, visitedFragments,
+        deferredGroupedFieldsList)}.
+      - Append a record containing {label} and {deferredGroupedFields} to
+        {deferredGroupedFieldsList}.
       - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
       {CollectFields(objectType, objectValue, fragmentSelectionSet,
-      variableValues, path, subsequentPayloads, asyncRecord, visitedFragments)}.
+      variableValues, path, asyncRecord, visitedFragments,
+      deferredGroupedFieldsList)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
@@ -641,19 +652,24 @@ subsequentPayloads, asyncRecord, visitedFragments):
         {variableValues} with the value {true}:
         - Let {label} be the value or the variable to {deferDirective}'s {label}
           argument.
-        - Call {ExecuteDeferredFragment(label, objectType, objectValue,
-          fragmentSelectionSet, path, asyncRecord, subsequentPayloads)}.
+        - Let {deferredGroupedFields} be the result of calling
+          {CollectFields(objectType, objectValue, fragmentSelectionSet,
+          variableValues, path, asyncRecord, visitedFragments,
+          deferredGroupedFieldsList)}.
+        - Append a record containing {label} and {deferredGroupedFields} to
+          {deferredGroupedFieldsList}.
         - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
       {CollectFields(objectType, objectValue, fragmentSelectionSet,
-      variableValues, path, subsequentPayloads, asyncRecord, visitedFragments)}.
+      variableValues, path, asyncRecord, visitedFragments,
+      deferredGroupedFieldsList)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
       - Let {groupForResponseKey} be the list in {groupedFields} for
         {responseKey}; if no such list exists, create it as an empty list.
       - Append all items in {fragmentGroup} to {groupForResponseKey}.
-- Return {groupedFields}.
+- Return {groupedFields} and {deferredGroupedFieldsList}.
 
 Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
 directives may be applied in either order since they apply commutatively.
@@ -687,22 +703,29 @@ All Async Payload Records are structures containing:
 
 #### Execute Deferred Fragment
 
-ExecuteDeferredFragment(label, objectType, objectValue, fragmentSelectionSet,
-path, variableValues, parentRecord, subsequentPayloads):
+ExecuteDeferredFragment(label, objectType, objectValue, groupedFieldSet, path,
+variableValues, parentRecord, subsequentPayloads):
 
 - Let {deferRecord} be an async payload record created from {label} and {path}.
 - Initialize {errors} on {deferRecord} to an empty list.
 - Let {dataExecution} be the asynchronous future value of:
   - Let {payload} be an unordered map.
-  - Let {data} be the result of {ExecuteSelectionSet(fragmentSelectionSet,
-    objectType, objectValue, variableValues, path, subsequentPayloads,
-    deferRecord)}.
+  - Initialize {resultMap} to an empty ordered map.
+  - For each {groupedFieldSet} as {responseKey} and {fields}:
+    - Let {fieldName} be the name of the first entry in {fields}. Note: This
+      value is unaffected if an alias is used.
+    - Let {fieldType} be the return type defined for the field {fieldName} of
+      {objectType}.
+    - If {fieldType} is defined:
+      - Let {responseValue} be {ExecuteField(objectType, objectValue, fieldType,
+        fields, variableValues, path, subsequentPayloads, asyncRecord)}.
+      - Set {responseValue} as the value for {responseKey} in {resultMap}.
   - Append any encountered field errors to {errors}.
   - If {parentRecord} is defined:
     - Wait for the result of {dataExecution} on {parentRecord}.
   - If {errors} is not empty:
     - Add an entry to {payload} named `errors` with the value {errors}.
-  - Add an entry to {payload} named `data` with the value {data}.
+  - Add an entry to {payload} named `data` with the value {resultMap}.
   - Add an entry to {payload} named `label` with the value {label}.
   - Add an entry to {payload} named `path` with the value {path}.
   - Return {payload}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -456,8 +456,11 @@ If during {ExecuteSelectionSet()} a field with a non-null {fieldType} raises a
 _field error_ then that error must propagate to this entire selection set,
 either resolving to {null} if allowed or further propagated to a parent field.
 
-If this occurs, any sibling fields which have not yet executed or have not yet
-yielded a value may be cancelled to avoid unnecessary work.
+If this occurs, any defer or stream executions with a path that starts with the
+same path as the resolved {null} must not return their results to the client.
+These defer or stream executions or any sibling fields which have not yet
+executed or have not yet yielded a value may be cancelled to avoid unnecessary
+work.
 
 Note: See [Handling Field Errors](#sec-Handling-Field-Errors) for more about
 this behavior.
@@ -748,7 +751,11 @@ variableValues, parentRecord, subsequentPayloads):
     - Wait for the result of {dataExecution} on {parentRecord}.
   - If {errors} is not empty:
     - Add an entry to {payload} named `errors` with the value {errors}.
-  - Add an entry to {payload} named `data` with the value {resultMap}.
+  - If a field error was raised, causing a {null} to be propagated to
+    {responseValue}, and {objectType} is a Non-Nullable type:
+    - Add an entry to {payload} named `data` with the value {null}.
+  - Otherwise:
+    - Add an entry to {payload} named `data` with the value {resultMap}.
   - Add an entry to {payload} named `label` with the value {label}.
   - Add an entry to {payload} named `path` with the value {path}.
   - Return {payload}.
@@ -923,8 +930,12 @@ variableValues, subsequentPayloads):
     - Wait for the result of {dataExecution} on {parentRecord}.
   - If {errors} is not empty:
     - Add an entry to {payload} named `errors` with the value {errors}.
-  - Add an entry to {payload} named `items` with a list containing the value
-    {data}.
+  - If a field error was raised, causing a {null} to be propagated to {data},
+    and {innerType} is a Non-Nullable type:
+    - Add an entry to {payload} named `items` with the value {null}.
+  - Otherwise:
+    - Add an entry to {payload} named `items` with a list containing the value
+      {data}.
   - Add an entry to {payload} named `label` with the value {label}.
   - Add an entry to {payload} named `path` with the value {itemPath}.
   - Return {payload}.
@@ -1099,6 +1110,21 @@ If a `List` type wraps a `Non-Null` type, and one of the elements of that list
 resolves to {null}, then the entire list must resolve to {null}. If the `List`
 type is also wrapped in a `Non-Null`, the field error continues to propagate
 upwards.
+
+When a field error is raised inside `ExecuteDeferredFragment` or
+`ExecuteStreamField`, the defer and stream payloads act as error boundaries.
+That is, the null resulting from a `Non-Null` type cannot propagate outside of
+the boundary of the defer or stream payload.
+
+If a fragment with the `defer` directive is spread on a Non-Nullable object
+type, and a field error has caused a {null} to propagate to the associated
+object, the {null} should not propagate any further, and the associated Defer
+Payload's `data` field must be set to {null}.
+
+If the `stream` directive is present on a list field with a Non-Nullable inner
+type, and a field error has caused a {null} to propagate to the list item, the
+{null} should not propagate any further, and the associated Stream Payload's
+`item` field must be set to {null}.
 
 If all fields from the root of the request to the source of the field error
 return `Non-Null` types, then the {"data"} entry in the response should be

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -827,8 +827,8 @@ be expected to yield the value representing Yoko Ono.
 
 A {ResolveFieldGenerator} might accept the {objectType} `MusicBand`, the {field}
 {"members"}, and the {objectValue} representing Beatles. It would be expected to
-yield a iterator of values representing, John Lennon, Paul McCartney, Ringo
-Starr and George Harrison.
+yield a iterator of values representing John Lennon, Paul McCartney, Ringo Starr
+and George Harrison.
 
 ResolveFieldValue(objectType, objectValue, fieldName, argumentValues):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1156,8 +1156,11 @@ error:
 ```graphql example
 {
   birthday {
-    ... @defer {
+    ... @defer(label: "monthDefer") {
       month
+    }
+    ... @defer(label: "yearDefer") {
+      year
     }
   }
 }
@@ -1172,15 +1175,33 @@ Response 1, the initial response is sent:
 }
 ```
 
-Response 2, the defer payload is sent. The {data} entry has been set to {null},
-as this {null} as propagated as high as the error boundary will allow.
+Response 2, the defer payload for label "monthDefer" is sent. The {data} entry
+has been set to {null}, as this {null} as propagated as high as the error
+boundary will allow.
 
 ```json example
 {
   "incremental": [
     {
       "path": ["birthday"],
+      "label": "monthDefer",
       "data": null
+    }
+  ],
+  "hasNext": false
+}
+```
+
+Response 3, the defer payload for label "yearDefer" is sent. The data in this
+payload is unaffected by the previous null error.
+
+```json example
+{
+  "incremental": [
+    {
+      "path": ["birthday"],
+      "label": "yearDefer",
+      "data": { "year": "2022" }
     }
   ],
   "hasNext": false

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -381,21 +381,13 @@ YieldSubsequentPayloads(subsequentPayloads):
 - While {subsequentPayloads} is not empty:
 - If a termination signal is received:
   - For each {record} in {subsequentPayloads}:
-    - If {record} is a Stream Record:
-      - Let {iterator} be the correspondent fields on the Stream Record
-        structure.
+    - If {record} contains {iterator}:
       - Send a termination signal to {iterator}.
   - Return.
-- Let {record} be the first complete item in {subsequentPayloads}.
+- Let {record} be the first item in {subsequentPayloads} with a completed
+  {dataExecution}.
   - Remove {record} from {subsequentPayloads}.
-  - Assert: {record} must be a Deferred Fragment Record or a Stream Record.
-  - If {record} is a Deferred Fragment Record:
-    - Let {payload} be the result of running
-      {ResolveDeferredFragmentRecord(record, variableValues,
-      subsequentPayloads)}.
-  - If {record} is a Stream Record:
-    - Let {payload} be the result of running {ResolveStreamRecord(record,
-      variableValues, subsequentPayloads)}.
+  - Let {payload} be the completed result returned by {dataExecution}.
   - If {payload} is {null}:
     - If {subsequentPayloads} is empty:
       - Yield a map containing a field `hasNext` with the value {false}.
@@ -627,10 +619,9 @@ subsequentPayloads, asyncRecord, visitedFragments):
     - If {deferDirective} is defined:
       - Let {label} be the value or the variable to {deferDirective}'s {label}
         argument.
-      - Let {deferredFragmentRecord} be the result of calling
-        {CreateDeferredFragmentRecord(label, objectType, objectValue,
-        fragmentSelectionSet, path, asyncRecord)}.
-      - Append {deferredFragmentRecord} to {subsequentPayloads}.
+      - Call {ExecuteDeferredFragment(label, objectType, objectValue,
+        fragmentSelectionSet, path, variableValues, asyncRecord,
+        subsequentPayloads)}.
       - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
       {CollectFields(objectType, objectValue, fragmentSelectionSet,
@@ -653,10 +644,8 @@ subsequentPayloads, asyncRecord, visitedFragments):
         {variableValues} with the value {true}:
         - Let {label} be the value or the variable to {deferDirective}'s {label}
           argument.
-        - Let {deferredFragmentRecord} be the result of calling
-          {CreateDeferredFragmentRecord(label, objectType, objectValue,
-          fragmentSelectionSet, path, asyncRecord)}.
-        - Append {deferredFragmentRecord} to {subsequentPayloads}.
+        - Call {ExecuteDeferredFragment(label, objectType, objectValue,
+          fragmentSelectionSet, path, asyncRecord, subsequentPayloads)}.
         - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
       {CollectFields(objectType, objectValue, fragmentSelectionSet,
@@ -690,50 +679,31 @@ An Async Payload Record is either a Deferred Fragment Record or a Stream Record.
 All Async Payload Records are structures containing:
 
 - {label}: value derived from the corresponding `@defer` or `@stream` directive.
-- {parentRecord}: optionally an Async Payload Record.
+- {path}: a list of field names and indices from root to the location of the
+  corresponding `@defer` or `@stream` directive.
+- {iterator}: The underlying iterator if created from a `@stream` directive.
 - {errors}: a list of field errors encountered during execution.
 - {dataExecution}: A result that can notify when the corresponding execution has
   completed.
-- {path}: a list of field names and indices from root to the location of the
-  corresponding `@defer` or `@stream` directive.
 
-#### Deferred Fragment Record
+#### Execute Deferred Fragment
 
-Let {deferredFragmentRecord} be an inline fragment or fragment spread with
-`@defer` provided.
+ExecuteDeferredFragment(label, objectType, objectValue, fragmentSelectionSet,
+path, variableValues, parentRecord, subsequentPayloads):
 
-Deferred Fragment Record is a structure containing all the entries of Async
-Payload Record, and additionally:
-
-- {objectType}: of the {deferredFragmentRecord}.
-- {objectValue}: of the {deferredFragmentRecord}.
-- {fragmentSelectionSet}: the top level selection set of
-  {deferredFragmentRecord}.
-
-CreateDeferredFragmentRecord(label, objectType, objectValue,
-fragmentSelectionSet, path, parentRecord):
-
-- Construct a deferred fragment record based on the parameters passed in.
-- Initialize {errors} to an empty list.
-
-ResolveDeferredFragmentRecord(deferredFragmentRecord, variableValues,
-subsequentPayloads):
-
-- Let {label}, {objectType}, {objectValue}, {fragmentSelectionSet}, {path},
-  {parentRecord} be the corresponding fields in the deferred fragment record
-  structure.
+- Let {deferRecord} be an async payload record created from {label} and {path}.
+- Initialize {errors} on {deferRecord} to an empty list.
 - Let {dataExecution} be the asynchronous future value of:
   - Let {payload} be the result of {ExecuteSelectionSet(fragmentSelectionSet,
     objectType, objectValue, variableValues, path, subsequentPayloads,
-    deferredFragmentRecord)}.
+    deferRecord)}.
   - If {parentRecord} is defined:
     - Wait for the result of {dataExecution} on {parentRecord}.
+  - Add an entry to {payload} named `label` with the value {label}.
+  - Add an entry to {payload} named `path` with the value {path}.
   - Return {payload}.
 - Set {dataExecution} on {deferredFragmentRecord}.
-- Let {payload} be the result of waiting for {dataExecution}.
-- Add an entry to {payload} named `label` with the value {label}.
-- Add an entry to {payload} named `path` with the value {path}.
-- Return {payload}.
+- Append {deferRecord} to {subsequentPayloads}.
 
 ## Executing Fields
 
@@ -877,28 +847,14 @@ field, value completion iterates over the iterator until the number of items
 yield by the iterator satisfies `initialCount` specified on the `@stream`
 directive.
 
-#### Stream Record
+#### Execute Stream Field
 
-Let {streamField} be a list field with a `@stream` directive provided.
+ExecuteStreamRecord(label, iterator, index, fields, innerType, path
+streamRecord, variableValues, subsequentPayloads):
 
-A Stream Record is a structure containing all the entries of Async Payload
-Record, and additionally:
-
-- {iterator}: created by {ResolveFieldGenerator}.
-- {index}: indicating the position of the item in the complete list.
-- {fields}: the group of fields grouped by CollectFields() for {streamField}.
-- {innerType}: inner type of {streamField}'s type.
-
-CreateStreamRecord(label, iterator, index, fields, innerType, path,
-parentRecord):
-
-- Construct a stream record based on the parameters passed in.
-- Initialize {errors} to an empty list.
-
-ResolveStreamRecord(streamRecord, variableValues, subsequentPayloads):
-
-- Let {label}, {parentRecord}, {iterator}, {index}, {path}, {fields},
-  {innerType} be the correspondent fields on the Stream Record structure.
+- Let {streamRecord} be an async payload record created from {label}, {path},
+  and {iterator}.
+- Initialize {errors} on {streamRecord} to an empty list.
 - Let {indexPath} be {path} with {index} appended.
 - Let {dataExecution} be the asynchronous future value of:
   - Wait for the next item from {iterator}.
@@ -908,17 +864,15 @@ ResolveStreamRecord(streamRecord, variableValues, subsequentPayloads):
   - Let {payload} be the result of calling {CompleteValue(innerType, fields,
     item, variableValues, indexPath, subsequentPayloads, parentRecord)}.
   - Increment {index}.
-  - Let {nextStreamRecord} be the result of calling {CreateStreamRecord(label,
-    iterator, index, fields, innerType, path, streamRecord)}.
-  - Append {nextStreamRecord} to {subsequentPayloads}.
+  - Call {ExecuteStreamRecord(label, iterator, index, fields, innerType, path,
+    streamRecord, variableValues, subsequentPayloads)}.
   - If {parentRecord} is defined:
     - Wait for the result of {dataExecution} on {parentRecord}.
+  - Add an entry to {payload} named `label` with the value {label}.
+  - Add an entry to {payload} named `path` with the value {indexPath}.
   - Return {payload}.
 - Set {dataExecution} on {streamRecord}.
-- Let {payload} be the result of waiting for {dataExecution}.
-- Add an entry to {payload} named `label` with the value {label}.
-- Add an entry to {payload} named `path` with the value {indexPath}.
-- Return {payload}.
+- Append {streamRecord} to {subsequentPayloads}.
 
 CompleteValue(fieldType, fields, result, variableValues, path,
 subsequentPayloads, asyncRecord):
@@ -956,9 +910,8 @@ subsequentPayloads, asyncRecord):
         - Increment {index}.
       - If {streamDirective} was provided and {index} is greater than or equal
         to {initialCount}:
-        - Let {streamRecord} be the result of calling {CreateStreamRecord(label,
-          result, index, fields, innerType, path, asyncRecord)}.
-        - Append {streamRecord} to {subsequentPayloads}.
+        - Call {ExecuteStreamRecord(label, result, index, fields, innerType,
+          path, asyncRecord, subsequentPayloads)}.
         - Let {result} be {initialItems}.
         - Exit while loop.
     - Return {initialItems}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -951,25 +951,29 @@ streamRecord, variableValues, subsequentPayloads):
     - Set {isCompletedIterator} to {true} on {streamRecord}.
     - Return {null}.
   - Let {payload} be an unordered map.
-  - Let {item} be the item retrieved from {iterator}.
-  - Let {data} be the result of calling {CompleteValue(innerType, fields, item,
-    variableValues, itemPath, subsequentPayloads, parentRecord)}.
-  - Append any encountered field errors to {errors}.
-  - Increment {index}.
-  - Call {ExecuteStreamField(label, iterator, index, fields, innerType, path,
-    streamRecord, variableValues, subsequentPayloads)}.
-  - If {parentRecord} is defined:
-    - Wait for the result of {dataExecution} on {parentRecord}.
-  - If {errors} is not empty:
-    - Add an entry to {payload} named `errors` with the value {errors}.
-  - If a field error was raised, causing a {null} to be propagated to {data},
-    and {innerType} is a Non-Nullable type:
+  - If an item is not retrieved because of an error:
+    - Append the encountered error to {errors}.
     - Add an entry to {payload} named `items` with the value {null}.
   - Otherwise:
-    - Add an entry to {payload} named `items` with a list containing the value
-      {data}.
+    - Let {item} be the item retrieved from {iterator}.
+    - Let {data} be the result of calling {CompleteValue(innerType, fields,
+      item, variableValues, itemPath, subsequentPayloads, parentRecord)}.
+    - Append any encountered field errors to {errors}.
+    - Increment {index}.
+    - Call {ExecuteStreamField(label, iterator, index, fields, innerType, path,
+      streamRecord, variableValues, subsequentPayloads)}.
+    - If a field error was raised, causing a {null} to be propagated to {data},
+      and {innerType} is a Non-Nullable type:
+      - Add an entry to {payload} named `items` with the value {null}.
+    - Otherwise:
+      - Add an entry to {payload} named `items` with a list containing the value
+        {data}.
+  - If {errors} is not empty:
+    - Add an entry to {payload} named `errors` with the value {errors}.
   - Add an entry to {payload} named `label` with the value {label}.
   - Add an entry to {payload} named `path` with the value {itemPath}.
+  - If {parentRecord} is defined:
+    - Wait for the result of {dataExecution} on {parentRecord}.
   - Return {payload}.
 - Set {dataExecution} on {streamRecord}.
 - Append {streamRecord} to {subsequentPayloads}.
@@ -1009,7 +1013,8 @@ subsequentPayloads, asyncRecord):
         path, asyncRecord, subsequentPayloads)}.
       - Return {items}.
     - Otherwise:
-      - Retrieve the next item from {result} via the {iterator}.
+      - Wait for the next item from {result} via the {iterator}.
+      - If an item is not retrieved because of an error, raise a _field error_.
       - Let {resultItem} be the item retrieved from {result}.
       - Let {itemPath} be {path} with {index} appended.
       - Let {resolvedItem} be the result of calling {CompleteValue(innerType,

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -481,7 +481,7 @@ raises a field error:
 ```
 
 In this case, only one response should be sent. The async payload record
-associated with the `@defer` directive should be removed and it's execution may
+associated with the `@defer` directive should be removed and its execution may
 be cancelled.
 
 ```json example

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -931,7 +931,7 @@ yielded items satisfies `initialCount` specified on the `@stream` directive.
 #### Execute Stream Field
 
 ExecuteStreamField(label, iterator, index, fields, innerType, path,
-streamRecord, variableValues, subsequentPayloads):
+parentRecord, variableValues, subsequentPayloads):
 
 - Let {streamRecord} be an async payload record created from {label}, {path},
   and {iterator}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -144,10 +144,10 @@ ExecuteQuery(query, schema, variableValues, initialValue):
 - If {subsequentPayloads} is empty:
   - Return an unordered map containing {data} and {errors}.
 - If {subsequentPayloads} is not empty:
-  - Let {intialResponse} be an unordered map containing {data}, {errors}, and an
-    entry named {hasNext} with the value {true}.
+  - Let {initialResponse} be an unordered map containing {data}, {errors}, and
+    an entry named {hasNext} with the value {true}.
   - Let {iterator} be the result of running
-    {YieldSubsequentPayloads(intialResponse, subsequentPayloads)}.
+    {YieldSubsequentPayloads(initialResponse, subsequentPayloads)}.
   - For each {payload} yielded by {iterator}:
     - If a termination signal is received:
       - Send a termination signal to {iterator}.
@@ -178,10 +178,10 @@ ExecuteMutation(mutation, schema, variableValues, initialValue):
 - If {subsequentPayloads} is empty:
   - Return an unordered map containing {data} and {errors}.
 - If {subsequentPayloads} is not empty:
-  - Let {intialResponse} be an unordered map containing {data}, {errors}, and an
-    entry named {hasNext} with the value {true}.
+  - Let {initialResponse} be an unordered map containing {data}, {errors}, and
+    an entry named {hasNext} with the value {true}.
   - Let {iterator} be the result of running
-    {YieldSubsequentPayloads(intialResponse, subsequentPayloads)}.
+    {YieldSubsequentPayloads(initialResponse, subsequentPayloads)}.
   - For each {payload} yielded by {iterator}:
     - If a termination signal is received:
       - Send a termination signal to {iterator}.
@@ -341,10 +341,10 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 - If {subsequentPayloads} is empty:
   - Return an unordered map containing {data} and {errors}.
 - If {subsequentPayloads} is not empty:
-  - Let {intialResponse} be an unordered map containing {data}, {errors}, and an
-    entry named {hasNext} with the value {true}.
+  - Let {initialResponse} be an unordered map containing {data}, {errors}, and
+    an entry named {hasNext} with the value {true}.
   - Let {iterator} be the result of running
-    {YieldSubsequentPayloads(intialResponse, subsequentPayloads)}.
+    {YieldSubsequentPayloads(initialResponse, subsequentPayloads)}.
   - For each {payload} yielded by {iterator}:
     - If a termination signal is received:
       - Send a termination signal to {iterator}.
@@ -372,7 +372,7 @@ If an operation contains subsequent payload records resulting from `@stream` or
 `@defer` directives, the {YieldSubsequentPayloads} algorithm defines how the
 payloads should be processed.
 
-YieldSubsequentPayloads(intialResponse, subsequentPayloads):
+YieldSubsequentPayloads(initialResponse, subsequentPayloads):
 
 - Let {initialRecords} be any items in {subsequentPayloads} with a completed
   {dataExecution}.
@@ -384,9 +384,9 @@ YieldSubsequentPayloads(intialResponse, subsequentPayloads):
   - Let {payload} be the completed result returned by {dataExecution}.
   - Append {payload} to {initialIncremental}.
 - If {initialIncremental} is not empty:
-  - Add an entry to {intialResponse} named `incremental` containing the value
+  - Add an entry to {initialResponse} named `incremental` containing the value
     {incremental}.
-- Yield {intialResponse}.
+- Yield {initialResponse}.
 - While {subsequentPayloads} is not empty:
 - If a termination signal is received:
   - For each {record} in {subsequentPayloads}:
@@ -555,7 +555,7 @@ A correct executor must generate the following result for that selection set:
 ```
 
 When subsections contain a `@stream` or `@defer` directive, these subsections
-are no longer required to execute serially. Exeuction of the deferred or
+are no longer required to execute serially. Execution of the deferred or
 streamed sections of the subsection may be executed in parallel, as defined in
 {ExecuteStreamField} and {ExecuteDeferredFragment}.
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -416,7 +416,7 @@ subsequentPayloads, asyncRecord):
 - If {path} is not provided, initialize it to an empty list.
 - If {subsequentPayloads} is not provided, initialize it to the empty set.
 - Let {groupedFieldSet} and {deferredGroupedFieldsList} be the result of
-  {CollectFields(objectType, selectionSet, variableValues, path, asyncRecord)}.
+  {CollectFields(objectType, selectionSet, variableValues)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -648,8 +648,8 @@ The depth-first-search order of the field groups produced by {CollectFields()}
 is maintained through execution, ensuring that fields appear in the executed
 response in a stable and predictable order.
 
-CollectFields(objectType, selectionSet, variableValues, path, asyncRecord,
-visitedFragments, deferredGroupedFieldsList):
+CollectFields(objectType, selectionSet, variableValues, visitedFragments,
+deferredGroupedFieldsList):
 
 - If {visitedFragments} is not provided, initialize it to the empty set.
 - Initialize {groupedFields} to an empty ordered map of lists.
@@ -696,14 +696,14 @@ visitedFragments, deferredGroupedFieldsList):
       - Let {label} be the value or the variable to {deferDirective}'s {label}
         argument.
       - Let {deferredGroupedFields} be the result of calling
-        {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
-        asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
+        {CollectFields(objectType, fragmentSelectionSet, variableValues,
+        visitedFragments, deferredGroupedFieldsList)}.
       - Append a record containing {label} and {deferredGroupedFields} to
         {deferredGroupedFieldsList}.
       - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
-      asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
+      {CollectFields(objectType, fragmentSelectionSet, variableValues,
+      visitedFragments, deferredGroupedFieldsList)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
@@ -726,21 +726,21 @@ visitedFragments, deferredGroupedFieldsList):
       - Let {label} be the value or the variable to {deferDirective}'s {label}
         argument.
       - Let {deferredGroupedFields} be the result of calling
-        {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
-        asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
+        {CollectFields(objectType, fragmentSelectionSet, variableValues,
+        visitedFragments, deferredGroupedFieldsList)}.
       - Append a record containing {label} and {deferredGroupedFields} to
         {deferredGroupedFieldsList}.
       - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues, path,
-      asyncRecord, visitedFragments, deferredGroupedFieldsList)}.
+      {CollectFields(objectType, fragmentSelectionSet, variableValues,
+      visitedFragments, deferredGroupedFieldsList)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
       - Let {groupForResponseKey} be the list in {groupedFields} for
         {responseKey}; if no such list exists, create it as an empty list.
       - Append all items in {fragmentGroup} to {groupForResponseKey}.
-- Return {groupedFields} and {deferredGroupedFieldsList}.
+- Return {groupedFields}, {deferredGroupedFieldsList} and {visitedFragments}.
 
 Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
 directives may be applied in either order since they apply commutatively.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1002,7 +1002,7 @@ subsequentPayloads, asyncRecord):
   - Let {iterator} be an iterator for {result}.
   - Let {items} be an empty list.
   - Let {index} be zero.
-    - While {result} is not closed:
+  - While {result} is not closed:
     - If {streamDirective} is defined and {index} is greater than or equal to
       {initialCount}:
       - Call {ExecuteStreamField(label, iterator, index, fields, innerType,
@@ -1015,9 +1015,9 @@ subsequentPayloads, asyncRecord):
       - Let {resolvedItem} be the result of calling {CompleteValue(innerType,
         fields, resultItem, variableValues, itemPath, subsequentPayloads,
         asyncRecord)}.
-      - Append {resolvedItem} to {initialItems}.
+      - Append {resolvedItem} to {items}.
       - Increment {index}.
-    - Return {items}.
+  - Return {items}.
 - If {fieldType} is a Scalar or Enum type:
   - Return the result of {CoerceResult(fieldType, result)}.
 - If {fieldType} is an Object, Interface, or Union type:

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -601,7 +601,7 @@ subsequentPayloads, asyncRecord, visitedFragments):
     - Append {selection} to the {groupForResponseKey}.
   - If {selection} is a {FragmentSpread}:
     - Let {fragmentSpreadName} be the name of {selection}.
-    - If {fragmentSpreadName} provides the directive `@defer` and it's {if}
+    - If {fragmentSpreadName} provides the directive `@defer` and its {if}
       argument is {true} or is a variable in {variableValues} with the value
       {true}:
       - Let {deferDirective} be that directive.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -627,8 +627,8 @@ asyncRecord, visitedFragments, deferredGroupedFieldsList):
   - If {selection} is a {FragmentSpread}:
     - Let {fragmentSpreadName} be the name of {selection}.
     - If {fragmentSpreadName} provides the directive `@defer` and its {if}
-      argument is {true} or is a variable in {variableValues} with the value
-      {true}:
+      argument is not {false} and is not a variable in {variableValues} with the
+      value {false}:
       - Let {deferDirective} be that directive.
     - If {deferDirective} is not defined:
       - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
@@ -668,19 +668,20 @@ asyncRecord, visitedFragments, deferredGroupedFieldsList):
       fragmentType)} is false, continue with the next {selection} in
       {selectionSet}.
     - Let {fragmentSelectionSet} be the top-level selection set of {selection}.
-    - If {InlineFragment} provides the directive `@defer`, let {deferDirective}
-      be that directive.
-      - If {deferDirective}'s {if} argument is {true} or is a variable in
-        {variableValues} with the value {true}:
-        - Let {label} be the value or the variable to {deferDirective}'s {label}
-          argument.
-        - Let {deferredGroupedFields} be the result of calling
-          {CollectFields(objectType, objectValue, fragmentSelectionSet,
-          variableValues, path, asyncRecord, visitedFragments,
-          deferredGroupedFieldsList)}.
-        - Append a record containing {label} and {deferredGroupedFields} to
-          {deferredGroupedFieldsList}.
-        - Continue with the next {selection} in {selectionSet}.
+    - If {InlineFragment} provides the directive `@defer` and its {if} argument
+      is not {false} and is not a variable in {variableValues} with the value
+      {false}:
+      - Let {deferDirective} be that directive.
+    - If {deferDirective} is defined:
+      - Let {label} be the value or the variable to {deferDirective}'s {label}
+        argument.
+      - Let {deferredGroupedFields} be the result of calling
+        {CollectFields(objectType, objectValue, fragmentSelectionSet,
+        variableValues, path, asyncRecord, visitedFragments,
+        deferredGroupedFieldsList)}.
+      - Append a record containing {label} and {deferredGroupedFields} to
+        {deferredGroupedFieldsList}.
+      - Continue with the next {selection} in {selectionSet}.
     - Let {fragmentGroupedFieldSet} be the result of calling
       {CollectFields(objectType, objectValue, fragmentSelectionSet,
       variableValues, path, asyncRecord, visitedFragments,
@@ -945,9 +946,9 @@ subsequentPayloads, asyncRecord):
   - If {result} is an iterator:
     - Let {field} be the first entry in {fields}.
     - Let {innerType} be the inner type of {fieldType}.
-    - If {field} provides the directive `@stream` and its {if} argument is
-      {true} or is a variable in {variableValues} with the value {true} and
-      {innerType} is the outermost return type of the list type defined for
+    - If {field} provides the directive `@stream` and its {if} argument is not
+      {false} and is not a variable in {variableValues} with the value {false}
+      and {innerType} is the outermost return type of the list type defined for
       {field}:
       - Let {streamDirective} be that directive.
     - Let {initialCount} be the value or variable provided to

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -41,8 +41,8 @@ operations that return a single response map.
 
 The GraphQL server may determine there are no more values in the response stream
 after a previous value with `hasNext` equal to `true` has been emitted. In this
-case the last value in the response stream should be a map without `data`,
-`label`, and `path` entries, and a `hasNext` entry with a value of `false`.
+case the last value in the response stream should be a map without `data` and
+`incremental` entries, and a `hasNext` entry with a value of `false`.
 
 The response map may also contain an entry with key `extensions`. This entry, if
 set, must have a map as its value. This entry is reserved for implementors to
@@ -326,7 +326,10 @@ Response 2, contains the defer payload and the first stream payload.
 }
 ```
 
-Response 3, contains an additional stream payload.
+Response 3, contains the final stream payload. In this example, the underlying
+iterator does not close synchronously so {hasNext} is set to {true}. If this
+iterator did close synchronously, {hasNext} would be set to {true} and this
+would be the final response.
 
 ```json example
 {
@@ -341,8 +344,9 @@ Response 3, contains an additional stream payload.
 }
 ```
 
-Response 4, contains no incremental payloads, {hasNext} set to {false} indicates
-the end of the stream.
+Response 4, contains no incremental payloads. {hasNext} set to {false} indicates
+the end of the response stream. This response is sent when the underlying
+iterator of the `films` field closes.
 
 ```json example
 {

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -39,10 +39,10 @@ all but the last response in the stream. The value of this entry is `false` for
 the last response of the stream. This entry must not be present for GraphQL
 operations that return a single response map.
 
-The GraphQL server may determine there are no more values in the response stream
-after a previous value with `hasNext` equal to `true` has been emitted. In this
-case the last value in the response stream should be a map without `data` and
-`incremental` entries, and a `hasNext` entry with a value of `false`.
+The GraphQL service may determine there are no more values in the response
+stream after a previous value with `hasNext` equal to `true` has been emitted.
+In this case the last value in the response stream should be a map without
+`data` and `incremental` entries, and a `hasNext` entry with a value of `false`.
 
 The response map may also contain an entry with key `extensions`. This entry, if
 set, must have a map as its value. This entry is reserved for implementors to

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -24,10 +24,10 @@ validation error, this entry must not be present.
 
 When the response of the GraphQL operation is an event stream, the first value
 will be the initial response. All subsequent values may contain `label` and
-`path` entries. These two entries are used by clients to identify the the
-`@defer` or `@stream` directive from the GraphQL operation that triggered this
-value to be returned by the event stream. The combination of these two entries
-must be unique across all values returned by the event stream.
+`path` entries. These two entries are used by clients to identify the `@defer`
+or `@stream` directive from the GraphQL operation that triggered this value to
+be returned by the event stream. The combination of these two entries must be
+unique across all values returned by the event stream.
 
 If the response of the GraphQL operation is an event stream, each response map
 must contain an entry with key `hasNext`. The value of this entry is `true` for

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -328,7 +328,7 @@ Response 2, contains the defer payload and the first stream payload.
 
 Response 3, contains the final stream payload. In this example, the underlying
 iterator does not close synchronously so {hasNext} is set to {true}. If this
-iterator did close synchronously, {hasNext} would be set to {true} and this
+iterator did close synchronously, {hasNext} would be set to {false} and this
 would be the final response.
 
 ```json example

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -43,7 +43,9 @@ and `path` entries, and a `hasNext` entry with a value of `false`.
 The response map may also contain an entry with key `extensions`. This entry, if
 set, must have a map as its value. This entry is reserved for implementors to
 extend the protocol however they see fit, and hence there are no additional
-restrictions on its contents.
+restrictions on its contents. When the response of the GraphQL operation is an
+event stream, implementors may send subsequent payloads containing only
+`hasNext` and `extensions` entries.
 
 To ensure future changes to the protocol do not break existing services and
 clients, the top level response map must not contain any entries other than the

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -30,7 +30,8 @@ The `label` and `path` entries on Defer and Stream responses are used by clients
 to identify the `@defer` or `@stream` directive from the GraphQL operation that
 triggered this response to be included in an `incremental` entry on a value
 returned by the event stream. When a label is provided, the combination of these
-two entries will be unique across all values returned by the event stream.
+two entries will be unique across all Defer and Stream responses returned in the
+event stream.
 
 If the response of the GraphQL operation is an event stream, each response map
 must contain an entry with key `hasNext`. The value of this entry is `true` for

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -26,8 +26,8 @@ When the response of the GraphQL operation is an event stream, the first value
 will be the initial response. All subsequent values may contain `label` and
 `path` entries. These two entries are used by clients to identify the `@defer`
 or `@stream` directive from the GraphQL operation that triggered this value to
-be returned by the event stream. The combination of these two entries must be
-unique across all values returned by the event stream.
+be returned by the event stream. When a label is provided, the combination of
+these two entries will be unique across all values returned by the event stream.
 
 If the response of the GraphQL operation is an event stream, each response map
 must contain an entry with key `hasNext`. The value of this entry is `true` for

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -63,9 +63,9 @@ of the query root operation type; if the operation was a mutation, this output
 will be an object of the mutation root operation type.
 
 If the result of the operation is an event stream, the `data` entry in
-subsequent values will be an object of the type of a particular field in the
-GraphQL result. The adjacent `path` field will contain the path segments of the
-field this data is associated with.
+subsequent values will be of the type of a particular field in the GraphQL
+result. The adjacent `path` field will contain the path segments of the field
+this data is associated with.
 
 If an error was raised before execution begins, the `data` entry should not be
 present in the result.

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -24,13 +24,13 @@ validation error, this entry must not be present.
 
 When the response of the GraphQL operation is an event stream, the first value
 will be the initial response. All subsequent values may contain an `incremental`
-entry, containing a list of Defer or Stream responses.
+entry, containing a list of Defer or Stream payloads.
 
-The `label` and `path` entries on Defer and Stream responses are used by clients
+The `label` and `path` entries on Defer and Stream payloads are used by clients
 to identify the `@defer` or `@stream` directive from the GraphQL operation that
 triggered this response to be included in an `incremental` entry on a value
 returned by the event stream. When a label is provided, the combination of these
-two entries will be unique across all Defer and Stream responses returned in the
+two entries will be unique across all Defer and Stream payloads returned in the
 event stream.
 
 If the response of the GraphQL operation is an event stream, each response map
@@ -49,7 +49,7 @@ set, must have a map as its value. This entry is reserved for implementors to
 extend the protocol however they see fit, and hence there are no additional
 restrictions on its contents. When the response of the GraphQL operation is an
 event stream, implementors may send subsequent payloads containing only
-`hasNext` and `extensions` entries. Defer and Stream responses may also contain
+`hasNext` and `extensions` entries. Defer and Stream payloads may also contain
 an entry with the key `extensions`, also reserved for implementors to extend the
 protocol however they see fit.
 
@@ -267,38 +267,38 @@ discouraged.
 ### Incremental
 
 The `incremental` entry in the response is a non-empty list of Defer or Stream
-responses. If the response of the GraphQL operation is an event stream, this
+payloads. If the response of the GraphQL operation is an event stream, this
 field may appear on both the initial and subsequent values.
 
-#### Stream response
+#### Stream payload
 
-A stream response is a map that may appear as an item in the `incremental` entry
-of a response. A stream response is the result of an associated `@stream`
-directive in the operation. A stream response must contain `items` and `path`
+A stream payload is a map that may appear as an item in the `incremental` entry
+of a response. A stream payload is the result of an associated `@stream`
+directive in the operation. A stream payload must contain `items` and `path`
 entries and may contain `label`, `errors`, and `extensions` entries.
 
 ##### Items
 
-The `items` entry in a stream response is a list of results from the execution
-of the associated @stream directive. This output will be a list of the same type
-of the field with the associated `@stream` directive. If `items` is set to
-`null`, it indicates that an error has caused a `null` to bubble up to a field
-higher than the list field with the associated `@stream` directive.
+The `items` entry in a stream payload is a list of results from the execution of
+the associated @stream directive. This output will be a list of the same type of
+the field with the associated `@stream` directive. If `items` is set to `null`,
+it indicates that an error has caused a `null` to bubble up to a field higher
+than the list field with the associated `@stream` directive.
 
-#### Defer response
+#### Defer payload
 
-A defer response is a map that may appear as an item in the `incremental` entry
-of a response. A defer response is the result of an associated `@defer`
-directive in the operation. A defer response must contain `data` and `path`
-entries and may contain `label`, `errors`, and `extensions` entries.
+A defer payload is a map that may appear as an item in the `incremental` entry
+of a response. A defer payload is the result of an associated `@defer` directive
+in the operation. A defer payload must contain `data` and `path` entries and may
+contain `label`, `errors`, and `extensions` entries.
 
 ##### Data
 
-The `data` entry in a Defer response will be of the type of a particular field
-in the GraphQL result. The adjacent `path` field will contain the path segments
-of the field this data is associated with. If `data` is set to `null`, it
-indicates that an error has caused a `null` to bubble up to a field higher than
-the field that contains the fragment with the associated `@defer` directive.
+The `data` entry in a Defer payload will be of the type of a particular field in
+the GraphQL result. The adjacent `path` field will contain the path segments of
+the field this data is associated with. If `data` is set to `null`, it indicates
+that an error has caused a `null` to bubble up to a field higher than the field
+that contains the fragment with the associated `@defer` directive.
 
 #### Path
 
@@ -310,7 +310,7 @@ indices should be 0-indexed integers. If the path is associated to an aliased
 field, the path should use the aliased name, since it represents a path in the
 response, not in the request.
 
-When the `path` field is present on a Stream response, it indicates that the
+When the `path` field is present on a Stream payload, it indicates that the
 `items` field represents the partial result of the list field containing the
 corresponding `@stream` directive. All but the non-final path segments must
 refer to the location of the list field containing the corresponding `@stream`
@@ -319,7 +319,7 @@ integer indicates that this result is set at a range, where the beginning of the
 range is at the index of this integer, and the length of the range is the length
 of the data.
 
-When the `path` field is present on a Defer response, it indicates that the
+When the `path` field is present on a Defer payload, it indicates that the
 `data` field represents the result of the fragment containing the corresponding
 `@defer` directive. The path segments must point to the location of the result
 of the field containing the associated `@defer` directive.
@@ -329,7 +329,7 @@ field which experienced the error.
 
 #### Label
 
-Stream and Defer responses may contain a string field `label`. This `label` is
+Stream and Defer payloads may contain a string field `label`. This `label` is
 the same label passed to the `@defer` or `@stream` directive associated with the
 response. This allows clients to identify which `@defer` or `@stream` directive
 is associated with this value. `label` will not be present if the corresponding

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -36,7 +36,7 @@ in the response stream.
 If the response of the GraphQL operation is a response stream, each response map
 must contain an entry with key `hasNext`. The value of this entry is `true` for
 all but the last response in the stream. The value of this entry is `false` for
-the last response of the stream. This entry is not required for GraphQL
+the last response of the stream. This entry must not be present for GraphQL
 operations that return a single response map.
 
 The GraphQL server may determine there are no more values in the response stream

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -10,7 +10,7 @@ the case that any _field error_ was raised on a field and was replaced with
 
 ## Response Format
 
-A response to a GraphQL request must be a map or an event stream of maps.
+A response to a GraphQL request must be a map or a response stream of maps.
 
 If the request raised any errors, the response map must contain an entry with
 key `errors`. The value of this entry is described in the "Errors" section. If
@@ -22,33 +22,33 @@ key `data`. The value of this entry is described in the "Data" section. If the
 request failed before execution, due to a syntax error, missing information, or
 validation error, this entry must not be present.
 
-When the response of the GraphQL operation is an event stream, the first value
+When the response of the GraphQL operation is a response stream, the first value
 will be the initial response. All subsequent values may contain an `incremental`
 entry, containing a list of Defer or Stream payloads.
 
 The `label` and `path` entries on Defer and Stream payloads are used by clients
 to identify the `@defer` or `@stream` directive from the GraphQL operation that
 triggered this response to be included in an `incremental` entry on a value
-returned by the event stream. When a label is provided, the combination of these
-two entries will be unique across all Defer and Stream payloads returned in the
-event stream.
+returned by the response stream. When a label is provided, the combination of
+these two entries will be unique across all Defer and Stream payloads returned
+in the response stream.
 
-If the response of the GraphQL operation is an event stream, each response map
+If the response of the GraphQL operation is a response stream, each response map
 must contain an entry with key `hasNext`. The value of this entry is `true` for
 all but the last response in the stream. The value of this entry is `false` for
 the last response of the stream. This entry is not required for GraphQL
 operations that return a single response map.
 
-The GraphQL server may determine there are no more values in the event stream
+The GraphQL server may determine there are no more values in the response stream
 after a previous value with `hasNext` equal to `true` has been emitted. In this
-case the last value in the event stream should be a map without `data`, `label`,
-and `path` entries, and a `hasNext` entry with a value of `false`.
+case the last value in the response stream should be a map without `data`,
+`label`, and `path` entries, and a `hasNext` entry with a value of `false`.
 
 The response map may also contain an entry with key `extensions`. This entry, if
 set, must have a map as its value. This entry is reserved for implementors to
 extend the protocol however they see fit, and hence there are no additional
-restrictions on its contents. When the response of the GraphQL operation is an
-event stream, implementors may send subsequent payloads containing only
+restrictions on its contents. When the response of the GraphQL operation is a
+response stream, implementors may send subsequent response maps containing only
 `hasNext` and `extensions` entries. Defer and Stream payloads may also contain
 an entry with the key `extensions`, also reserved for implementors to extend the
 protocol however they see fit.
@@ -267,7 +267,7 @@ discouraged.
 ### Incremental
 
 The `incremental` entry in the response is a non-empty list of Defer or Stream
-payloads. If the response of the GraphQL operation is an event stream, this
+payloads. If the response of the GraphQL operation is a response stream, this
 field may appear on both the initial and subsequent values.
 
 #### Stream payload

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -134,7 +134,7 @@ If an error can be associated to a particular field in the GraphQL result, it
 must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
 `null` result is intentional or caused by a runtime error. The value of this
-field is described in the "Path" section.
+field is described in the [Path](#sec-Path) section.
 
 For example, if fetching one of the friends' names fails in the following
 operation:

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -12,9 +12,9 @@ the case that any _field error_ was raised on a field and was replaced with
 
 A response to a GraphQL request must be a map or an event stream of maps.
 
-If the operation encountered any errors, the response map must contain an entry
-with key `errors`. The value of this entry is described in the "Errors" section.
-If the request completed without raising any errors, this entry must not be
+If the request raised any errors, the response map must contain an entry with
+key `errors`. The value of this entry is described in the "Errors" section. If
+the request completed without raising any errors, this entry must not be
 present.
 
 If the request included execution, the response map must contain an entry with


### PR DESCRIPTION
supersedes  #1026 

This version sets up an Incremental Publisher Record that includes:
(a) an Execution Event Queue input stream on the and
(b) a Subsequent Result output stream.

No mutations happen outside the algorithms that define any records.

With the following caveats:
1. The event queue is not considered to be "mutated" when different sub-algorithms push events into it.
2. The `CreateIncrementalPublisher()` algorithm is where the magic happens, a long algorithm where the Execution Event Handler and lazily executed Subsequent Result stream are managed concurrently. To increase readability, several subprocedures/macros/inner functions are defined that have access to the variables defined within the entire algorithm.