### PR TITLE
[RFC] Directive proposal for opting out of null bubbling

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2026,7 +2026,7 @@ by a validator, executor, or client tool such as a code generator.
 :: A _built-in directive_ is any directive defined within this specification.
 
 GraphQL implementations should provide the `@skip`, `@include` and
-`@nullOnError` directives.
+`@disableErrorPropagation` directives.
 
 GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of the
@@ -2249,22 +2249,22 @@ to the relevant IETF specification.
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 ```
 
-### @nullOnError
+### @disableErrorPropagation
 
 ```graphql
-directive @nullOnError on QUERY | MUTATION | SUBSCRIPTION
+directive @disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 ```
 
-The `@nullOnError` _built-in directive_ may be provided on query, mutation and
-subscription operations, and disables the error propagation behavior described
-in [Handling Field Errors](#sec-Handling-Field-Errors) by treating all Non-Null
-types as if they were instead Null-Only-On-Error types.
+The `@disableErrorPropagation` _built-in directive_ may be provided on query,
+mutation and subscription operations, and disables the error propagation
+behavior described in [Handling Field Errors](#sec-Handling-Field-Errors) by
+treating all Non-Null types as if they were instead Null-Only-On-Error types.
 
 Note: This is useful for clients that still wish to receive sibling fields when
-an error on a Non-Null value occurs. Effectively, `@nullOnError` enables the
-client to opt in to handling errors locally; for example, a client might use
-this to limit the scope of null propagation to a fragment rather than the entire
-field, or to update a normalized store even when an error occurs.
+an error on a Non-Null value occurs. Effectively, `@disableErrorPropagation`
+enables the client to opt in to handling errors locally; for example, a client
+might use this to limit the scope of null propagation to a fragment rather than
+the entire field, or to update a normalized store even when an error occurs.
 
 Consider the following schema:
 
@@ -2309,10 +2309,10 @@ Would return a result such as:
 }
 ```
 
