### PR TITLE
RFC: deduplicated incremental delivery

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -4,6 +4,7 @@ ignoreRegExpList:
   - /[a-z]{2,}'s/
 words:
   # Terms of art
+  - deprioritization
   - endianness
   - interoperation
   - monospace

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -794,8 +794,9 @@ And will yield the subset of each object type queried:
 When querying an Object, the resulting mapping of fields are conceptually
 ordered in the same order in which they were encountered during execution,
 excluding fragments for which the type does not apply and fields or fragments
-that are skipped via `@skip` or `@include` directives. This ordering is
-correctly produced when using the {CollectFields()} algorithm.
+that are skipped via `@skip` or `@include` directives or temporarily skipped via
+`@defer`. This ordering is correctly produced when using the {CollectFields()}
+algorithm.
 
 Response serialization formats capable of representing ordered maps should
 maintain this ordering. Serialization formats which can only represent unordered
@@ -1941,10 +1942,10 @@ by a validator, executor, or client tool such as a code generator.
 
 GraphQL implementations should provide the `@skip` and `@include` directives.
 
-GraphQL implementations are not required to implement the `@stream` directive.
-If the directive is implemented, it must be implemented according to this
-specification. GraphQL implementations that do not support the `@stream`
-directive must not make it available via introspection.
+GraphQL implementations are not required to implement the `@defer` and `@stream`
+directives. If either or both of these directives are implemented, they must be
+implemented according to this specification. GraphQL implementations that do not
+support these directives must not make them available via introspection.
 
 GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of the
@@ -2167,6 +2168,50 @@ to the relevant IETF specification.
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 ```
 
+### @defer
+
+```graphql
+directive @defer(
+  label: String
+  if: Boolean! = true
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+```
+
+The `@defer` directive may be provided for fragment spreads and inline fragments
+to inform the executor to delay the execution of the current fragment to
+indicate deprioritization of the current fragment. A query with `@defer`
+directive will cause the request to potentially return multiple responses, where
+non-deferred data is delivered in the initial response and data deferred is
+delivered in a subsequent response. `@include` and `@skip` take precedence over
+`@defer`.
+
+```graphql example
+query myQuery($shouldDefer: Boolean) {
+  user {
+    name
+    ...someFragment @defer(label: "someLabel", if: $shouldDefer)
+  }
+}
+fragment someFragment on User {
+  id
+  profile_picture {
+    uri
+  }
+}
+```
+
+#### @defer Arguments
+
+- `if: Boolean! = true` - When `true`, fragment _should_ be deferred (See
+  [related note](#note-088b7)). When `false`, fragment will not be deferred and
+  data will be included in the initial response. Defaults to `true` when
+  omitted.
+- `label: String` - May be used by GraphQL clients to identify the data from
+  responses and associate it with the corresponding defer directive. If
+  provided, the GraphQL service must add it to the corresponding payload.
+  `label` must be unique label across all `@defer` and `@stream` directives in a
+  document. `label` must not be provided as a variable.
+
 ### @stream
 
 ```graphql
@@ -2201,20 +2246,20 @@ query myQuery($shouldStream: Boolean) {
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding stream directive. If
   provided, the GraphQL service must add it to the corresponding payload.
-  `label` must be unique label across all `@stream` directives in a document.
-  `label` must not be provided as a variable.
+  `label` must be unique label across all `@defer` and `@stream` directives in a
+  document. `label` must not be provided as a variable.
 - `initialCount: Int` - The number of list items the service should return as
   part of the initial response. If omitted, defaults to `0`. A field error will
   be raised if the value of this argument is less than `0`.
 
-Note: The ability to stream parts of a response can have a potentially
-significant impact on application performance. Developers generally need clear,
-predictable control over their application's performance. It is highly
-recommended that GraphQL services honor the `@stream` directives on each
-execution. However, the specification allows advanced use cases where the
-service can determine that it is more performant to not stream. Therefore,
-GraphQL clients _must_ be able to process a response that ignores the `@stream`
-directive. This also applies to the `initialCount` argument on the `@stream`
-directive. Clients _must_ be able to process a streamed response that contains a
-different number of initial list items than what was specified in the
-`initialCount` argument.
+Note: The ability to defer and/or stream parts of a response can have a
+potentially significant impact on application performance. Developers generally
+need clear, predictable control over their application's performance. It is
+highly recommended that GraphQL services honor the `@defer` and `@stream`
+directives on each execution. However, the specification allows advanced use
+cases where the service can determine that it is more performant to not defer
+and/or stream. Therefore, GraphQL clients _must_ be able to process a response
+that ignores the `@defer` and/or `@stream` directives. This also applies to the
+`initialCount` argument on the `@stream` directive. Clients _must_ be able to
+process a streamed response that contains a different number of initial list
+items than what was specified in the `initialCount` argument.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -463,7 +463,7 @@ unambiguous. Therefore any two field selections which might both be encountered
 for the same object are only valid if they are equivalent.
 
 During execution, the simultaneous execution of fields with the same response
-name is accomplished by {MergeSelectionSets()} and {CollectFields()}.
+name is accomplished by {CollectSubfields()}.
 
 For simple hand-written GraphQL, this rule is obviously a clear developer error,
 however nested fragments can make this difficult to detect manually.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -874,13 +874,14 @@ GetSinglyDeferredFutures(newPendingResults, originalDeferStates):
   - Let {deferState} be the entry in {deferStates} for {newPendingResult}.
   - If {deferState} is not defined:
     - Continue to the next {newPendingResult} in {newPendingResults}.
-  - Let {parent} be the result of {GetNonEmptyParent(newPendingResult,
-    deferStates)}.
+  - Let {parent} be the corresponding entry on {newPendingResult}.
   - If {parent} is not defined:
+    - Let {futuresToRelease} and {deferState} be the result of
+      {ReleaseFragment(newPendingResult, deferStates)}.
+    - If {futuresToRelease} is empty:
+      - Continue to the next {newPendingResult} in {newPendingResults}.
     - Append {newPendingResult} to {pending}.
-    - Let {unreleasedFutures} and {deferState} be the result of
-      {ReleaseFragment(newPendingResult,deferStates)}.
-    - Append all of the items in {unreleasedFutures} to {newFutures}.
+    - Append all of the items in {futuresToRelease} to {newFutures}.
     - Continue to the next {newPendingResult} in {newPendingResults}.
   - Let {parentDeferState} be the entry in {deferStates} for {parent}.
   - Let {newParentDeferState} be a new unordered map containing all entries in
@@ -896,23 +897,22 @@ ReleaseFragment(deferredFragment, deferStates):
 - Let {deferStates} be a new unordered map containing all entries in
   {originalDeferStates}.
 - Let {deferState} be the entry in {deferStates} for {newPendingResult}.
+- Remove the entry for {deferredFragment} on {deferStates}.
 - Let {unreleasedFutures} be the corresponding entry on {deferState}.
+- If {unreleasedFutures} is empty:
+  - Let {children} be the corresponding entry on {deferState}.
+  - Initialize {futuresToRelease} to an empty list.
+  - For each {child} of {children}:
+    - Let {childFuturesToRelease} and {deferStates} be the result of
+      ReleaseFragment(child, deferStates).
+    - Append all of the items in {childFuturesToRelease} to {futuresToRelease}.
+    - Return {futuresToRelease} and {deferStates}.
 - Let {pendingFutures} be a new list containing all members of {pendingFutures}
   on {deferState}.
 - Append all of the items in {unreleasedFutures} to {pendingFutures}.
 - Reset {unreleasedFutures} on {deferState} to an empty list.
 - Set the corresponding entry on {deferState} to {pendingFutures}.
 - Return {unreleasedFutures} and {deferStates}.
-
-GetNonEmptyParent(deferredFragment, deferStates):
-
-- Let {parent} be the corresponding entry on {deferredFragment}.
-- If {parent} is not defined, return.
-- Let {parentDeferState} be the entry for {parent} on {deferStates}.
-- Let {futures} be the corresponding entry on {parentDeferState}.
-- If {futures} is empty, return the result of {GetNonEmptyParent(parent,
-  deferStates)}.
-- Return {parent}.
 
 GetUpdateForStreamItems(originalDeferStates, completedFuture):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -927,7 +927,7 @@ GetUpdatesForDeferredResult(originalDeferStates, deferredResult):
     - Remove the entry for {deferredFragment} on {deferStates}.
     - Append {deferredFragment} to {completed}.
     - Append all items in {pending} on {newDeferState} to {incremental}.
-- For each {deferredResult} in {completed}:
+- For each {deferredResult} in {incremental}:
   - Let {deferredFragments} be the corresponding entry on {deferredResult}.
   - For each {deferredFragment} in {deferredFragments}:
     - Let {deferState} be the entry on {deferStates} for {deferredFragment}.
@@ -937,7 +937,8 @@ GetUpdatesForDeferredResult(originalDeferStates, deferredResult):
     - If {pending} contains {deferredResult}:
       - Let {newDeferState} be a new unordered map containing all entries on
         {deferState}.
-      - Set the entry for {deferredFragment} on {deferStates} to {deferState}.
+      - Set the entry for {deferredFragment} on {deferStates} to
+        {newDeferState}.
       - Let {pending} be a new set containing all of the members of {pending} on
         {newDeferState}.
       - Set the corresponding entry on {newDeferState} to {pending}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -350,14 +350,27 @@ serial):
   {groupedFieldSet}.
 - Let {newPendingResults}, {futures}, and {deferStates} be the result of
   {ProcessIncrementalDigests(incrementalDigests)}.
-- Let {ids} and {initialPayload} be the result of
-  {GetIncrementalPayload(newPendingResults)}.
-- If {ids} is empty, return an empty unordered map consisting of {data} and
+- Let {pending} and {ids} be the result of {GetPending(newPendingResults)}.
+- If {pending} is empty, return an unordered map consisting of {data} and
   {errors}.
-- Set the corresponding entries on {initialPayload} to {data} and {errors}.
+- Let {hasNext} be {true}.
+- Let {initialResult} be an unordered map consisting of {data}, {errors},
+  {pending}, and {hasNext}.
 - Let {subsequentResults} be the result of {YieldSubsequentResults(ids,
   deferStates, futures)}.
-- Return {initialPayload} and {subsequentResults}.
+- Return {initialResult} and {subsequentResults}.
+
+GetPending(newPendingResults):
+
+- Initialize {pending} to an empty list.
+- Initialize {ids} to a new unordered map of pending results to identifiers.
+- For each {newPendingResult} in {newPendingResults}:
+  - Let {path} and {label} be the corresponding entries on {newPendingResult}.
+  - Let {id} be a unique identifier for this {newPendingResult}.
+  - Set the entry for {newPendingResult} in {ids} to {id}.
+  - Let {pendingEntry} be an unordered map containing {path}, {label}, and {id}.
+  - Append {pendingEntry} to {pending}.
+- Return {pending} and {ids}.
 
 ### Field Collection
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -730,8 +730,8 @@ serial):
 - Initialize {newPendingResultsByFragment}, {pendingFuturesByFragment}, and
   {completedFuturesByFragment} to empty unordered maps.
 - Repeat the following steps:
-  - Wait for any futures within {pendingFutures} to complete.
   - Initialize {pending}, {incremental}, and {completed} to empty lists.
+  - Wait for any futures within {pendingFutures} to complete.
   - Let {completedFutures} be those completed futures.
   - For each {future} in {completedFutures}:
     - Remove {future} from {pendingFutures}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -833,6 +833,8 @@ FilterDefers(newPendingResults, futures, originalDeferStates):
   GetStreamFutures(originalDeferStates, futures).
 - Let {pending}, {newFutures}, and {deferStates} be the result of
   {FilterNestedDefers(newPendingResults, deferStates)}.
+- Notify the executor as necessary that all items in {pending} have been
+  released.
 - Return {pending}, {newFutures}, and {deferStates}.
 
 GetStreamFutures(deferStates, futures):

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -975,7 +975,7 @@ completedFuture):
     {completedFutures} on {newDeferState}, appended by {completedFuture}.
   - Set the {completedFutures} entry on {newDeferState} to
     {newCompletedFutures}.
-  - Let {futures} be the corresponding entries on {newDeferState}.
+  - Let {pendingFutures} be the corresponding entries on {newDeferState}.
   - If the size of {newCompletedFutures} is equal to the size of
     {pendingFutures}:
     - Let {deferStates}, {fragmentPending}, {fragmentIncremental},
@@ -996,8 +996,8 @@ originalDeferStates):
 - Let {futureStates} and {deferStates} be a new unordered map containing all the
   entries in {originalFutureStates} and {originalDeferStates}, respectively.
 - Remove the entry for {deferredFragment} on {deferStates}.
-- Let {futures} and {children} be the corresponding entry on {deferState}.
-- For each {future} of {futures}:
+- Let {pendingFutures} and {children} be the corresponding entry on {deferState}.
+- For each {future} of {pendingFutures}:
   - Let {futureState} be the entry for {future} on {futureStates}.
   - Let {newFutureState} be a new unordered map containing all entries in
     {futureState}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -837,11 +837,11 @@ serial):
     - If {data} is defined:
       - Let {incrementalResult} be a new unordered map containing {data},
         {errors} and {pending}.
-      - Yield {update}.
+      - Yield {incrementalResult}.
     - Otherwise, if {incremental} or {completed} is not empty:
       - Let {incrementalResult} be a new unordered map containing {pending},
         {incremental}, {completed} and {hasNext}.
