### PR TITLE
Implementations may not deprecate a field that the interface hasn't deprecated

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -947,6 +947,8 @@ IsValidImplementation(type, implementedType):
        2. Let {implementedFieldType} be the return type of {implementedField}.
        3. {IsValidImplementationFieldType(fieldType, implementedFieldType)} must
           be {true}.
+    6. If the `@deprecated` directive is not applied to {implementedField}, then
+       the `@deprecated` directive must not be applied to {field}.
 
 IsValidImplementationFieldType(fieldType, implementedFieldType):
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -947,8 +947,7 @@ IsValidImplementation(type, implementedType):
        2. Let {implementedFieldType} be the return type of {implementedField}.
        3. {IsValidImplementationFieldType(fieldType, implementedFieldType)} must
           be {true}.
-    6. If the `@deprecated` directive is not applied to {implementedField}, then
-       the `@deprecated` directive must not be applied to {field}.
+    6. If {field} is deprecated then {implementedField} must also be deprecated.
 
 IsValidImplementationFieldType(fieldType, implementedFieldType):
 


### PR DESCRIPTION
This PR addresses a spec validation omission; if an interface field is not deprecated then any implementation of that interface field should also not be deprecated. I.e. the following schema _should_ be invalid, but before this PR it is valid:

```graphql
interface Node {
  id: ID!
}

type Foo implements Node {
  id: ID! @deprecated(reason: "...")
}

type Query {
  foo: Foo
}
```

To solve this, either the deprecation should be removed, or the `id` field on `Node` should _also_ be deprecated:

```graphql
interface Node {
  id: ID! @deprecated(reason: "...")
}
```


Relevant action item: https://github.com/graphql/graphql-wg/issues/1331

GraphQL.js Implementation: https://github.com/graphql/graphql-js/pull/3986