### PR TITLE
[WIP] Non-nullable error boundary - interrobang

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1238,6 +1238,12 @@ NonNullType :
 
 - NamedType !
 - ListType !
+- NonNullErrorBoundaryType
+
+NonNullErrorBoundaryType :
+
+- NamedType ! ?
+- ListType ! ?
 
 GraphQL describes the types of data expected by arguments and variables. Input
 types may be lists of another input type, or a non-null variant of any other

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1787,11 +1787,16 @@ Following are examples of input coercion with various list types and values:
 ## Non-Null
 
 By default, all types in GraphQL are nullable; the {null} value is a valid
-response for all of the above types. To declare a type that disallows null, the
-GraphQL Non-Null type can be used. This type wraps an underlying type, and this
-type acts identically to that wrapped type, with the exception that {null} is
-not a valid response for the wrapping type. A trailing exclamation mark is used
-to denote a field that uses a Non-Null type like this: `name: String!`.
+response for all of the above types. To declare a type that is not expected to
+be null, the GraphQL Non-Null type can be used. This type wraps an underlying
+type, and this type acts identically to that wrapped type, with the exception
+that {null} is not an expected response for the wrapping type. A Non-Null type
+may be an error-boundary in which case the response is allowed to be {null}, but
+only with an associated error in the errors array; otherwise {null} is not a
+valid value. A trailing exclamation mark is used to denote a field that uses a
+Non-Null type like this: `name: String!`, and an additional `?` is used to
+indicate that this Non-Null type is an error boundary, like this:
+`name: String!?`.
 
 **Nullable vs. Optional**
 
@@ -1810,8 +1815,10 @@ always optional and non-null types are always required.
 In all of the above result coercions, {null} was considered a valid value. To
 coerce the result of a Non-Null type, the coercion of the wrapped type should be
 performed. If that result was not {null}, then the result of coercing the
-Non-Null type is that result. If that result was {null}, then a _field error_
-must be raised.
+Non-Null type is that result. If that result was {null}, then: if the Non-Null
+is an error boundary then the result of coercing the Non-Null type is {null} but
+a _field error_ must be collected; otherwise if the Non-Null is not an error
+boundary then a _field error_ must be raised.
 
 Note: When a _field error_ is raised on a non-null value, the error propagates
 to the parent field. For more information on this process, see

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -674,7 +674,10 @@ CompleteValue(fieldType, fields, result, variableValues):
   - Let {innerType} be the inner type of {fieldType}.
   - Let {completedResult} be the result of calling {CompleteValue(innerType,
     fields, result, variableValues)}.
-  - If {completedResult} is {null}, raise a _field error_.
+  - If {completedResult} is {null}:
+    - If {fieldType} is an error boundary, collect a _field error_ and return
+      {null}.
+    - Otherwise, raise a _field error_.
   - Return {completedResult}.
 - If {result} is {null} (or another internal value similar to {null} such as
   {undefined}), return {null}.


### PR DESCRIPTION
Inspired by @captbaritone's True Nullability Schema discussion (https://github.com/graphql/graphql-wg/discussions/1394) and following @fotoetienne's excellent talk at GraphQLConf, and trying to "use the things we already have in new ways" I am proposing that we introduce a new non-nullable variant, the "Non-Null error boundary" type, represented via interrobang mark `!?`. This will be a `Non-Null` type in the current sense, but with an extra property of `__Type.isErrorBoundary: true`

Critically, this type would "evaporate" for legacy clients, appearing the same as a nullable field. (This is enabled via the `includeErrorBoundaries` argument to the `__Field.type` field, which defaults to `false`.)

The main difference in this type is that it will never be `null` _unless_ there is an error in the `errors` array. So it's like a hybrid between the nullability default, and Non-Null. A middle ground.

I have _not_ made all the spec edits for this, I'm just feeling out the problem space right now. "Collecting" the field error (rather than _throwing_ it) is going to need some careful wording... but that's a problem for when we come to formalize it.