-      - Yield {update}.
+      - Yield {incrementalResult}.
     - If {hasNext} is {false}, complete this incremental result stream and
       return.
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -256,10 +256,11 @@ CreateSourceEventStream(subscription, schema, variableValues, initialValue):
 - Let {groupedFieldSet} be the result of {CollectFields(subscriptionType,
   selectionSet, variableValues)}.
 - If {groupedFieldSet} does not have exactly one entry, raise a _request error_.
-- Let {fields} be the value of the first entry in {groupedFieldSet}.
-- Let {fieldName} be the name of the first entry in {fields}. Note: This value
-  is unaffected if an alias is used.
-- Let {field} be the first entry in {fields}.
+- Let {fieldDetailsList} be the value of the first entry in {groupedFieldSet}.
+- Let {fieldDetails} be the first entry in {fieldDetailsList}.
+- Let {node} be the corresponding entry on {fieldDetails}.
+- Let {fieldName} be the name of {node}. Note: This value is unaffected if an
+  alias is used.
 - Let {argumentValues} be the result of {CoerceArgumentValues(subscriptionType,
   field, variableValues)}
 - Let {fieldStream} be the result of running
@@ -327,27 +328,27 @@ Executing the root selection set works similarly for queries (parallel),
 mutations (serial), and subscriptions (where it is executed for each event in
 the underlying Source Stream).
 
-First, the selection set is turned into a grouped field set; then, we execute
-this grouped field set and return the resulting {data} and {errors}.
+First, the selection set is turned into a field plan; then, we execute this
+field plan and return the resulting {data} and {errors}.
 
-If an operation contains `@stream` directives, execution may also result in an
-Subsequent Result stream in addition to the initial response. The procedure for
-yielding subsequent results is specified by the {YieldSubsequentResults()}
-algorithm.
+If an operation contains `@defer` or `@stream` directives, execution may also
+result in an Subsequent Result stream in addition to the initial response. The
+procedure for yielding subsequent results is specified by the
+{YieldSubsequentResults()} algorithm.
 
 ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
 serial):
 
 - If {serial} is not provided, initialize it to {false}.
-- Let {groupedFieldSet} be the result of {CollectFields(objectType,
-  selectionSet, variableValues)}.
+- Let {groupedFieldSet} and {newDeferUsages} be the result of
+  {CollectFields(objectType, selectionSet, variableValues)}.
+- Let {fieldPlan} be the result of {BuildFieldPlan(groupedFieldSet)}.
 - Let {data} and {incrementalDigests} be the result of
-  {ExecuteGroupedFieldSet(groupedFieldSet, queryType, initialValue,
-  variableValues)} _serially_ if {serial} is {true}, _normally_ (allowing
-  parallelization) otherwise.
+  {ExecuteFieldPlan(newDeferUsages, fieldPlan, objectType, initialValue,
+  variableValues, serial)}.
 - Let {errors} be the list of all _field error_ raised while executing the
   {groupedFieldSet}.
-- Let {newPendingResults} and {futures} be the results of
+- Let {newPendingResults}, {futures}, and {deferStates} be the result of
   {ProcessIncrementalDigests(incrementalDigests)}.
 - Let {ids} and {initialPayload} be the result of
   {GetIncrementalPayload(newPendingResults)}.
@@ -355,19 +356,35 @@ serial):
   {errors}.
 - Set the corresponding entries on {initialPayload} to {data} and {errors}.
 - Let {subsequentResults} be the result of {YieldSubsequentResults(ids,
-  futures)}.
+  deferStates, futures)}.
 - Return {initialPayload} and {subsequentResults}.
 
 ### Field Collection
 
-Before execution, the selection set is converted to a grouped field set by
-calling {CollectFields()}. Each entry in the grouped field set is a list of
-fields that share a response key (the alias if defined, otherwise the field
-name). This ensures all fields with the same response key (including those in
-referenced fragments) are executed at the same time.
+Before execution, selection set(s) are converted to a field plan via a two-step
+process. In the first step, selections are converted into a grouped field set by
+calling {CollectFields()}. Each entry in a grouped field set is a list of Field
+Details records describing all fields that share a response key (the alias if
+defined, otherwise the field name). This ensures all fields with the same
+response key (including those in referenced fragments) are executed at the same
+time.
 
