### PR TITLE
Relax non-inclusion of schema definition.

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -221,7 +221,7 @@ _root operation type_ uses its respective _default root type name_ and no other
 type uses any _default root type name_.
 
 Likewise, when representing a GraphQL schema using the type system definition
-language, a schema definition should be omitted if each _root operation type_
+language, a schema definition may be omitted if each _root operation type_
 uses its respective _default root type name_ and no other type uses any _default
 root type name_.
 


### PR DESCRIPTION
"should" seems to strong here given a schema can have a description and directives applied to it.
