### PR TITLE
3.10 Input Objects - clarify lists are permitted as Input fields

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1548,7 +1548,7 @@ Fields may accept arguments to configure their behavior. These inputs are often
 scalars or enums, but they sometimes need to represent more complex values.
 
 A GraphQL Input Object defines a set of input fields; the input fields are
-either scalars, enums, or other input objects. This allows arguments to accept
+scalars, enums, lists, or other input objects. This allows arguments to accept
 arbitrarily complex structs.
 
 In this example, an Input Object called `Point2D` describes `x` and `y` inputs:

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1548,8 +1548,9 @@ Fields may accept arguments to configure their behavior. These inputs are often
 scalars or enums, but they sometimes need to represent more complex values.
 
 A GraphQL Input Object defines a set of input fields; the input fields are
-scalars, enums, lists, or other input objects. This allows arguments to accept
-arbitrarily complex structs.
+scalars, enums, other input objects, or any wrapping type whose underlying base
+type is one of those three. This allows arguments to accept arbitrarily complex
+structs.
 
 In this example, an Input Object called `Point2D` describes `x` and `y` inputs:
 


### PR DESCRIPTION
A minor omission in 3.10 Input Objects confused me briefly today by suggesting lists might not be permitted as the type of an input field. However, they are (and are even used in the examples), so add it in.

Alternatively, the kinds of permitted fields could be described explicitly as they are under Field Arguments: https://spec.graphql.org/draft/#sel-GAHZjCZABABDukZ

I believe this is simply an editing mistake.