### PR TITLE
Fix heading level for Required Arguments validation rule

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -739,7 +739,7 @@ invalid.
     which contains {argument}.
   - {arguments} must be the set containing only {argument}.
 
-#### Required Arguments
+### Required Arguments
 
 - For each Field or Directive in the document:
   - Let {arguments} be the arguments provided by the Field or Directive.


### PR DESCRIPTION
Currently in the rendered spec, Required Arguments shows up as a sub-rule of "Argument Uniqueness". It's an independent rule so it should show up next to it instead.
<img width="251" alt="image" src="https://github.com/graphql/graphql-spec/assets/1006268/13fc4615-77ea-4b1e-8c11-a7e1cf91215d">