-As an example, collecting the fields of this selection set would collect two
-instances of the field `a` and one of field `b`:
+A Field Details record is a structure containing:
+
+- {node}: the field node itself.
+- {deferUsage}: the Defer Usage record corresponding to the deferred fragment
+  enclosing this field, not defined if the field was not deferred.
+
+Defer Usage records contain information derived from the presence of a `@defer`
+directive on a fragment and are structures containing:
+
+- {label}: value of the corresponding argument to the `@defer` directive.
+- {parentDeferUsage}: the parent Defer Usage record corresponding to the
+  deferred fragment enclosing this deferred fragment, not defined if this Defer
+  Usage record is deferred directly by the initial result.
+
+As an example, collecting the fields of this selection set would return field
+details related to two instances of the field `a` and one of field `b`:
 
 ```graphql example
 {
@@ -389,9 +406,11 @@ The depth-first-search order of the field groups produced by {CollectFields()}
 is maintained through execution, ensuring that fields appear in the executed
 response in a stable and predictable order.
 
-CollectFields(objectType, selectionSet, variableValues, visitedFragments):
+CollectFields(objectType, selectionSet, variableValues, deferUsage,
+newDeferUsages, visitedFragments):
 
 - If {visitedFragments} is not provided, initialize it to the empty set.
+- If {newDeferUsages} is not provided, initialize it to the empty set.
 - Initialize {groupedFields} to an empty ordered map of lists.
 - For each {selection} in {selectionSet}:
   - If {selection} provides the directive `@skip`, let {skipDirective} be that
@@ -407,14 +426,23 @@ CollectFields(objectType, selectionSet, variableValues, visitedFragments):
   - If {selection} is a {Field}:
     - Let {responseKey} be the response key of {selection} (the alias if
       defined, otherwise the field name).
+    - Let {fieldDetails} be a new Field Details record created from {selection}
+      and {deferUsage}.
     - Let {groupForResponseKey} be the list in {groupedFields} for
       {responseKey}; if no such list exists, create it as an empty list.
-    - Append {selection} to the {groupForResponseKey}.
+    - Append {fieldDetails} to the {groupForResponseKey}.
   - If {selection} is a {FragmentSpread}:
     - Let {fragmentSpreadName} be the name of {selection}.
-    - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
-      {selection} in {selectionSet}.
-    - Add {fragmentSpreadName} to {visitedFragments}.
+    - If {fragmentSpreadName} provides the directive `@defer` and its {if}
+      argument is not {false} and is not a variable in {variableValues} with the
+      value {false}:
+      - Let {deferDirective} be that directive.
+      - If this execution is for a subscription operation, raise a _field
+        error_.
+    - If {deferDirective} is not defined:
+      - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
+        {selection} in {selectionSet}.
+      - Add {fragmentSpreadName} to {visitedFragments}.
     - Let {fragment} be the Fragment in the current Document whose name is
       {fragmentSpreadName}.
     - If no such {fragment} exists, continue with the next {selection} in
@@ -423,9 +451,17 @@ CollectFields(objectType, selectionSet, variableValues, visitedFragments):
     - If {DoesFragmentTypeApply(objectType, fragmentType)} is false, continue
       with the next {selection} in {selectionSet}.
     - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
+    - If {deferDirective} is defined:
+      - Let {label} be the value or the variable to {deferDirective}'s {label}
+        argument.
+      - Let {fragmentDeferUsage} be a new Defer Usage record created from
+        {label} and {deferUsage}.
+      - Add {fragmentDeferUsage} to {newDeferUsages}.
+    - Otherwise:
+      - Let {fragmentDeferUsage} be {deferUsage}.
     - Let {fragmentGroupedFieldSet} be the result of calling
       {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments)}.
+      fragmentDeferUsage, newDeferUsages, visitedFragments)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
@@ -438,16 +474,30 @@ CollectFields(objectType, selectionSet, variableValues, visitedFragments):
       fragmentType)} is false, continue with the next {selection} in
       {selectionSet}.
     - Let {fragmentSelectionSet} be the top-level selection set of {selection}.
+    - If {InlineFragment} provides the directive `@defer` and its {if} argument
+      is not {false} and is not a variable in {variableValues} with the value
+      {false}:
+      - Let {deferDirective} be that directive.
+      - If this execution is for a subscription operation, raise a _field
+        error_.
+    - If {deferDirective} is defined:
+      - Let {label} be the value or the variable to {deferDirective}'s {label}
+        argument.
+      - Let {fragmentDeferUsage} be a new Defer Usage record created from
+        {label} and {deferUsage}.
+      - Add {fragmentDeferUsage} to {newDeferUsages}.
+    - Otherwise:
+      - Let {fragmentDeferUsage} be {deferUsage}.
     - Let {fragmentGroupedFieldSet} be the result of calling
       {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments)}.
+      fragmentDeferUsage, newDeferUsages, visitedFragments)}.
     - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
       - Let {responseKey} be the response key shared by all fields in
         {fragmentGroup}.
       - Let {groupForResponseKey} be the list in {groupedFields} for
         {responseKey}; if no such list exists, create it as an empty list.
       - Append all items in {fragmentGroup} to {groupForResponseKey}.
-- Return {groupedFields}.
+- Return {groupedFields} and {newDeferUsages}.
 
 DoesFragmentTypeApply(objectType, fragmentType):
 
@@ -464,6 +514,116 @@ DoesFragmentTypeApply(objectType, fragmentType):
 Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
 directives may be applied in either order since they apply commutatively.
 
+### Field Plan Generation
+
+In the second step, the original grouped field set is converted into a field
+plan via analysis of the Field Details.
+
+A Field Plan record is a structure containing:
+
+- {groupedFieldSet}: the grouped field set for the current result.
+- {newGroupedFieldSets}: an unordered map containing additional grouped field
+  sets for related to previously encountered Defer Usage records. The map is
+  keyed by the unique set of Defer Usage records to which these new grouped
+  field sets belong. (See below for an explanation of why these additional
+  grouped field sets may be required.)
+- {newGroupedFieldSetsRequiringDeferral}: a map containing additional grouped
+  field sets for new incremental results relating to the newly encountered
+  deferred fragments. The map is keyed by the set of Defer Usage records to
+  which these new grouped field sets belong.
+
+Additional grouped field sets are constructed carefully so as to ensure that
+each field is executed exactly once and so that fields are grouped according to
+the set of deferred fragments that include them.
+
+Deferred grouped field sets do not always require initiating deferral. For
+example, when a parent field is deferred by multiple fragments, deferral is
+initiated on the parent field. New grouped field sets for child fields will be
+created if the child fields are not all present in all of the deferred
+fragments, but these new grouped field sets, while representing deferred fields,
+do not require additional deferral. The produced field plan will also retain
+this information.
+
+BuildFieldPlan(groupedFieldSet, parentDeferUsages):
+
+- If {parentDeferUsages} is not provided, initialize it to the empty set.
+- Initialize {originalGroupedFieldSet} to an empty ordered map.
+- Initialize {newGroupedFieldSets} to an empty unordered map.
+- Initialize {newGroupedFieldSetsRequiringDeferral} to an empty unordered map.
+- For each {responseKey} and {groupForResponseKey} of {groupedFieldSet}:
+  - Let {deferUsageSet} be the result of
+    {GetDeferUsageSet(groupForResponseKey)}.
+  - If {IsSameSet(deferUsageSet, parentDeferUsages)} is {true}:
+    - Let {groupedFieldSet} be {originalGroupedFieldSet}.
+  - Otherwise:
+    - Let {groupedFieldSets} be {newGroupedFieldSetsRequiringDeferral} if
+      {ShouldInitiateDefer(deferUsageSet, parentDeferUsages)} is {true},
+      otherwise let it be {newGroupedFieldSets}:
+    - For each {key} in {groupedFieldSets}:
+      - If {IsSameSet(key, deferUsageSet)} is {true}:
+        - Let {groupedFieldSet} be the map in {groupedFieldSets} for {key}.
+    - If {groupedFieldSet} is not defined:
+      - Initialize {groupedFieldSet} to an empty ordered map.
+      - Set the entry for {deferUsageSet} in {groupedFieldSets} to
+        {groupedFieldSet}.
+  - Set the entry for {responseKey} in {originalGroupedFieldSet} to
+    {groupForResponseKey}.
+- Let {fieldPlan} be a new Field Plan record created from
+  {originalGroupedFieldSet}, {newGroupedFieldSets}, and
+  {newGroupedFieldSetsRequiringDeferral}.
+- Return {fieldPlan}.
+
+GetDeferUsageSet(fieldDetailsList):
+
+- Initialize {deferUsageSet} to the empty set.
+- Let {inInitialResult} be {false}.
+- For each {fieldDetails} in {fieldDetailsList}:
+  - Let {deferUsage} be the corresponding entry on {fieldDetails}.
+  - If {deferUsage} is not defined:
+    - Let {inInitialResult} be {true}.
+    - Continue to the next {fieldDetails} in {fieldDetailsList}.
+  - Add {deferUsage} to {deferUsageSet}.
+- If {inInitialResult} is true, reset {deferUsageSet} to the empty set;
+  otherwise, let {deferUsageSet} be the result of
+  {FilterDeferUsages(deferUsageSet)}.
+- Return {deferUsageSet}.
+
+FilterDeferUsages(deferUsages):
+
+- Initialize {filteredDeferUsages} to the empty set.
+- For each {deferUsage} in {deferUsages}:
+  - Let {ancestors} be the result of {GetAncestors(deferUsage)}.
+  - For each {ancestor} of {ancestors}:
+    - If {ancestor} is in {deferUsages}.
+    - Continue to the next {deferUsage} in {deferUsages}.
+  - Add {deferUsage} to {filteredDeferUsages}.
+- Return {filteredDeferUsages}.
+
+GetAncestors(deferUsage):
+
+- Initialize {ancestors} to an empty list.
+- Let {parentDeferUsage} be the corresponding entry on {deferUsage}.
+- If {parentDeferUsage} is not defined, return {ancestors}.
+- Append {parentDeferUsage} to {ancestors}.
+- Append all the items in {GetAncestors(parentDeferUsage)} to {ancestors}.
+- Return {ancestors}.
+
+ShouldInitiateDefer(deferUsageSet, parentDeferUsageSet):
+
+- For each {deferUsage} in {deferUsageSet}:
+  - If {parentDeferUsageSet} does not contain {deferUsage}:
+    - Return {true}.
+- Return {false}.
+
+IsSameSet(setA, setB):
+
+- If the size of setA is not equal to the size of setB:
+  - Return {false}.
+- For each {item} in {setA}:
+  - If {setB} does not contain {item}:
+    - Return {false}.
+- Return {true}.
+
 ### Processing Incremental Digests
 
 An Incremental Digest is a structure containing:
@@ -475,11 +635,53 @@ An Incremental Digest is a structure containing:
   contain additional Incremental Digests that will immediately or eventually
   complete those results.
 
-ProcessIncrementalDigests(incrementalDigests):
+Given the current state of any pending results, if any, the
+{ProcessIncrementalDigests()} algorithm describes how incremental digests are
+processed to update that state as incremental digests are encountered.
 
+ProcessIncrementalDigests(incrementalDigests, originalDeferStates):
+
+- Let {deferStates} be a new unordered map containing all entries in
+  {originalDeferStates}.
 - Let {newPendingResults} and {futures} be lists containing all of the items
   from the corresponding lists within each item of {incrementalDigests}.
-- Return {newPendingResults} and {futures}.
+- For each {future} in {futures}:
+  - Let {deferredFragments} be the list of deferred fragments completed by
+    {future}.
+  - For each {deferredFragment} of {deferredFragments}:
+    - Let {deferState} be the entry in {deferStates} for {deferredFragment}.
+    - Let {newDeferState} be a new unordered map containing all of the entries
+      in {deferState}.
+    - Let {count} be the corresponding entry on {newDeferState} for
+      {deferredFragment}.
+    - Let {newCount} be {count} + 1 if {count} is defined, otherwise {0}.
+    - Set the entry for {deferredFragment} in {deferStates} to {deferState}.
+- Initialize {pending} to an empty list.
+- For each {newPendingResult} in {newPendingResults}:
+  - If {newPendingResult} is a deferred fragment:
+    - Let {deferState} be the entry in {deferStates} for {newPendingResult}.
+    - Let {parent} and {parentDeferState} be the result of
+      {GetParentAndParentDeferState(deferState, deferStates)}.
+    - If {parent} is not defined:
+      - Append {newPendingResult} to {pending}.
+    - Otherwise:
+      - Let {newParentDeferState} be an unordered map containing all of the
+        entries on {parentDeferState}.
+      - Let {children} be a new list containing all of the entries on {children}
+        on {newParentDeferState}.
+      - Append {newPendingResult} to {children}.
+      - Set the corresponding entry on {newParentDeferState} to {children}.
+      - Set the entry for {parent} in {deferStates} to {newDeferState}.
+- Return {pending}, {futures}, and {deferStates}.
+
+GetParentAndPendingInfo(pendingInfo, pendingMap):
+
+- Let {ancestors} be the corresponding entry on {pendingInfo}.
+- For each {ancestor} of {ancestors}:
+  - Let {ancestorPendingInfo} be the entry in {pendingMap} for {ancestor}.
+  - If {ancestorPendingInfo} is defined, return {ancestor} and
+    {ancestorPendingInfo}.
+- Return.
 
 ### Yielding Subsequent Results
 
@@ -489,22 +691,29 @@ initiated. Then, any completed future executions are processed to determine the
 payload to be yielded. Finally, if any pending results remain, the procedure is
 repeated recursively.
 
-YieldSubsequentResults(originalIds, newFutures, initiatedFutures):
+YieldSubsequentResults(originalIds, originalDeferStates, newFutures,
+initiatedFutures, pendingFutures):
 
 - Initialize {futures} to a list containing all items in {initiatedFutures}.
+- If {pendingFutures} is not provided, initialize it to an empty list.
 - For each {future} in {newFutures}:
-  - If {future} has not been initiated, initiate it.
-  - Append {future} to {futures}.
-- Wait for any future execution contained in {futures} to complete.
-- Let {updates}, {newPendingResults}, {newestFutures}, and {remainingFutures} be
-  the result of {ProcessCompletedFutures(futures)}.
+  - If {future} contributes to a pending result that has been sent:
+    - If {future} has not been initiated, initiate it.
+    - Append {future} to {futures}.
+  - Otherwise:
+    - Append {future} to {pendingFutures}.
+- Wait for any future execution contained in {maybeCompletedFutures} to
+  complete.
+- Let {deferStates}, {updates}, {newPendingResults}, {newestFutures},
+  {remainingFutures}, and {pendingFutures} be the result of
+  {ProcessCompletedFutures(futures, originalDeferStates)}.
 - Let {ids} and {payload} be the result of
   {GetIncrementalPayload(newPendingResults, originalIds, updates)}.
-- Yield {payload}.
+- If {hasNext} is not the only entry on {payload}, yield {payload}.
 - If {hasNext} on {payload} is {false}:
   - Complete this subsequent result stream and return.
-- Yield the results of {YieldSubsequentResults(ids, newestFutures,
-  remainingFutures)}.
+- Yield the results of {YieldSubsequentResults(ids, deferStates, newestFutures,
+  remainingFutures, pendingFutures)}.
 
 GetIncrementalPayload(newPendingResults, originalIds, updates):
 
@@ -530,14 +739,25 @@ GetIncrementalPayload(newPendingResults, originalIds, updates):
       {errors}.
     - Append {completedEntry} to {completed}.
   - For each {incrementalResult} in {incremental}:
-    - Let {stream} be the corresponding entry on {incrementalResult}.
-    - Let {id} be the corresponding entry on {ids} for {stream}.
-    - If {id} is not defined, continue to the next {incrementalResult} in
-      {incremental}.
-    - Let {items} and {errors} be the corresponding entries on
-      {incrementalResult}.
-    - Let {incrementalEntry} be an unordered map containing {id}, {items}, and
-      {errors}.
+    - If {incrementalResult} represents completion of Stream Items:
+      - Let {stream} be the corresponding entry on {incrementalResult}.
+      - Let {id} be the corresponding entry on {ids} for {stream}.
+      - If {id} is not defined, continue to the next {incrementalResult} in
+        {incremental}.
+      - Let {items} and {errors} be the corresponding entries on
+        {incrementalResult}.
+      - Let {incrementalEntry} be an unordered map containing {id}, {items}, and
+        {errors}.
+    - Otherwise:
+      - Let {id} and {subPath} be the result of calling
+        {GetIdAndSubPath(incrementalResult, ids)}.
+      - If {id} is not defined, continue to the next {incrementalResult} in
+        {incremental}.
+      - Let {data} and {errors} be the corresponding entries on
+        {incrementalResult}.
+      - Let {incrementalEntry} be an unordered map containing {id}, {data}, and
+        {errors}.
+    - Append {incrementalEntry} to {incremental}.
 - Let {hasNext} be {false} if {ids} is empty, otherwise {true}.
 - Let {payload} be an unordered map containing {hasNext}.
 - If {pending} is not empty:
@@ -547,6 +767,29 @@ GetIncrementalPayload(newPendingResults, originalIds, updates):
 - If {completed} is not empty:
   - Set the corresponding entry on {payload} to {completed}.
 - Return {ids} and {payload}.
+
+GetIdAndSubPath(deferredResult, ids):
+
+- Initialize {releasedFragments} to an empty list.
+- Let {deferredFragments} be the corresponding entry on {deferredResult}.
+- For each {deferredFragment} in {deferredFragments}:
+  - Let {id} be the entry for {deferredFragment} on {ids}.
+  - If {id} is defined, append {deferredFragment} to {releasedFragments}.
+- Let {currentFragment} be the first member of {releasedFragments}.
+- Let {currentPath} be the entry for {path} on {firstDeferredFragment}.
+- Let {currentPathLength} be the length of {currentPath}.
+- For each remaining {deferredFragment} within {deferredFragments}.
+  - Let {path} be the corresponding entry on {deferredFragment}.
+  - Let {pathLength} be the length of {path}.
+  - If {pathLength} is larger than {currentPathLength}:
+    - Set {currentPathLength} to {pathLength}.
+    - Set {currentFragment} to {deferredFragment}.
+- Let {id} be the entry on {ids} for {currentFragment}.
+- If {id} is not defined, return.
+- Let {path} be the corresponding entry on {currentFragment}.
+- Let {subPath} be the subset of {path}, omitting the first {currentPathLength}
+  entries.
+- Return {id} and {subPath}.
 
 ### Processing Completed Futures
 
@@ -565,18 +808,34 @@ for any completed futures, as long as the new Incremental Digests do not contain
 any new pending results. If they do, first a new payload is yielded, notifying
 the client that new pending results have been encountered.
 
-ProcessCompletedFutures(maybeCompletedFutures, updates, pending,
-incrementalDigests, remainingFutures):
+ProcessCompletedFutures(maybeCompletedFutures, originalDeferStates, updates,
+pending, incrementalDigests, remainingFutures, pendingFutures):
 
-- If {updates}, {pending}, {incrementalDigests}, or {remainingFutures} are not
-  provided, initialize them to empty lists.
+- If {updates}, {pending}, {incrementalDigests}, {remainingFutures}, or
+  {pendingFutures} are not provided, initialize them to empty lists.
 - Let {completedFutures} be a list containing all completed futures from
   {maybeCompletedFutures}; append the remaining futures to {remainingFutures}.
+- Let {deferStates} be {originalDeferStates}.
 - Initialize {supplementalIncrementalDigests} to an empty list.
 - For each {completedFuture} in {completedFutures}:
   - Let {result} be the result of {completedFuture}.
-  - Let {update} and {resultIncrementalDigests} be the result of calling
-    {GetUpdatesForStreamItems(result)}.
+  - If {result} represents completion of Stream Items:
+    - Let {update} and {resultIncrementalDigests} be the result of calling
+      {GetUpdatesForStreamItems(result)}.
+    - Let {remainingPendingFutures} be {pendingFutures}.
+  - Otherwise:
+    - Let {deferStates}, {update}, {resultPending}, and
+      {resultIncrementalDigests} be the result of calling
+      {GetUpdatesForDeferredResult(deferStates, result)}.
+    - Append all items in {resultPending} to {pending}.
+    - Initialize {releasedFutures} and {remainingPendingFutures} to empty lists.
+    - For each {future} in {pendingFutures}:
+      - Let {deferredFragments} be the Deferred Fragments completed by {future}.
+      - For each {deferredFragment} of {deferredFragments}:
+        - If {deferredFragment} is in {resultPending}, append {future} to
+          {releasedFutures}.
+        - Continue to the next {future} in {pendingFutures}.
+      - Append {future} to {remainingPendingFutures}.
   - Append {update} to {updates}.
   - For each {resultIncrementalDigest} in {resultIncrementalDigests}:
     - If {resultIncrementalDigest} contains a {newPendingResults} entry:
@@ -584,15 +843,16 @@ incrementalDigests, remainingFutures):
     - Otherwise:
       - Append {resultIncrementalDigest} to {supplementalIncrementalDigests}.
 - If {supplementalIncrementalDigests} is empty:
-  - Let {newPendingResults} and {futures} be the result of
-    {ProcessIncrementalDigests(incrementalDigests)}.
+  - Let {newPendingResults}, {futures}, and {deferStates} be the result of
+    {ProcessIncrementalDigests(incrementalDigests, originalDeferStates)}.
   - Append all items in {newPendingResults} to {pending}.
-  - Return {updates}, {pending}, {newFutures}, and {remainingFutures}.
-- Let {newPendingResults} and {futures} be the result of
-  {ProcessIncrementalDigests(supplementalIncrementalDigests)}.
+  - Return {deferStates}, {updates}, {pending}, {newFutures},
+    {remainingFutures}, and {remainingPendingFutures}.
+- Let {newPendingResults}, {futures}, and {deferStates} be the results of
+  {ProcessIncrementalDigests(supplementalIncrementalDigests, deferStates)}.
 - Append all items in {newPendingResults} to {pending}.
-- Return the result of {ProcessCompletedFutures(futures, updates, pending,
-  incrementalDigests, remainingFutures)}.
+- Return the result of {ProcessCompletedFutures(futures, deferStates, updates,
+  pending, incrementalDigests, remainingFutures, remainingPendingFutures)}.
 
 GetUpdatesForStreamItems(streamItems):
 
@@ -609,8 +869,114 @@ GetUpdatesForStreamItems(streamItems):
   - Let {incremental} be a list containing {streamItems}.
   - Let {update} be an unordered map containing {incremental}.
   - Let {incrementalDigests} be the corresponding entry on {streamItems}.
-- Let {updates} be a list containing {update}.
-- Return {updates} and {incrementalDigests}.
+- Return {update} and {incrementalDigests}.
+
+GetUpdatesForDeferredResult(originalDeferStates, deferredResult):
+
+- Let {deferStates} be a new unordered map containing all of the entries in
+  {originalDeferStates}.
+- Initialize {incrementalDigests} to an empty list.
+- Let {deferredFragments}, {data}, and {errors} be the corresponding entries on
+  {deferredResult}.
+- Initialize {completed} to an empty list.
+- If {data} is {null}:
+  - For each {deferredFragment} of {deferredFragments}:
+    - Let {deferState} be the entry on {deferStates} for {deferredFragment}.
+    - If {deferState} is not defined, continue to the next {deferredFragment} of
+      {deferredFragments}.
+    - Remove the entry for {deferredFragment} on {completed}.
+    - Append {deferredFragment} to {completed}.
+  - Let {update} be an unordered map containing {completed} and {errors}.
+  - Return {update} and {incrementalDigests}.
+- Initialize {incremental} to an empty list.
+- Initialize {newPending} to the empty set.
+- For each {deferredFragment} of {deferredFragments}:
+  - Let {deferState} be the entry on {deferStates} for {deferredFragment}.
+  - If {deferState} is not defined, continue to the next {deferredFragment} of
+    {deferredFragments}.
+  - Let {newDeferState} be a new unordered map containing all entries on
+    {deferState}.
+  - Set the entry for {deferredFragment} on {deferStates} to {newDeferState}.
+  - Decrement {count} on {newDeferState}.
+  - Let {pending} be a new set containing all of the members of {pending} on
+    {newDeferState}.
+  - Set the corresponding entry on {newDeferState} to {pending}.
+  - Add {deferredResult} to {pending}.
+  - If {count} on {newDeferState} is equal to {0}:
+    - Let {children} be the corresponding entry on {newDeferState}.
+    - Add all items in {children} to {newPending}.
+    - Remove the entry for {deferredFragment} on {deferStates}.
+    - Append {deferredFragment} to {completed}.
+    - Append all items in {pending} on {newDeferState} to {incremental}.
+- For each {deferredResult} in {completed}:
+  - Let {deferredFragments} be the corresponding entry on {deferredResult}.
+  - For each {deferredFragment} in {deferredFragments}:
+    - Let {deferState} be the entry on {deferStates} for {deferredFragment}.
+    - If {deferState} is not defined, continue to the next {deferredFragment} of
+      {deferredFragments}.
+    - Let {pending} be the corresponding entry on {deferState}.
+    - If {pending} contains {deferredResult}:
+      - Let {newDeferState} be a new unordered map containing all entries on
+        {deferState}.
+      - Set the entry for {deferredFragment} on {deferStates} to {deferState}.
+      - Let {pending} be a new set containing all of the members of {pending} on
+        {newDeferState}.
+      - Set the corresponding entry on {newDeferState} to {pending}.
+      - Remove {deferredResult} from {pending}.
+- Let {update} be an unordered map containing {incremental} and {completed}.
+- Return {deferStates}, {update}, {newPending}, and {incrementalDigests}.
+
+## Executing a Field Plan
+
+To execute a field plan, the object value being evaluated and the object type
+need to be known, as well as whether the non-deferred grouped field set must be
+executed serially, or may be executed in parallel.
+
+ExecuteFieldPlan(newDeferUsages, fieldPlan, objectType, objectValue,
+variableValues, serial, path, deferUsageSet, deferMap):
+
+- If {path} is not provided, initialize it to an empty list.
+- Let {groupedFieldSet}, {newGroupedFieldSets}, {newDeferUsages}, and
+  {newGroupedFieldSetsRequiringDeferral} be the corresponding entries on
+  {fieldPlan}.
+- Let {newDeferMap} and {newPendingResults} be the result of
+  {GetNewDeferredFragments(newDeferUsages, path, deferMap)}.
+- Allowing for parallelization, perform the following steps:
+  - Let {data} and {nestedIncrementalDigests} be the result of running
+    {ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+    variableValues, path, deferUsageSet, newDeferMap)} _serially_ if {serial} is
+    {true}, _normally_ (allowing parallelization) otherwise.
+  - Let {incrementalDigest} be the result of
+    {ExecuteDeferredGroupedFieldSets(objectType, objectValue, variableValues,
+    newGroupedFieldSets, false, path, newDeferMap)}.
+  - Let {deferredIncrementalDigest} be the result of
+    {ExecuteDeferredGroupedFieldSets(objectType, objectValue, variableValues,
+    newGroupedFieldSetsRequiringDeferral, true, path, newDeferMap)}.
+- Set the corresponding entry on {deferredIncrementalDigest} to
+  {newPendingResults}.
+- Let {incrementalDigests} be a list containing {incrementalDigest},
+  {deferredIncrementalDigest}, and all items in {nestedIncrementalDigests}.
+- Return {data} and {incrementalDigests}.
+
+GetNewDeferredFragments(newDeferUsages, path, deferMap):
+
+- Initialize {newDeferredFragments} to an empty list.
+- If {newDeferUsages} is empty:
+  - Return {deferMap} and {newDeferredFragments}.
+- Let {newDeferMap} be a new unordered map of Defer Usage records to Deferred
+  Fragment records containing all of the entries in {deferMap}.
+- For each {deferUsage} in {newDeferUsages}:
+  - Initialize {ancestors} to an empty list.
+  - Let {deferUsageAncestors} be the result of {GetAncestors(deferUsage)}.
+  - For each {deferUsageAncestor} of {deferUsageAncestors}:
+    - Let {ancestor} be the entry in {deferMap} for {deferUsageAncestor}.
+    - Append {ancestor} to {ancestors}.
+  - Let {label} be the corresponding entry on {deferUsage}.
+  - Let {newDeferredFragment} be an unordered map containing {ancestors}, {path}
+    and {label}.
+  - Set the entry for {deferUsage} in {newDeferMap} to {newDeferredFragment}.
+  - Append {newDeferredFragment} to {newDeferredFragments}.
+- Return {newDeferMap} and {newDeferredFragments}.
 
 ## Executing a Grouped Field Set
 
@@ -622,9 +988,8 @@ Each represented field in the grouped field set produces an entry into a
 response map.
 
 ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue, variableValues,
-path):
+path, deferUsageSet, deferMap):
 
-- If {path} is not provided, initialize it to an empty list.
 - Initialize {resultMap} to an empty ordered map.
 - Initialize {incrementalDigests} to an empty list.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
@@ -658,19 +1023,23 @@ to a location that has resolved to {null} due to propagation of a field error.
 If these subsequent results have not yet executed or have not yet yielded a
 value they may also be cancelled to avoid unnecessary work.
 
-For example, assume the field `alwaysThrows` is a list of `Non-Null` type where
-completion of the list item always raises a field error:
+For example, assume the field `alwaysThrows` is a `Non-Null` type that always
+raises a field error:
 
 ```graphql example
 {
-  myObject(initialCount: 1) @stream {
+  myObject {
+    ... @defer {
+      name
+    }
     alwaysThrows
   }
 }
 ```
 
-In this case, only one response should be sent. Subsequent items from the stream
-should be ignored and their completion, if initiated, may be cancelled.
+In this case, only one response should be sent. The result of the fragment
+tagged with the `@defer` directive should be ignored and its execution, if
+initiated, may be cancelled.
 
 ```json example
 {
@@ -777,9 +1146,48 @@ A correct executor must generate the following result for that selection set:
 }
 ```
 
-When subsections contain a `@stream` directive, these subsections are no longer
-required to execute serially. Execution of the streamed sections of the
-subsection may be executed in parallel, as defined in {ExecuteStreamField}.
+When subsections contain a `@stream` or `@defer` directive, these subsections
+are no longer required to execute serially. Execution of the deferred or
+streamed sections of the subsection may be executed in parallel, as defined in
+{ExecuteDeferredGroupedFieldSets} and {ExecuteStreamField}.
+
+## Executing Deferred Grouped Field Sets
+
+ExecuteDeferredGroupedFieldSets(objectType, objectValue, variableValues,
+newGroupedFieldSets, shouldInitiateDefer, path, deferMap):
+
+- Initialize {futures} to an empty list.
+- For each {deferUsageSet} and {newGroupedFieldSet} in {newGroupedFieldSets}:
+  - Let {deferredFragments} be an empty list.
+  - For each {deferUsage} in {deferUsageSet}:
+    - Let {deferredFragment} be the entry for {deferUsage} in {deferMap}.
+    - Append {deferredFragment} to {deferredFragments}.
+  - Let {groupedFieldSet} be the corresponding entries on {newGroupedFieldSet}.
+  - Let {future} represent the future execution of
+    {ExecuteDeferredGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+    variableValues, deferredFragments, path, deferUsageSet, deferMap)},
+    incrementally completing {deferredFragments}.
+  - If {shouldInitiateDefer} is {false}:
+    - Initiate {future}.
+  - Otherwise, if early execution of deferred fields is desired:
+    - Following any implementation specific deferral of further execution,
+      initiate {future}.
+  - Append {future} to {futures}.
+- Let {incrementalDigest} be a new Incremental Digest created from {futures}.
+- Return {incrementalDigest}.
+
+ExecuteDeferredGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+variableValues, path, deferUsageSet, deferMap):
+
+- Let {data} and {incrementalDigests} be the result of running
+  {ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+  variableValues, path, deferUsageSet, deferMap)} _normally_ (allowing
+  parallelization).
+- Let {errors} be the list of all _field error_ raised while executing the
+  {groupedFieldSet}.
+- Let {deferredResult} be an unordered map containing {path},
+  {deferredFragments}, {data}, {errors}, and {incrementalDigests}.
+- Return {deferredResult}.
 
 ## Executing Fields
 
@@ -789,17 +1197,19 @@ coerces any provided argument values, then resolves a value for the field, and
 finally completes that value either by recursively executing another selection
 set or coercing a scalar value.
 
-ExecuteField(objectType, objectValue, fieldType, fields, variableValues, path):
+ExecuteField(objectType, objectValue, fieldType, fieldDetailsList,
+variableValues, path, deferUsageSet, deferMap):
 
-- Let {field} be the first entry in {fields}.
-- Let {fieldName} be the field name of {field}.
+- Let {fieldDetails} be the first entry in {fieldDetailsList}.
+- Let {node} be the corresponding entry on {fieldDetails}.
+- Let {fieldName} be the field name of {node}.
 - Append {fieldName} to {path}.
 - Let {argumentValues} be the result of {CoerceArgumentValues(objectType, field,
   variableValues)}
 - Let {resolvedValue} be {ResolveFieldValue(objectType, objectValue, fieldName,
   argumentValues)}.
 - Return the result of {CompleteValue(fieldType, fields, resolvedValue,
-  variableValues, path)}.
+  variableValues, path, deferUsageSet, deferMap)}.
 
 ### Coercing Field Arguments
 
@@ -899,7 +1309,8 @@ completion process. In the case where `@stream` is specified on a field of list
 type, value completion iterates over the collection until the number of items
 yielded items satisfies `initialCount` specified on the `@stream` directive.
 
-CompleteValue(fieldType, fields, result, variableValues, path):
+CompleteValue(fieldType, fieldDetailsList, result, variableValues, path,
+deferUsageSet, deferMap):
 
 - If the {fieldType} is a Non-Null type:
   - Let {innerType} be the inner type of {fieldType}.
@@ -932,6 +1343,8 @@ CompleteValue(fieldType, fields, result, variableValues, path):
     - If {streamDirective} is defined and {index} is greater than or equal to
       {initialCount}:
       - Let {stream} be an unordered map containing {path} and {label}.
+      - Let {streamFieldDetails} be the result of
+        {GetStreamFieldDetailsList(fieldDetailsList)}.
       - Let {future} represent the future execution of
         {ExecuteStreamField(stream, iterator, streamFieldDetailsList, index,
         innerType, variableValues)}.
@@ -961,15 +1374,26 @@ CompleteValue(fieldType, fields, result, variableValues, path):
     - Let {objectType} be {fieldType}.
   - Otherwise if {fieldType} is an Interface or Union type.
     - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
-  - Let {groupedFieldSet} be the result of calling {CollectSubfields(objectType,
-    fields, variableValues)}.
-  - Return the result of evaluating {ExecuteGroupedFieldSet(groupedFieldSet,
-    objectType, result, variableValues)} _normally_ (allowing for
-    parallelization).
+  - Let {groupedFieldSet} and {newDeferUsages} be the result of calling
+    {CollectSubfields(objectType, fieldDetailsList, variableValues)}.
+  - Let {fieldPlan} be the result of {BuildFieldPlan(groupedFieldSet,
+    deferUsageSet)}.
+  - Return the result of {ExecuteFieldPlan(newDeferUsages, fieldPlan,
+    objectType, result, variableValues, false, path, deferUsageSet, deferMap)}.
+
+GetStreamFieldDetailsList(fieldDetailsList):
+
+- Let {streamFields} be an empty list.
+- For each {fieldDetails} in {fieldDetailsList}:
+  - Let {node} be the corresponding entry on {fieldDetails}.
+  - Let {newFieldDetails} be a new Field Details record created from {node}.
+  - Append {newFieldDetails} to {streamFields}.
+- Return {streamFields}.
 
 #### Execute Stream Field
 
-ExecuteStreamField(stream, iterator, fields, index, innerType, variableValues):
+ExecuteStreamField(stream, iterator, fieldDetailsList, index, innerType,
+variableValues):
 
 - Let {path} be the corresponding entry on {stream}.
 - Let {itemPath} be {path} with {index} appended.
@@ -984,7 +1408,7 @@ ExecuteStreamField(stream, iterator, fields, index, innerType, variableValues):
 - Let {errors} be the list of all _field error_ raised while completing the
   item.
 - Let {future} represent the future execution of {ExecuteStreamField(stream,
-  path, iterator, fields, nextIndex, innerType, variableValues)}.
+  path, iterator, fieldDetailsList, nextIndex, innerType, variableValues)}.
 - If early execution of streamed fields is desired:
   - Following any implementation specific deferral of further execution,
     initiate {future}.
@@ -1060,14 +1484,15 @@ sub-selections.
 After resolving the value for `me`, the selection sets are merged together so
 `firstName` and `lastName` can be resolved for one value.
 
-CollectSubfields(objectType, fields, variableValues):
+CollectSubfields(objectType, fieldDetailsList, variableValues):
 
 - Let {groupedFieldSet} be an empty map.
-- For each {field} in {fields}:
+- For each {fieldDetails} in {fieldDetailsList}:
+  - Let {field} and {deferUsage} be the corresponding entries on {fieldDetails}.
   - Let {fieldSelectionSet} be the selection set of {field}.
   - If {fieldSelectionSet} is null or empty, continue to the next field.
   - Let {subGroupedFieldSet} be the result of {CollectFields(objectType,
-    fieldSelectionSet, variableValues)}.
+    fieldSelectionSet, variableValues, deferUsage)}.
   - For each {subGroupedFieldSet} as {responseKey} and {subfields}:
     - Let {groupForResponseKey} be the list in {groupedFieldSet} for
       {responseKey}; if no such list exists, create it as an empty list.
@@ -1107,9 +1532,83 @@ resolves to {null}, then the entire list must resolve to {null}. If the `List`
 type is also wrapped in a `Non-Null`, the field error continues to propagate
 upwards.
 
-When a field error is raised inside `ExecuteStreamField`, the stream payloads
-act as error boundaries. That is, the null resulting from a `Non-Null` type
-cannot propagate outside of the boundary of the stream payload.
+When a field error is raised inside `ExecuteDeferredGroupedFieldSets` or
+`ExecuteStreamField`, the defer and stream payloads act as error boundaries.
+That is, the null resulting from a `Non-Null` type cannot propagate outside of
+the boundary of the defer or stream payload.
+
+If a field error is raised while executing the selection set of a fragment with
+the `defer` directive, causing a {null} to propagate to the object containing
+this fragment, the {null} should not be sent to the client, as this will
+overwrite existing data. In this case, the associated Defer Payload's
+`completed` entry must include the causative errors, whose presence indicated
+the failure of the payload to be included within the final reconcilable object.
+
+For example, assume the `month` field is a `Non-Null` type that raises a field
+error:
+
+```graphql example
+{
+  birthday {
+    ... @defer(label: "monthDefer") {
+      month
+    }
+    ... @defer(label: "yearDefer") {
+      year
+    }
+  }
+}
+```
+
+Response 1, the initial response is sent:
+
+```json example
+{
+  "data": { "birthday": {} },
+  "pending": [
+    { "path": ["birthday"], "label": "monthDefer" }
+    { "path": ["birthday"], "label": "yearDefer" }
+  ],
+  "hasNext": true
+}
+```
+
+Response 2, the defer payload for label "monthDefer" is completed with errors.
+Incremental data cannot be sent, as this would overwrite previously sent values.
+
+```json example
+{
+  "completed": [
+    {
+      "path": ["birthday"],
+      "label": "monthDefer",
+      "errors": [...]
+    }
+  ],
+  "hasNext": false
+}
+```
+
+Response 3, the defer payload for label "yearDefer" is sent. The data in this
+payload is unaffected by the previous null error.
+
+```json example
+{
+  "incremental": [
+    {
+      "path": ["birthday"],
+      "data": { "year": "2022" }
+    }
+  ],
+  "completed": [
+    {
+      "path": ["birthday"],
+      "label": "yearDefer"
+    }
+  ],
+  "hasNext": false
+}
+```
 
 If the `stream` directive is present on a list field with a Non-Nullable inner
 type, and a field error has caused a {null} to propagate to the list item, the

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -748,10 +748,9 @@ YieldIncrementalResults(newFutures, originalFutureStates, originalDeferStates):
 - For each {future} in {newFutures}:
   - Let {futureState} be a new unordered map.
   - If {futureState} incrementally completes Deferred Fragments:
-    - Let {deferredFragments} be those Deferred Fragments.
-    - Let {count} be the length of {deferredFragments}.
-    - Set the corresponding entries on {futureState} to {count} and
-      {deferredFragments}.
+    - Let {pendingDeferredFragments} be those Deferred Fragments.
+    - Set the corresponding entry on {futureState} to
+      {pendingDeferredFragments}.
   - Set the entry for {future} in {futureStates} to {futureState}.
 - Let {maybeCompletedFutures} be the set of keys of {originalFutureStates}.
 - Wait for any futures within {maybeCompletedFutures} to complete.
@@ -1000,10 +999,10 @@ originalDeferStates):
   - Let {futureState} be the entry for {future} on {futureStates}.
   - Let {newFutureState} be a new unordered map containing all entries in
     {futureState}.
-  - Reset {deferredFragments} on {newFutureState} to a new set containing all of
-    the original members except for {deferredFragment}.
-  - If {deferredFragments} on {futureState} is empty, remove the entry for
-    {future} in {futureStates}.
+  - Reset {pendingDeferredFragments} on {newFutureState} to a new set containing
+    all of the original members except for {deferredFragment}.
+  - If {pendingDeferredFragments} on {futureState} is empty, remove the entry
+    for {future} in {futureStates}.
   - Otherwise, set the entry for {future} in {futureStates} to {newFutureState}.
 - For each {child} of {children}:
   - Let {childDeferState} be the entry on {deferStates} for {child}.
@@ -1022,16 +1021,15 @@ originalDeferStates):
 - Initialize {newFutures} to the empty set.
 - For each {completedFuture} in {completedFutures}:
   - Let {futureState} be the entry for {completedFuture} in {futureStates}.
-  - Let {sent} be the corresponding entry on {futureState}.
-  - If {sent} is {true}, continue to the next {completedFuture} in
+  - If {futureState} is not defined, continue to the next {completedFuture} in
     {completedFutures}.
   - Let {newFutureState} be a new unordered map containing all entries in
     {futureState}.
-  - Set the entry for {sent} in {newFutureState} to {true}.
   - Set the entry for {completedFuture} in {futureStates} to {newFutureState}.
-  - Decrement the entry for {count} on {futureState}.
-  - If {count} on {futureState} is {0}, remove the entry for {completedFuture}
-    from {futureStates}.
+  - Reset {pendingDeferredFragments} on {newFutureState} to a new set containing
+    all of the original members except for {deferredFragment}.
+  - If {pendingDeferredFragments} is empty, remove the entry for
+    {completedFuture} from {futureStates}.
   - Let {deferredResult} be the result of {completedFuture}.
   - Append {deferredResult} to {incremental}.
   - Let {newPendingResults} and {futures} be the corresponding entries on

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -688,6 +688,8 @@ ProcessIncrementalDigests(incrementalDigests, originalDeferStates):
       - Append {newPendingResult} to {children}.
       - Set the corresponding entry on {newParentDeferState} to {children}.
       - Set the entry for {parent} in {deferStates} to {newDeferState}.
+  - Otherwise:
+    - Append {newPendingResult} to {pending}.
 - Return {pending}, {futures}, and {deferStates}.
 
 GetParentAndParentDeferState(deferState, deferStates):

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -832,7 +832,7 @@ FilterDefers(newPendingResults, futures, originalDeferStates):
 - Let {streamFutures} and {deferStates} be the result of
   GetStreamFutures(originalDeferStates, futures).
 - Let {pending}, {newFutures}, and {deferStates} be the result of
-  {GetSinglyDeferredFutures(newPendingResults, deferStates)}.
+  {FilterNestedDefers(newPendingResults, deferStates)}.
 - Return {pending}, {newFutures}, and {deferStates}.
 
 GetStreamFutures(deferStates, futures):
@@ -860,7 +860,7 @@ GetStreamFutures(deferStates, futures):
     - Set the entry for {deferredFragment} in {deferStates} to {newDeferState}.
 - Return {streamFutures} and {deferStates}.
 
-GetSinglyDeferredFutures(newPendingResults, originalDeferStates):
+FilterNestedDefers(newPendingResults, originalDeferStates):
 
 - Let {deferStates} be a new unordered map containing all entries in
   {originalDeferStates}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1007,8 +1007,6 @@ originalDeferStates):
   - Otherwise, set the entry for {future} in {futureStates} to {newFutureState}.
 - For each {child} of {children}:
   - Let {childDeferState} be the entry on {deferStates} for {child}.
-  - If {childDeferState} is not defined, continue to the next {child} of
-    {children}.
   - Let {deferStates} be the result of {RemoveFragment(child, childDeferState,
     futureStates, deferStates)}.
 - Return {futureStates} and {deferStates}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -897,22 +897,21 @@ ReleaseFragment(deferredFragment, deferStates):
 - Let {deferStates} be a new unordered map containing all entries in
   {originalDeferStates}.
 - Let {deferState} be the entry in {deferStates} for {newPendingResult}.
-- Remove the entry for {deferredFragment} on {deferStates}.
+- Initialize {futuresToRelease} to an empty list.
 - Let {unreleasedFutures} be the corresponding entry on {deferState}.
-- If {unreleasedFutures} is empty:
+- Append all items in {unreleasedFutures} to {futuresToRelease}.
+- Let {pendingFutures} be a new list containing all members of {pendingFutures}
+  on {deferState}.
+- Append all of the items in {unreleasedFutures} to {pendingFutures}.
+- Set the corresponding entry on {deferState} to {pendingFutures}.
+- If {pendingFutures} is empty:
+  - Remove the entry for {deferredFragment} on {deferStates}.
   - Let {children} be the corresponding entry on {deferState}.
-  - Initialize {futuresToRelease} to an empty list.
   - For each {child} of {children}:
     - Let {childFuturesToRelease} and {deferStates} be the result of
       ReleaseFragment(child, deferStates).
     - Append all of the items in {childFuturesToRelease} to {futuresToRelease}.
-    - Return {futuresToRelease} and {deferStates}.
-- Let {pendingFutures} be a new list containing all members of {pendingFutures}
-  on {deferState}.
-- Append all of the items in {unreleasedFutures} to {pendingFutures}.
-- Reset {unreleasedFutures} on {deferState} to an empty list.
-- Set the corresponding entry on {deferState} to {pendingFutures}.
-- Return {unreleasedFutures} and {deferStates}.
+- Return {futuresToRelease} and {deferStates}.
 
 GetUpdateForStreamItems(originalDeferStates, completedFuture):
 
@@ -996,7 +995,8 @@ originalDeferStates):
 - Let {futureStates} and {deferStates} be a new unordered map containing all the
   entries in {originalFutureStates} and {originalDeferStates}, respectively.
 - Remove the entry for {deferredFragment} on {deferStates}.
-- Let {pendingFutures} and {children} be the corresponding entry on {deferState}.
+- Let {pendingFutures} and {children} be the corresponding entry on
+  {deferState}.
 - For each {future} of {pendingFutures}:
   - Let {futureState} be the entry for {future} on {futureStates}.
   - Let {newFutureState} be a new unordered map containing all entries in

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -808,20 +808,19 @@ originalDeferStates, originalNewFutures, originalUpdate).
     - Remove the entry for {completedFuture} from {futureStates}.
     - Return {update}, {pending}, {newFutures}, and {deferStates}.
   - Otherwise, if {completedFuture} incrementally completes a stream:
-    - Let {resultUpdate}, {resultPending}, {resultNewFutures}, and {deferStates}
-      be the result of {GetUpdateForStreamItems(deferStates, completedFuture)}.
+    - Let {resultUpdate}, {resultNewFutures}, and {deferStates} be the result of
+      {GetUpdateForStreamItems(deferStates, completedFuture)}.
     - Remove the entry for {completedFuture} from {futureStates}.
   - Otherwise:
     - Let {sent} be the corresponding entry on {futureState}.
     - If {sent} is {true}, continue to the next {completedFuture} in
       {completedFutures}.
-    - Let {resultUpdate}, {resultPending}, {resultNewFutures}, {futureStates},
-      and {deferStates} be the result of
-      {GetUpdateForDeferredResult(futureStates, deferStates, completedFuture)}.
-  - Append all items in {resultPending} to {pending}.
+    - Let {resultUpdate}, {resultNewFutures}, {futureStates}, and {deferStates}
+      be the result of {GetUpdateForDeferredResult(futureStates, deferStates,
+      completedFuture)}.
   - Add all items in {resultNewFutures} to {newFutures}.
-  - Append all of the items in {incremental} and {completed} on {resultUpdate}
-    to {incremental} and {completed}, respectively.
+  - Append all of the items in {pending}, {incremental}, and {completed} on
+    {resultUpdate} to {pending}, {incremental}, and {completed}, respectively.
 - Let {newCompletedFutures} be the completed futures from {newFutures}.
 - Let {update} be a new unordered map containing {pending}, {incremental}, and
   {completed}.
@@ -939,7 +938,8 @@ GetUpdateForStreamItems(originalDeferStates, completedFuture):
     {streamItems}.
   - Let {pending}, {newFutures}, and {deferStates} be the result of
     {FilterDefers(newPendingResults, futures, originalDeferStates)}.
-- Return {update}, {pending}, {newFutures}, and {deferStates}.
+  - Set the corresponding entry on {update} to {pending}.
+- Return {pending}, {newFutures}, and {deferStates}.
 
 GetUpdateForDeferredResult(originalFutureStates, originalDeferStates,
 completedFuture):

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -728,7 +728,7 @@ serial):
   serial)}.
 - Initiate {initialFuture}.
 - Initialize {pendingFutures} to a set containing {initialFuture}.
-- Initialize {pendingResults} {pendingFutures}, and {unsent} to the empty set.
+- Initialize {pendingResults} and {unsent} to the empty set.
 - Initialize {newPendingResultsByFragment}, {pendingFuturesByFragment}, and
   {completedFuturesByFragment} to empty unordered maps.
 - Repeat the following steps:

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -863,7 +863,7 @@ serial):
 - Return {initialResult}.
 
 CompleteFragment(deferredFragment, completedFuturesForFragment,
-pendingFuturesForFragment, newPendingResultsByFragment,
+pendingFuturesByFragment, newPendingResultsByFragment,
 completedFuturesByFragment, unsent):
 
 - Initialize {newFutures} to the empty set.
@@ -888,8 +888,8 @@ completedFuturesByFragment, unsent):
     {fragmentPendingFuturesForFragment}:
     - Let {fragmentNewFutures}, {fragmentPending}, {fragmentIncremental}, and
       {fragmentCompleted}, be the result of {CompleteFragment(deferredFragment,
-      resultsForFragment, pendingFuturesForFragment,
-      newPendingResultsByFragment, resultsByFragment, unsent)}.
+      resultsForFragment, pendingFuturesByFragment, newPendingResultsByFragment,
+      resultsByFragment, unsent)}.
     - Add all items in {fragmentNewFutures} to {newFutures}.
     - Append all items in {fragmentPending} to {pending}.
     - Append all items in {fragmentIncremental} to {incremental}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -746,14 +746,12 @@ YieldIncrementalResults(newFutures, originalFutureStates, originalDeferStates):
 - Let {futureStates} be a new unordered map containing all entries in
   {originalFutureStates}.
 - For each {future} in {newFutures}:
-  - Let {futureState} be the entry for {future} in {futureStates}.
-  - If {futureState} is not defined:
-    - Let {futureState} be a new unordered map.
-    - If {futureState} incrementally completes Deferred Fragments:
-      - Let {defers} be those Deferred Fragments.
-      - Let {count} be {0}.
-      - Set the corresponding entries on {futureState} to {count} and {defers}.
-    - Set the entry for {future} in {futureStates} to {futureState}.
+  - Let {futureState} be a new unordered map.
+  - If {futureState} incrementally completes Deferred Fragments:
+    - Let {defers} be those Deferred Fragments.
+    - Let {count} be {0}.
+    - Set the corresponding entries on {futureState} to {count} and {defers}.
+  - Set the entry for {future} in {futureStates} to {futureState}.
 - Let {maybeCompletedFutures} be the set of keys of {originalFutureStates}.
 - Wait for any futures within {maybeCompletedFutures} to complete.
 - Let {completedFutures} be those completed futures.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -749,7 +749,7 @@ YieldIncrementalResults(newFutures, originalFutureStates, originalDeferStates):
   - Let {futureState} be a new unordered map.
   - If {futureState} incrementally completes Deferred Fragments:
     - Let {defers} be those Deferred Fragments.
-    - Let {count} be {0}.
+    - Let {count} be the length of {defers}.
     - Set the corresponding entries on {futureState} to {count} and {defers}.
   - Set the entry for {future} in {futureStates} to {futureState}.
 - Let {maybeCompletedFutures} be the set of keys of {originalFutureStates}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -748,9 +748,10 @@ YieldIncrementalResults(newFutures, originalFutureStates, originalDeferStates):
 - For each {future} in {newFutures}:
   - Let {futureState} be a new unordered map.
   - If {futureState} incrementally completes Deferred Fragments:
-    - Let {defers} be those Deferred Fragments.
-    - Let {count} be the length of {defers}.
-    - Set the corresponding entries on {futureState} to {count} and {defers}.
+    - Let {deferredFragments} be those Deferred Fragments.
+    - Let {count} be the length of {deferredFragments}.
+    - Set the corresponding entries on {futureState} to {count} and
+      {deferredFragments}.
   - Set the entry for {future} in {futureStates} to {futureState}.
 - Let {maybeCompletedFutures} be the set of keys of {originalFutureStates}.
 - Wait for any futures within {maybeCompletedFutures} to complete.
@@ -999,10 +1000,10 @@ originalDeferStates):
   - Let {futureState} be the entry for {future} on {futureStates}.
   - Let {newFutureState} be a new unordered map containing all entries in
     {futureState}.
-  - Reset {defers} on {newFutureState} to a new set containing all of the
-    original members except for {deferredFragment}.
-  - If {defers} on {futureState} is empty, remove the entry for {future} in
-    {futureStates}.
+  - Reset {deferredFragments} on {newFutureState} to a new set containing all of
+    the original members except for {deferredFragment}.
+  - If {deferredFragments} on {futureState} is empty, remove the entry for
+    {future} in {futureStates}.
   - Otherwise, set the entry for {future} in {futureStates} to {newFutureState}.
 - For each {child} of {children}:
   - Let {childDeferState} be the entry on {deferStates} for {child}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -664,6 +664,12 @@ As an example, this might accept the {objectType} `Person`, the {field}
 {"soulMate"}, and the {objectValue} representing John Lennon. It would be
 expected to yield the value representing Yoko Ono.
 
+List values are resolved similarly. For example, {ResolveFieldValue} might also
+accept the {objectType} `MusicBand`, the {field} {"members"}, and the
+{objectValue} representing the Beatles. It would be expected to yield a
+collection of values representing John Lennon, Paul McCartney, Ringo Starr and
+George Harrison.
+
 ResolveFieldValue(objectType, objectValue, fieldName, argumentValues):
 
 - Let {resolver} be the internal function provided by {objectType} for
@@ -674,7 +680,8 @@ ResolveFieldValue(objectType, objectValue, fieldName, argumentValues):
 Note: It is common for {resolver} to be asynchronous due to relying on reading
 an underlying database or networked service to produce a value. This
 necessitates the rest of a GraphQL executor to handle an asynchronous execution
-flow.
+flow. In addition, an implementation for collections may leverage asynchronous
+iterators or asynchronous generators provided by many programming languages.
 
 ### Value Completion
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -846,12 +846,12 @@ pending, incrementalDigests, remainingFutures, pendingFutures):
       {resultIncrementalDigests} be the result of calling
       {GetUpdatesForDeferredResult(deferStates, result)}.
     - Append all items in {resultPending} to {pending}.
-    - Initialize {releasedFutures} and {remainingPendingFutures} to empty lists.
+    - Initialize {remainingPendingFutures} to empty lists.
     - For each {future} in {pendingFutures}:
       - Let {deferredFragments} be the Deferred Fragments completed by {future}.
       - For each {deferredFragment} of {deferredFragments}:
         - If {deferredFragment} is in {resultPending}, append {future} to
-          {releasedFutures}.
+          {remainingFutures}.
         - Continue to the next {future} in {pendingFutures}.
       - Append {future} to {remainingPendingFutures}.
   - Append {update} to {updates}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -321,31 +321,34 @@ Executing the root selection set works similarly for queries (parallel),
 mutations (serial), and subscriptions (where it is executed for each event in
 the underlying Source Stream).
 
+First, the selection set is turned into a grouped field set; then, we execute
+this grouped field set and return the resulting {data} and {errors}.
+
 ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
 serial):
 
 - If {serial} is not provided, initialize it to {false}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
+- Let {groupedFieldSet} be the result of {CollectFields(objectType,
+  selectionSet, variableValues)}.
+- Let {data} be the result of running {ExecuteGroupedFieldSet(groupedFieldSet,
   objectType, initialValue, variableValues)} _serially_ if {serial} is {true},
   _normally_ (allowing parallelization) otherwise.
 - Let {errors} be the list of all _field error_ raised while executing the
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
-## Executing Selection Sets
+## Executing a Grouped Field Set
 
-To execute a selection set, the object value being evaluated and the object type
-need to be known, as well as whether it must be executed serially, or may be
-executed in parallel.
+To execute a grouped field set, the object value being evaluated and the object
+type need to be known, as well as whether it must be executed serially, or may
+be executed in parallel.
 
-First, the selection set is turned into a grouped field set; then, each
-represented field in the grouped field set produces an entry into a response
-map.
+Each represented field in the grouped field set produces an entry into a
+response map.
 
-ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues):
+ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+variableValues):
 
-- Let {groupedFieldSet} be the result of {CollectFields(objectType,
-  selectionSet, variableValues)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -363,8 +366,8 @@ is explained in greater detail in the Field Collection section below.
 
 **Errors and Non-Null Fields**
 
-If during {ExecuteSelectionSet()} a field with a non-null {fieldType} raises a
-_field error_ then that error must propagate to this entire selection set,
+If during {ExecuteGroupedFieldSet()} a field with a non-null {fieldType} raises
+a _field error_ then that error must propagate to this entire selection set,
 either resolving to {null} if allowed or further propagated to a parent field.
 
 If this occurs, any sibling fields which have not yet executed or have not yet
@@ -702,8 +705,9 @@ CompleteValue(fieldType, fields, result, variableValues):
     - Let {objectType} be {fieldType}.
   - Otherwise if {fieldType} is an Interface or Union type.
     - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
-  - Let {subSelectionSet} be the result of calling {MergeSelectionSets(fields)}.
-  - Return the result of evaluating {ExecuteSelectionSet(subSelectionSet,
+  - Let {groupedFieldSet} be the result of calling {CollectSubfields(objectType,
+    fields, variableValues)}.
+  - Return the result of evaluating {ExecuteGroupedFieldSet(groupedFieldSet,
     objectType, result, variableValues)} _normally_ (allowing for
     parallelization).
 
@@ -750,9 +754,9 @@ ResolveAbstractType(abstractType, objectValue):
 
 **Merging Selection Sets**
 
-When more than one field of the same name is executed in parallel, their
-selection sets are merged together when completing the value in order to
-continue execution of the sub-selection sets.
+When more than one field of the same name is executed in parallel, during value
+completion their selection sets are collected together to produce a single
+grouped field set in order to continue execution of the sub-selection sets.
 
 An example operation illustrating parallel fields with the same name with
 sub-selections.
@@ -771,14 +775,19 @@ sub-selections.
 After resolving the value for `me`, the selection sets are merged together so
 `firstName` and `lastName` can be resolved for one value.
 
-MergeSelectionSets(fields):
+CollectSubfields(objectType, fields, variableValues):
 
-- Let {selectionSet} be an empty list.
+- Let {groupedFieldSet} be an empty map.
 - For each {field} in {fields}:
   - Let {fieldSelectionSet} be the selection set of {field}.
   - If {fieldSelectionSet} is null or empty, continue to the next field.
-  - Append all selections in {fieldSelectionSet} to {selectionSet}.
-- Return {selectionSet}.
+  - Let {subGroupedFieldSet} be the result of {CollectFields(objectType,
+    fieldSelectionSet, variableValues)}.
+  - For each {subGroupedFieldSet} as {responseKey} and {subfields}:
+    - Let {groupForResponseKey} be the list in {groupedFieldSet} for
+      {responseKey}; if no such list exists, create it as an empty list.
+    - Append all fields in {subfields} to {groupForResponseKey}.
+- Return {groupedFieldSet}.
 
 ### Handling Field Errors
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -842,7 +842,8 @@ serial):
       - Let {incrementalResult} be a new unordered map containing {pending},
         {incremental}, {completed} and {hasNext}.
       - Yield {update}.
-    - If {hasNext} is {false}, complete this incremental result stream.
+    - If {hasNext} is {false}, complete this incremental result stream and
+      return.
 
 ExecuteInitialResult(variableValues, initialValue, objectType, selectionSet,
 serial):

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1103,7 +1103,7 @@ GetNewDeferredFragments(newDeferUsages, path, deferMap):
   - Let {parentDeferUsage} be the corresponding entry on {deferUsage}.
   - Let {parent} be the entry in {deferMap} for {parentDeferUsage}.
   - Let {label} be the corresponding entry on {deferUsage}.
-  - Let {newDeferredFragment} be an unordered map containing {ancestors}, {path}
+  - Let {newDeferredFragment} be an unordered map containing {parent}, {path}
     and {label}.
   - Append {newDeferredFragment} to {newDeferredFragments}.
   - Set the entry for {deferUsage} in {newDeferMap} to {newDeferredFragment}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1105,7 +1105,7 @@ GetNewDeferredFragments(newDeferUsages, path, deferMap):
 - Let {newDeferMap} be a new unordered map of Defer Usage records to Deferred
   Fragment records containing all of the entries in {deferMap}.
 - For each {deferUsage} in {newDeferUsages}:
-  - Let {parentDeferUsage} be the corresponding entry on {deferUsage.}
+  - Let {parentDeferUsage} be the corresponding entry on {deferUsage}.
   - Let {parent} be the entry in {deferMap} for {parentDeferUsage}.
   - Let {label} be the corresponding entry on {deferUsage}.
   - Let {newDeferredFragment} be an unordered map containing {ancestors}, {path}

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -674,7 +674,7 @@ ProcessIncrementalDigests(incrementalDigests, originalDeferStates):
     - Set the entry for {deferredFragment} in {deferStates} to {deferState}.
 - Initialize {pending} to an empty list.
 - For each {newPendingResult} in {newPendingResults}:
-  - If {newPendingResult} is a deferred fragment:
+  - If {newPendingResult} is a Deferred Fragment:
     - Let {deferState} be the entry in {deferStates} for {newPendingResult}.
     - Let {parent} and {parentDeferState} be the result of
       {GetParentAndParentDeferState(deferState, deferStates)}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -780,8 +780,8 @@ possibly:
 - Contributing data for the next payload.
 - Containing additional pending results or futures.
 
-When encountering completed futures, {ProcessCompletedFutures()} calls itself
-recursively on any new futures in case they have been completed.
+{ProcessCompletedFutures()} may calls itself recursively on any new futures in
+the event that they have completed.
 
 ProcessCompletedFutures(completedFutures, originalFutureStates,
 originalDeferStates, originalNewFutures, originalUpdate).

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -337,6 +337,112 @@ serial):
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
+### Field Collection
+
+Before execution, the selection set is converted to a grouped field set by
+calling {CollectFields()}. Each entry in the grouped field set is a list of
+fields that share a response key (the alias if defined, otherwise the field
+name). This ensures all fields with the same response key (including those in
+referenced fragments) are executed at the same time.
+
+As an example, collecting the fields of this selection set would collect two
+instances of the field `a` and one of field `b`:
+
+```graphql example
+{
+  a {
+    subfield1
+  }
+  ...ExampleFragment
+}
+
+fragment ExampleFragment on Query {
+  a {
+    subfield2
+  }
+  b
+}
+```
+
+The depth-first-search order of the field groups produced by {CollectFields()}
+is maintained through execution, ensuring that fields appear in the executed
+response in a stable and predictable order.
+
+CollectFields(objectType, selectionSet, variableValues, visitedFragments):
+
+- If {visitedFragments} is not provided, initialize it to the empty set.
+- Initialize {groupedFields} to an empty ordered map of lists.
+- For each {selection} in {selectionSet}:
+  - If {selection} provides the directive `@skip`, let {skipDirective} be that
+    directive.
+    - If {skipDirective}'s {if} argument is {true} or is a variable in
+      {variableValues} with the value {true}, continue with the next {selection}
+      in {selectionSet}.
+  - If {selection} provides the directive `@include`, let {includeDirective} be
+    that directive.
+    - If {includeDirective}'s {if} argument is not {true} and is not a variable
+      in {variableValues} with the value {true}, continue with the next
+      {selection} in {selectionSet}.
+  - If {selection} is a {Field}:
+    - Let {responseKey} be the response key of {selection} (the alias if
+      defined, otherwise the field name).
+    - Let {groupForResponseKey} be the list in {groupedFields} for
+      {responseKey}; if no such list exists, create it as an empty list.
+    - Append {selection} to the {groupForResponseKey}.
+  - If {selection} is a {FragmentSpread}:
+    - Let {fragmentSpreadName} be the name of {selection}.
+    - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
+      {selection} in {selectionSet}.
+    - Add {fragmentSpreadName} to {visitedFragments}.
+    - Let {fragment} be the Fragment in the current Document whose name is
+      {fragmentSpreadName}.
+    - If no such {fragment} exists, continue with the next {selection} in
+      {selectionSet}.
+    - Let {fragmentType} be the type condition on {fragment}.
+    - If {DoesFragmentTypeApply(objectType, fragmentType)} is false, continue
+      with the next {selection} in {selectionSet}.
+    - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
+    - Let {fragmentGroupedFieldSet} be the result of calling
+      {CollectFields(objectType, fragmentSelectionSet, variableValues,
+      visitedFragments)}.
+    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
+      - Let {responseKey} be the response key shared by all fields in
+        {fragmentGroup}.
+      - Let {groupForResponseKey} be the list in {groupedFields} for
+        {responseKey}; if no such list exists, create it as an empty list.
+      - Append all items in {fragmentGroup} to {groupForResponseKey}.
+  - If {selection} is an {InlineFragment}:
+    - Let {fragmentType} be the type condition on {selection}.
+    - If {fragmentType} is not {null} and {DoesFragmentTypeApply(objectType,
+      fragmentType)} is false, continue with the next {selection} in
+      {selectionSet}.
+    - Let {fragmentSelectionSet} be the top-level selection set of {selection}.
+    - Let {fragmentGroupedFieldSet} be the result of calling
+      {CollectFields(objectType, fragmentSelectionSet, variableValues,
+      visitedFragments)}.
+    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
+      - Let {responseKey} be the response key shared by all fields in
+        {fragmentGroup}.
+      - Let {groupForResponseKey} be the list in {groupedFields} for
+        {responseKey}; if no such list exists, create it as an empty list.
+      - Append all items in {fragmentGroup} to {groupForResponseKey}.
+- Return {groupedFields}.
+
+DoesFragmentTypeApply(objectType, fragmentType):
+
+- If {fragmentType} is an Object Type:
+  - if {objectType} and {fragmentType} are the same type, return {true},
+    otherwise return {false}.
+- If {fragmentType} is an Interface Type:
+  - if {objectType} is an implementation of {fragmentType}, return {true}
+    otherwise return {false}.
+- If {fragmentType} is a Union:
+  - if {objectType} is a possible type of {fragmentType}, return {true}
+    otherwise return {false}.
+
+Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
+directives may be applied in either order since they apply commutatively.
+
 ## Executing a Grouped Field Set
 
 To execute a grouped field set, the object value being evaluated and the object
@@ -362,7 +468,7 @@ variableValues):
 - Return {resultMap}.
 
 Note: {resultMap} is ordered by which fields appear first in the operation. This
-is explained in greater detail in the Field Collection section below.
+is explained in greater detail in the Field Collection section above.
 
 **Errors and Non-Null Fields**
 
@@ -471,112 +577,6 @@ A correct executor must generate the following result for that selection set:
   }
 }
 ```
-
-### Field Collection
-
-Before execution, the selection set is converted to a grouped field set by
-calling {CollectFields()}. Each entry in the grouped field set is a list of
-fields that share a response key (the alias if defined, otherwise the field
-name). This ensures all fields with the same response key (including those in
-referenced fragments) are executed at the same time.
-
-As an example, collecting the fields of this selection set would collect two
-instances of the field `a` and one of field `b`:
-
-```graphql example
-{
-  a {
-    subfield1
-  }
-  ...ExampleFragment
-}
-
-fragment ExampleFragment on Query {
-  a {
-    subfield2
-  }
-  b
-}
-```
-
-The depth-first-search order of the field groups produced by {CollectFields()}
-is maintained through execution, ensuring that fields appear in the executed
-response in a stable and predictable order.
-
-CollectFields(objectType, selectionSet, variableValues, visitedFragments):
-
-- If {visitedFragments} is not provided, initialize it to the empty set.
-- Initialize {groupedFields} to an empty ordered map of lists.
-- For each {selection} in {selectionSet}:
-  - If {selection} provides the directive `@skip`, let {skipDirective} be that
-    directive.
-    - If {skipDirective}'s {if} argument is {true} or is a variable in
-      {variableValues} with the value {true}, continue with the next {selection}
-      in {selectionSet}.
-  - If {selection} provides the directive `@include`, let {includeDirective} be
-    that directive.
-    - If {includeDirective}'s {if} argument is not {true} and is not a variable
-      in {variableValues} with the value {true}, continue with the next
-      {selection} in {selectionSet}.
-  - If {selection} is a {Field}:
-    - Let {responseKey} be the response key of {selection} (the alias if
-      defined, otherwise the field name).
-    - Let {groupForResponseKey} be the list in {groupedFields} for
-      {responseKey}; if no such list exists, create it as an empty list.
-    - Append {selection} to the {groupForResponseKey}.
-  - If {selection} is a {FragmentSpread}:
-    - Let {fragmentSpreadName} be the name of {selection}.
-    - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
-      {selection} in {selectionSet}.
-    - Add {fragmentSpreadName} to {visitedFragments}.
-    - Let {fragment} be the Fragment in the current Document whose name is
-      {fragmentSpreadName}.
-    - If no such {fragment} exists, continue with the next {selection} in
-      {selectionSet}.
-    - Let {fragmentType} be the type condition on {fragment}.
-    - If {DoesFragmentTypeApply(objectType, fragmentType)} is false, continue
-      with the next {selection} in {selectionSet}.
-    - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
-    - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments)}.
-    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
-      - Let {responseKey} be the response key shared by all fields in
-        {fragmentGroup}.
-      - Let {groupForResponseKey} be the list in {groupedFields} for
-        {responseKey}; if no such list exists, create it as an empty list.
-      - Append all items in {fragmentGroup} to {groupForResponseKey}.
-  - If {selection} is an {InlineFragment}:
-    - Let {fragmentType} be the type condition on {selection}.
-    - If {fragmentType} is not {null} and {DoesFragmentTypeApply(objectType,
-      fragmentType)} is false, continue with the next {selection} in
-      {selectionSet}.
-    - Let {fragmentSelectionSet} be the top-level selection set of {selection}.
-    - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments)}.
-    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
-      - Let {responseKey} be the response key shared by all fields in
-        {fragmentGroup}.
-      - Let {groupForResponseKey} be the list in {groupedFields} for
-        {responseKey}; if no such list exists, create it as an empty list.
-      - Append all items in {fragmentGroup} to {groupForResponseKey}.
-- Return {groupedFields}.
-
-DoesFragmentTypeApply(objectType, fragmentType):
-
-- If {fragmentType} is an Object Type:
-  - if {objectType} and {fragmentType} are the same type, return {true},
-    otherwise return {false}.
-- If {fragmentType} is an Interface Type:
-  - if {objectType} is an implementation of {fragmentType}, return {true}
-    otherwise return {false}.
-- If {fragmentType} is a Union:
-  - if {objectType} is a possible type of {fragmentType}, return {true}
-    otherwise return {false}.
-
-Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
-directives may be applied in either order since they apply commutatively.
 
 ## Executing Fields
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -648,9 +648,12 @@ An Incremental Digest is a structure containing:
   contain additional Incremental Digests that will immediately or eventually
   complete those results.
 