-However, if we apply the `@nullOnError` directive to our operation:
+However, if we apply the `@disableErrorPropagation` directive to our operation:
 
 ```graphql example
-query myQuery @nullOnError {
+query myQuery @disableErrorPropagation {
   me {
     username
     bestFriend {

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2025,7 +2025,8 @@ by a validator, executor, or client tool such as a code generator.
 
 :: A _built-in directive_ is any directive defined within this specification.
 
-GraphQL implementations should provide the `@skip` and `@include` directives.
+GraphQL implementations should provide the `@skip`, `@include` and
+`@nullOnError` directives.
 
 GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of the
@@ -2246,4 +2247,97 @@ to the relevant IETF specification.
 
 ```graphql example
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
+```
+
+### @nullOnError
+
+```graphql
+directive @nullOnError on QUERY | MUTATION | SUBSCRIPTION
+```
+
+The `@nullOnError` _built-in directive_ may be provided on query, mutation and
+subscription operations, and disables the error propagation behavior described
+in [Handling Field Errors](#sec-Handling-Field-Errors) by treating all Non-Null
+types as if they were instead Null-Only-On-Error types.
+
+Note: This is useful for clients that still wish to receive sibling fields when
+an error on a Non-Null value occurs. Effectively, `@nullOnError` enables the
+client to opt in to handling errors locally; for example, a client might use
+this to limit the scope of null propagation to a fragment rather than the entire
+field, or to update a normalized store even when an error occurs.
+
+Consider the following schema:
+
+```graphql
+type Query {
+  me: Viewer
+}
+
+type Viewer {
+  username: String!
+  bestFriend: Viewer!
+}
+```
+
+If the `bestFriend` field were to return `null`, then the following operation:
+
+```graphql example
+query myQuery {
+  me {
+    username
+    bestFriend {
+      username
+    }
+  }
+}
+```
+
+Would return a result such as:
+
+```json example
+{
+  "errors": [
+    {
+      "message": "Value cannot be null",
+      "locations": [{ "line": 4, "column": 5 }],
+      "path": ["me", "bestFriend"]
+    }
+  ],
+  "data": {
+    "me": null
+  }
+}
+```
+
+However, if we apply the `@nullOnError` directive to our operation:
+
+```graphql example
+query myQuery @nullOnError {
+  me {
+    username
+    bestFriend {
+      username
+    }
+  }
+}
+```
+
+The result would contain identical errors, but the "me" field will be populated:
+
+```json example
+{
+  "errors": [
+    {
+      "message": "Value cannot be null",
+      "locations": [{ "line": 4, "column": 5 }],
+      "path": ["me", "bestFriend"]
+    }
+  ],
+  "data": {
+    "me": {
+      "username": "billy",
+      "bestFriend": null
+    }
+  }
+}
 ```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2258,7 +2258,7 @@ directive @disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 The `@disableErrorPropagation` _built-in directive_ may be provided on query,
 mutation and subscription operations, and disables the error propagation
 behavior described in [Handling Field Errors](#sec-Handling-Field-Errors) by
-treating all Non-Null types as if they were instead Null-Only-On-Error types.
+treating all Non-Null types as if they were instead Semantic-Non-Null types.
 
 Note: This is useful for clients that still wish to receive sibling fields when
 an error on a Non-Null value occurs. Effectively, `@disableErrorPropagation`

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -801,7 +801,8 @@ handled by the parent field. If the parent field may be {null} then it resolves
 to {null}, otherwise if it is a `Non-Null` type, the field error is further
 propagated to its parent field.
 
-If a `List` type wraps a `Non-Null` type, and one of the elements of that list
+If a `List` type wraps a `Non-Null` type, the operation does not provide the
+`@disableErrorPropagation` directive, and one of the elements of that list
 resolves to {null}, then the entire list must resolve to {null}. If the `List`
 type is also wrapped in a `Non-Null` and the operation does not provide the
 `@disableErrorPropagation` directive, the field error continues to propagate

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -792,14 +792,19 @@ added to the {"errors"} list in the response, the {"errors"} list must not be
 further affected. That is, only one error should be added to the errors list per
 field.
 
-Since `Non-Null` type fields cannot be {null}, field errors are propagated to be
+If the operation provides the `@disableErrorPropagation` directive then
+`Non-Null` type fields will become {null} if an error occurs.
+
+If the operation does not provide the `@disableErrorPropagation` directive then
+`Non-Null` type fields cannot be {null}, and field errors are propagated to be
 handled by the parent field. If the parent field may be {null} then it resolves
 to {null}, otherwise if it is a `Non-Null` type, the field error is further
 propagated to its parent field.
 
 If a `List` type wraps a `Non-Null` type, and one of the elements of that list
 resolves to {null}, then the entire list must resolve to {null}. If the `List`
-type is also wrapped in a `Non-Null`, the field error continues to propagate
+type is also wrapped in a `Non-Null` and the operation does not provide the
+`@disableErrorPropagation` directive, the field error continues to propagate
 upwards.
 
 If all fields from the root of the request to the source of the field error


### PR DESCRIPTION
This PR builds on #1065.

This introduces a directive on operations that disables the null/error propagation behavior by treating all Non-Null types as if they were Semantic-Non-Null types (see #1065).

The specific name of this directive (currently `@disableNullPropagation`) is open to workshopping:

- [`@noBubblesPlz` :wink: or `@tepid` :rofl:](https://www.youtube.com/watch?v=k5Qec3OvKjU&t=1426s)
- `@disableNullPropagation` / `@disableErrorPropagation` / `@noNullPropagation` / `@noPropagation` / `@nullOnError` / etc
- `@localErrors`
- `@dontHandleErrorsForMeIKnowWhatImDoing`
- {your suggestion here}

Implemented in https://github.com/graphql/graphql-js/pull/4192 as part of semantic non-null support.