### PR TITLE
Add a note about omitting introspection type definitions

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -224,7 +224,7 @@ When representing a GraphQL schema using the type system definition language the
 _introspection type system definitions_ may be omitted for brevity.
 
 When introspecting a GraphQL service all provided _introspection type system
-definitions_ must be included in the set of returned directives.
+definitions_ must be included in the set of returned types.
 
 ### The \_\_Schema Type
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -220,6 +220,12 @@ enum __DirectiveLocation {
 }
 ```
 
+When representing a GraphQL schema using the type system definition language the
+_introspection type system definitions_ may be omitted for brevity.
+
+When introspecting a GraphQL service all provided _introspection type system
+definitions_, must be included in the set of returned directives.
+
 ### The \_\_Schema Type
 
 The `__Schema` type is returned from the `__schema` meta-field and provides all

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -224,7 +224,7 @@ When representing a GraphQL schema using the type system definition language the
 _introspection type system definitions_ may be omitted for brevity.
 
 When introspecting a GraphQL service all provided _introspection type system
-definitions_, must be included in the set of returned directives.
+definitions_ must be included in the set of returned directives.
 
 ### The \_\_Schema Type
 


### PR DESCRIPTION
There is a similar note 

[for scalars](https://spec.graphql.org/draft/#sel-GAHXJHABAB_D4G):

```
When representing a GraphQL schema using the type system definition language, all built-in scalars 
must be omitted for brevity.
```

[for directives](https://spec.graphql.org/draft/#sel-FAHnBPLCAACCcooU):

```
When representing a GraphQL schema using the type system definition language any built-in directive 
may be omitted for brevity.
```

I didn't find anything for introspection types.