-Given the current state of any pending results, if any, the
-{ProcessIncrementalDigests()} algorithm describes how incremental digests are
-processed to update that state as incremental digests are encountered.
+Incremental digests must be processed carefully because pending results must be
+delivered to the client in the appropriate order. In particular, nested deferred
+fragments may complete in any order, and the results of those fragments must be
+delivered to the client in the order in which they were specified in the
+operation. The {ProcessIncrementalDigests()} algorithm manages the tree that
+maintains the correct delivery order.
 
 ProcessIncrementalDigests(incrementalDigests, originalDeferStates):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -131,12 +131,8 @@ ExecuteQuery(query, schema, variableValues, initialValue):
 - Let {queryType} be the root Query type in {schema}.
 - Assert: {queryType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {query}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  queryType, initialValue, variableValues)} _normally_ (allowing
-  parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue, queryType,
+  selectionSet)}.
 
 ### Mutation
 
@@ -153,11 +149,8 @@ ExecuteMutation(mutation, schema, variableValues, initialValue):
 - Let {mutationType} be the root Mutation type in {schema}.
 - Assert: {mutationType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {mutation}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  mutationType, initialValue, variableValues)} _serially_.
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue, mutationType,
+  selectionSet, true)}.
 
 ### Subscription
 
@@ -301,12 +294,8 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 - Let {subscriptionType} be the root Subscription type in {schema}.
 - Assert: {subscriptionType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {subscription}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  subscriptionType, initialValue, variableValues)} _normally_ (allowing
-  parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue,
+  subscriptionType, selectionSet)}.
 
 Note: The {ExecuteSubscriptionEvent()} algorithm is intentionally similar to
 {ExecuteQuery()} since this is how each event result is produced.
@@ -321,6 +310,27 @@ the subscription.
 Unsubscribe(responseStream):
 
 - Cancel {responseStream}
+
+## Executing the Root Selection Set
+
+To execute the root selection set, the object value being evaluated and the
+object type need to be known, as well as whether it must be executed serially,
+or may be executed in parallel.
+
+Executing the root selection set works similarly for queries (parallel),
+mutations (serial), and subscriptions (where it is executed for each event in
+the underlying Source Stream).
+
+ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
+serial):
+
+- If {serial} is not provided, initialize it to {false}.
+- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
+  objectType, initialValue, variableValues)} _serially_ if {serial} is {true},
+  _normally_ (allowing parallelization) otherwise.
+- Let {errors} be the list of all _field error_ raised while executing the
+  selection set.
+- Return an unordered map containing {data} and {errors}.
 
 ## Executing Selection Sets
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1044,9 +1044,9 @@ originalDeferStates):
 - Let {children} be the corresponding entry on {deferState}.
 - Append all items in {children} to {pending}.
 - For each {child} of {children}:
-  - Let {unreleasedFutures} and {deferStates} be the result of {ReleaseFragment(
+  - Let {futuresToRelease} and {deferStates} be the result of {ReleaseFragment(
     child, deferStates)}.
-  - Append all items in {unreleasedFutures} to {newFutures}.
+  - Append all items in {futuresToRelease} to {newFutures}.
   - Let {childDeferState} be the entry for {child} on {deferStates}.
   - Let {pendingFutures} and {completedFutures} be the corresponding entries on
     {childDeferState}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -687,13 +687,13 @@ ProcessIncrementalDigests(incrementalDigests, originalDeferStates):
       - Set the entry for {parent} in {deferStates} to {newDeferState}.
 - Return {pending}, {futures}, and {deferStates}.
 
-GetParentAndPendingInfo(pendingInfo, pendingMap):
+GetParentAndParentDeferState(deferState, deferStates):
 
-- Let {ancestors} be the corresponding entry on {pendingInfo}.
+- Let {ancestors} be the corresponding entry on {deferState}.
 - For each {ancestor} of {ancestors}:
-  - Let {ancestorPendingInfo} be the entry in {pendingMap} for {ancestor}.
-  - If {ancestorPendingInfo} is defined, return {ancestor} and
-    {ancestorPendingInfo}.
+  - Let {ancestorDeferState} be the entry in {deferStates} for {ancestor}.
+  - If {ancestorDeferState} is defined, return {ancestor} and
+    {ancestorDeferState}.
 - Return.
 
 ### Yielding Subsequent Results

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -861,16 +861,17 @@ pending, incrementalDigests, remainingFutures, pendingFutures):
     - Otherwise:
       - Append {resultIncrementalDigest} to {supplementalIncrementalDigests}.
 - If {supplementalIncrementalDigests} is empty:
-  - Let {newPendingResults}, {futures}, and {deferStates} be the result of
+  - Let {newPendingResults}, {newFutures}, and {deferStates} be the result of
     {ProcessIncrementalDigests(incrementalDigests, originalDeferStates)}.
   - Append all items in {newPendingResults} to {pending}.
   - Return {deferStates}, {updates}, {pending}, {newFutures},
     {remainingFutures}, and {remainingPendingFutures}.
-- Let {newPendingResults}, {futures}, and {deferStates} be the results of
+- Let {newPendingResults}, {newFutures}, and {deferStates} be the results of
   {ProcessIncrementalDigests(supplementalIncrementalDigests, deferStates)}.
 - Append all items in {newPendingResults} to {pending}.
-- Return the result of {ProcessCompletedFutures(futures, deferStates, updates,
-  pending, incrementalDigests, remainingFutures, remainingPendingFutures)}.
+- Return the result of {ProcessCompletedFutures(newFutures, deferStates,
+  updates, pending, incrementalDigests, remainingFutures,
+  remainingPendingFutures)}.
 
 GetUpdatesForStreamItems(streamItems):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -675,10 +675,10 @@ ProcessIncrementalDigests(incrementalDigests, originalDeferStates):
 - Initialize {pending} to an empty list.
 - For each {newPendingResult} in {newPendingResults}:
   - If {newPendingResult} is a Deferred Fragment:
-    - Let {deferState} be the entry in {deferStates} for {newPendingResult}.
-    - Let {parent} and {parentDeferState} be the result of
-      {GetParentAndParentDeferState(deferState, deferStates)}.
-    - If {parent} is not defined:
+    - Let {parent} be the result of {GetNonEmptyParent(newPendingResult,
+      deferStates)}.
+    - Let {parentDeferState} be the entry for {parent} on {deferStates}.
+    - If {parentDeferState} is not defined:
       - Append {newPendingResult} to {pending}.
     - Otherwise:
       - Let {newParentDeferState} be an unordered map containing all of the
@@ -692,14 +692,14 @@ ProcessIncrementalDigests(incrementalDigests, originalDeferStates):
     - Append {newPendingResult} to {pending}.
 - Return {pending}, {futures}, and {deferStates}.
 
-GetParentAndParentDeferState(deferState, deferStates):
+GetNonEmptyParent(deferredFragment, deferStates):
 
-- Let {ancestors} be the corresponding entry on {deferState}.
-- For each {ancestor} of {ancestors}:
-  - Let {ancestorDeferState} be the entry in {deferStates} for {ancestor}.
-  - If {ancestorDeferState} is defined, return {ancestor} and
-    {ancestorDeferState}.
-- Return.
+- Let {parent} be the corresponding entry on {deferredFragment}.
+- If {parent} is not defined, return.
+- Let {parentDeferState} be the entry for {parent} on {deferStates}.
+- If {parentDeferState} is not defined, return the result of
+  {GetAncestor(parent, deferStates)}.
+- Return {parent}.
 
 ### Yielding Subsequent Results
 
@@ -986,11 +986,8 @@ GetNewDeferredFragments(newDeferUsages, path, deferMap):
 - Let {newDeferMap} be a new unordered map of Defer Usage records to Deferred
   Fragment records containing all of the entries in {deferMap}.
 - For each {deferUsage} in {newDeferUsages}:
-  - Initialize {ancestors} to an empty list.
-  - Let {deferUsageAncestors} be the result of {GetAncestors(deferUsage)}.
-  - For each {deferUsageAncestor} of {deferUsageAncestors}:
-    - Let {ancestor} be the entry in {deferMap} for {deferUsageAncestor}.
-    - Append {ancestor} to {ancestors}.
+  - Let {parentDeferUsage} be the corresponding entry on {deferUsage.}
+  - Let {parent} be the entry in {deferMap} for {parentDeferUsage}.
   - Let {label} be the corresponding entry on {deferUsage}.
   - Let {newDeferredFragment} be an unordered map containing {ancestors}, {path}
     and {label}.

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -10,7 +10,7 @@ the case that any _field error_ was raised on a field and was replaced with
 
 ## Response Format
 
-A response to a GraphQL request must be a map.
+A response to a GraphQL request must be a map or a response stream of maps.
 
 If the request raised any errors, the response map must contain an entry with
 key `errors`. The value of this entry is described in the "Errors" section. If
@@ -22,14 +22,39 @@ key `data`. The value of this entry is described in the "Data" section. If the
 request failed before execution, due to a syntax error, missing information, or
 validation error, this entry must not be present.
 
+When the response of the GraphQL operation is a response stream, the first value
+will be the initial response. All subsequent values may contain an `incremental`
+entry, containing a list of Stream payloads.
+
+The `label` and `path` entries on Stream payloads are used by clients to
+identify the `@stream` directive from the GraphQL operation that triggered this
+response to be included in an `incremental` entry on a value returned by the
+response stream. When a label is provided, the combination of these two entries
+will be unique across all Stream payloads returned in the response stream.
+
+If the response of the GraphQL operation is a response stream, each response map
+must contain an entry with key `hasNext`. The value of this entry is `true` for
+all but the last response in the stream. The value of this entry is `false` for
+the last response of the stream. This entry must not be present for GraphQL
+operations that return a single response map.
+
+The GraphQL service may determine there are no more values in the response
+stream after a previous value with `hasNext` equal to `true` has been emitted.
+In this case the last value in the response stream should be a map without
+`data` and `incremental` entries, and a `hasNext` entry with a value of `false`.
+
 The response map may also contain an entry with key `extensions`. This entry, if
 set, must have a map as its value. This entry is reserved for implementors to
 extend the protocol however they see fit, and hence there are no additional
-restrictions on its contents.
+restrictions on its contents. When the response of the GraphQL operation is a
+response stream, implementors may send subsequent response maps containing only
+`hasNext` and `extensions` entries. Stream payloads may also contain an entry
+with the key `extensions`, also reserved for implementors to extend the protocol
+however they see fit.
 
 To ensure future changes to the protocol do not break existing services and
 clients, the top level response map must not contain any entries other than the
-three described above.
+five described above.
 
 Note: When `errors` is present in the response, it may be helpful for it to
 appear first when serialized to make it more clear when errors are present in a
@@ -107,14 +132,8 @@ syntax element.
 If an error can be associated to a particular field in the GraphQL result, it
 must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
-`null` result is intentional or caused by a runtime error.
-
-This field should be a list of path segments starting at the root of the
-response and ending with the field associated with the error. Path segments that
-represent fields should be strings, and path segments that represent list
-indices should be 0-indexed integers. If the error happens in an aliased field,
-the path to the error should use the aliased name, since it represents a path in
-the response, not in the request.
+`null` result is intentional or caused by a runtime error. The value of this
+field is described in the [Path](#sec-Path) section.
 
 For example, if fetching one of the friends' names fails in the following
 operation:
@@ -244,6 +263,136 @@ discouraged.
 }
 ```
 
+### Incremental Delivery
+
+The `pending` entry in the response is a non-empty list of references to pending
+Stream results. If the response of the GraphQL operation is a response stream,
+this field should appear on the initial and possibly subsequent payloads.
+
+The `incremental` entry in the response is a non-empty list of data fulfilling
+Stream results. If the response of the GraphQL operation is a response stream,
+this field may appear on the subsequent payloads.
+
+The `completed` entry in the response is a non-empty list of references to
+completed Stream results.
+
+For example:
+
+```graphql example
+query {
+  person(id: "cGVvcGxlOjE=") {
+    name
+    films @stream(initialCount: 1, label: "filmsStream") {
+      title
+    }
+  }
+}
+```
+
+The response stream might look like:
+
+Response 1, the initial response does not contain any streamed results.
+
+```json example
+{
+  "data": {
+    "person": {
+      "name": "Luke Skywalker",
+      "films": [{ "title": "A New Hope" }]
+    }
+  },
+  "pending": [{ "path": ["person", "films"], "label": "filmStream" }],
+  "hasNext": true
+}
+```
+
+Response 2, contains the first stream payload.
+
+```json example
+{
+  "incremental": [
+    {
+      "path": ["person", "films"],
+      "items": [{ "title": "The Empire Strikes Back" }]
+    }
+  ],
+  "hasNext": true
+}
+```
+
+Response 3, contains the final stream payload. In this example, the underlying
+iterator does not close synchronously so {hasNext} is set to {true}. If this
+iterator did close synchronously, {hasNext} would be set to {false} and this
+would be the final response.
+
+```json example
+{
+  "incremental": [
+    {
+      "path": ["person", "films"],
+      "items": [{ "title": "Return of the Jedi" }]
+    }
+  ],
+  "hasNext": true
+}
+```
+
+Response 4, contains no incremental payloads. {hasNext} set to {false} indicates
+the end of the response stream. This response is sent when the underlying
+iterator of the `films` field closes.
+
+```json example
+{
+  "completed": [{ "path": ["person", "films"], "label": "filmStream" }],
+  "hasNext": false
+}
+```
+
+#### Streamed data
+
+Streamed data may appear as an item in the `incremental` entry of a response.
+Streamed data is the result of an associated `@stream` directive in the
+operation. A stream payload must contain `items` and `path` entries and may
+contain `errors`, and `extensions` entries.
+
+##### Items
+
+The `items` entry in a stream payload is a list of results from the execution of
+the associated @stream directive. This output will be a list of the same type of
+the field with the associated `@stream` directive. If an error has caused a
+`null` to bubble up to a field higher than the list field with the associated
+`@stream` directive, then the stream will complete with errors.
+
+#### Path
+
+A `path` field allows for the association to a particular field in a GraphQL
+result. This field should be a list of path segments starting at the root of the
+response and ending with the field to be associated with. Path segments that
+represent fields should be strings, and path segments that represent list
+indices should be 0-indexed integers. If the path is associated to an aliased
+field, the path should use the aliased name, since it represents a path in the
+response, not in the request.
+
+When the `path` field is present on a Stream payload, it indicates that the
+`items` field represents the partial result of the list field containing the
+corresponding `@stream` directive. All but the non-final path segments must
+refer to the location of the list field containing the corresponding `@stream`
+directive. The final segment of the path list must be a 0-indexed integer. This
+integer indicates that this result is set at a range, where the beginning of the
+range is at the index of this integer, and the length of the range is the length
+of the data.
+
+When the `path` field is present on an "Error result", it indicates the response
+field which experienced the error.
+
+#### Label
+
+Stream may contain a string field `label`. This `label` is the same label passed
+to the `@stream` directive associated with the response. This allows clients to
+identify which `@stream` directive is associated with this value. `label` will
+not be present if the corresponding `@stream` directive is not passed a `label`
+argument.
+
 ## Serialization Format
 
 GraphQL does not require a specific serialization format. However, clients
@@ -303,10 +452,10 @@ enables more efficient parsing of responses if the order of properties can be
 anticipated.
 
 Serialization formats which represent an ordered map should preserve the order
-of requested fields as defined by {CollectFields()} in the Execution section.
-Serialization formats which only represent unordered maps but where order is
-still implicit in the serialization's textual order (such as JSON) should
-preserve the order of requested fields textually.
+of requested fields as defined by {AnalyzeSelectionSet()} in the Execution
+section. Serialization formats which only represent unordered maps but where
+order is still implicit in the serialization's textual order (such as JSON)
+should preserve the order of requested fields textually.
 
 For example, if the request was `{ name, age }`, a GraphQL service responding in
 JSON should respond with `{ "name": "Mark", "age": 30 }` and should not respond


### PR DESCRIPTION
Iterating on #1034 and #1026, removed mutation of internal state, event stream management, and the need for subprocedures.

YieldSubsequentPayloads now is passed the entirety of the "state," pending futures, etc, monitors for any changes to pending futures, rebuilds a new "state" representation based on any changes, yields a single result as necessary, and then recursively calls itself to yield remaining results. 

[The diff to main might be helpful, but this is built on top of the amazing #742 and so the diff [from that branch could be more useful](https://github.com/robrichard/graphql-spec/compare/incremental..yaacovCR:graphql-spec:deduplicate3).]
