### PR TITLE
incremental: maintain defer fragment ordering

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -4,6 +4,7 @@ ignoreRegExpList:
   - /[a-z]{2,}'s/
 words:
   # Terms of art
+  - deprioritization
   - endianness
   - interoperation
   - monospace

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -794,8 +794,9 @@ And will yield the subset of each object type queried:
 When querying an Object, the resulting mapping of fields are conceptually
 ordered in the same order in which they were encountered during execution,
 excluding fragments for which the type does not apply and fields or fragments
-that are skipped via `@skip` or `@include` directives. This ordering is
-correctly produced when using the {CollectFields()} algorithm.
+that are skipped via `@skip` or `@include` directives or temporarily skipped via
+`@defer`. This ordering is correctly produced when using the {CollectFields()}
+algorithm.
 
 Response serialization formats capable of representing ordered maps should
 maintain this ordering. Serialization formats which can only represent unordered
@@ -1941,10 +1942,10 @@ by a validator, executor, or client tool such as a code generator.
 
 GraphQL implementations should provide the `@skip` and `@include` directives.
 
-GraphQL implementations are not required to implement the `@stream` directive.
-If the directive is implemented, it must be implemented according to this
-specification. GraphQL implementations that do not support the `@stream`
-directive must not make it available via introspection.
+GraphQL implementations are not required to implement the `@defer` and `@stream`
+directives. If either or both of these directives are implemented, they must be
+implemented according to this specification. GraphQL implementations that do not
+support these directives must not make them available via introspection.
 
 GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of the
@@ -2167,6 +2168,50 @@ to the relevant IETF specification.
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 ```
 
+### @defer
+
+```graphql
+directive @defer(
+  label: String
+  if: Boolean! = true
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+```
+
+The `@defer` directive may be provided for fragment spreads and inline fragments
+to inform the executor to delay the execution of the current fragment to
+indicate deprioritization of the current fragment. A query with `@defer`
+directive will cause the request to potentially return multiple responses, where
+non-deferred data is delivered in the initial response and data deferred is
+delivered in a subsequent response. `@include` and `@skip` take precedence over
+`@defer`.
+
+```graphql example
+query myQuery($shouldDefer: Boolean) {
+  user {
+    name
+    ...someFragment @defer(label: "someLabel", if: $shouldDefer)
+  }
+}
+fragment someFragment on User {
+  id
+  profile_picture {
+    uri
+  }
+}
+```
+
+#### @defer Arguments
+
+- `if: Boolean! = true` - When `true`, fragment _should_ be deferred (See
+  [related note](#note-088b7)). When `false`, fragment will not be deferred and
+  data will be included in the initial response. Defaults to `true` when
+  omitted.
+- `label: String` - May be used by GraphQL clients to identify the data from
+  responses and associate it with the corresponding defer directive. If
+  provided, the GraphQL service must add it to the corresponding payload.
+  `label` must be unique label across all `@defer` and `@stream` directives in a
+  document. `label` must not be provided as a variable.
+
 ### @stream
 
 ```graphql
@@ -2201,20 +2246,20 @@ query myQuery($shouldStream: Boolean) {
 - `label: String` - May be used by GraphQL clients to identify the data from
   responses and associate it with the corresponding stream directive. If
   provided, the GraphQL service must add it to the corresponding payload.
-  `label` must be unique label across all `@stream` directives in a document.
-  `label` must not be provided as a variable.
+  `label` must be unique label across all `@defer` and `@stream` directives in a
+  document. `label` must not be provided as a variable.
 - `initialCount: Int` - The number of list items the service should return as
   part of the initial response. If omitted, defaults to `0`. A field error will
   be raised if the value of this argument is less than `0`.
 
-Note: The ability to stream parts of a response can have a potentially
-significant impact on application performance. Developers generally need clear,
-predictable control over their application's performance. It is highly
-recommended that GraphQL services honor the `@stream` directives on each
-execution. However, the specification allows advanced use cases where the
-service can determine that it is more performant to not stream. Therefore,
-GraphQL clients _must_ be able to process a response that ignores the `@stream`
-directive. This also applies to the `initialCount` argument on the `@stream`
-directive. Clients _must_ be able to process a streamed response that contains a
-different number of initial list items than what was specified in the
-`initialCount` argument.
+Note: The ability to defer and/or stream parts of a response can have a
+potentially significant impact on application performance. Developers generally
+need clear, predictable control over their application's performance. It is
+highly recommended that GraphQL services honor the `@defer` and `@stream`
+directives on each execution. However, the specification allows advanced use
+cases where the service can determine that it is more performant to not defer
+and/or stream. Therefore, GraphQL clients _must_ be able to process a response
+that ignores the `@defer` and/or `@stream` directives. This also applies to the
+`initialCount` argument on the `@stream` directive. Clients _must_ be able to
+process a streamed response that contains a different number of initial list
+items than what was specified in the `initialCount` argument.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -463,7 +463,7 @@ unambiguous. Therefore any two field selections which might both be encountered
 for the same object are only valid if they are equivalent.
 
 During execution, the simultaneous execution of fields with the same response
-name is accomplished by {MergeSelectionSets()} and {CollectFields()}.
+name is accomplished by {CollectSubfields()}.
 
 For simple hand-written GraphQL, this rule is obviously a clear developer error,
 however nested fragments can make this difficult to detect manually.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -664,6 +664,12 @@ As an example, this might accept the {objectType} `Person`, the {field}
 {"soulMate"}, and the {objectValue} representing John Lennon. It would be
 expected to yield the value representing Yoko Ono.
 
+List values are resolved similarly. For example, {ResolveFieldValue} might also
+accept the {objectType} `MusicBand`, the {field} {"members"}, and the
+{objectValue} representing the Beatles. It would be expected to yield a
+collection of values representing John Lennon, Paul McCartney, Ringo Starr and
+George Harrison.
+
 ResolveFieldValue(objectType, objectValue, fieldName, argumentValues):
 
 - Let {resolver} be the internal function provided by {objectType} for
@@ -674,7 +680,8 @@ ResolveFieldValue(objectType, objectValue, fieldName, argumentValues):
 Note: It is common for {resolver} to be asynchronous due to relying on reading
 an underlying database or networked service to produce a value. This
 necessitates the rest of a GraphQL executor to handle an asynchronous execution
-flow.
+flow. In addition, an implementation for collections may leverage asynchronous
+iterators or asynchronous generators provided by many programming languages.
 
 ### Value Completion
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -321,31 +321,34 @@ Executing the root selection set works similarly for queries (parallel),
 mutations (serial), and subscriptions (where it is executed for each event in
 the underlying Source Stream).
 
+First, the selection set is turned into a grouped field set; then, we execute
+this grouped field set and return the resulting {data} and {errors}.
+
 ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
 serial):
 
 - If {serial} is not provided, initialize it to {false}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
+- Let {groupedFieldSet} be the result of {CollectFields(objectType,
+  selectionSet, variableValues)}.
+- Let {data} be the result of running {ExecuteGroupedFieldSet(groupedFieldSet,
   objectType, initialValue, variableValues)} _serially_ if {serial} is {true},
   _normally_ (allowing parallelization) otherwise.
 - Let {errors} be the list of all _field error_ raised while executing the
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
-## Executing Selection Sets
+## Executing a Grouped Field Set
 
-To execute a selection set, the object value being evaluated and the object type
-need to be known, as well as whether it must be executed serially, or may be
-executed in parallel.
+To execute a grouped field set, the object value being evaluated and the object
+type need to be known, as well as whether it must be executed serially, or may
+be executed in parallel.
 
-First, the selection set is turned into a grouped field set; then, each
-represented field in the grouped field set produces an entry into a response
-map.
+Each represented field in the grouped field set produces an entry into a
+response map.
 
-ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues):
+ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+variableValues):
 
-- Let {groupedFieldSet} be the result of {CollectFields(objectType,
-  selectionSet, variableValues)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -363,8 +366,8 @@ is explained in greater detail in the Field Collection section below.
 
 **Errors and Non-Null Fields**
 
-If during {ExecuteSelectionSet()} a field with a non-null {fieldType} raises a
-_field error_ then that error must propagate to this entire selection set,
+If during {ExecuteGroupedFieldSet()} a field with a non-null {fieldType} raises
+a _field error_ then that error must propagate to this entire selection set,
 either resolving to {null} if allowed or further propagated to a parent field.
 
 If this occurs, any sibling fields which have not yet executed or have not yet
@@ -702,8 +705,9 @@ CompleteValue(fieldType, fields, result, variableValues):
     - Let {objectType} be {fieldType}.
   - Otherwise if {fieldType} is an Interface or Union type.
     - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
-  - Let {subSelectionSet} be the result of calling {MergeSelectionSets(fields)}.
-  - Return the result of evaluating {ExecuteSelectionSet(subSelectionSet,
+  - Let {groupedFieldSet} be the result of calling {CollectSubfields(objectType,
+    fields, variableValues)}.
+  - Return the result of evaluating {ExecuteGroupedFieldSet(groupedFieldSet,
     objectType, result, variableValues)} _normally_ (allowing for
     parallelization).
 
@@ -750,9 +754,9 @@ ResolveAbstractType(abstractType, objectValue):
 
 **Merging Selection Sets**
 
-When more than one field of the same name is executed in parallel, their
-selection sets are merged together when completing the value in order to
-continue execution of the sub-selection sets.
+When more than one field of the same name is executed in parallel, during value
+completion their selection sets are collected together to produce a single
+grouped field set in order to continue execution of the sub-selection sets.
 
 An example operation illustrating parallel fields with the same name with
 sub-selections.
@@ -771,14 +775,19 @@ sub-selections.
 After resolving the value for `me`, the selection sets are merged together so
 `firstName` and `lastName` can be resolved for one value.
 
-MergeSelectionSets(fields):
+CollectSubfields(objectType, fields, variableValues):
 
-- Let {selectionSet} be an empty list.
+- Let {groupedFieldSet} be an empty map.
 - For each {field} in {fields}:
   - Let {fieldSelectionSet} be the selection set of {field}.
   - If {fieldSelectionSet} is null or empty, continue to the next field.
-  - Append all selections in {fieldSelectionSet} to {selectionSet}.
-- Return {selectionSet}.
+  - Let {subGroupedFieldSet} be the result of {CollectFields(objectType,
+    fieldSelectionSet, variableValues)}.
+  - For each {subGroupedFieldSet} as {responseKey} and {subfields}:
+    - Let {groupForResponseKey} be the list in {groupedFieldSet} for
+      {responseKey}; if no such list exists, create it as an empty list.
+    - Append all fields in {subfields} to {groupForResponseKey}.
+- Return {groupedFieldSet}.
 
 ### Handling Field Errors
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -337,6 +337,112 @@ serial):
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
+### Field Collection
+
+Before execution, the selection set is converted to a grouped field set by
+calling {CollectFields()}. Each entry in the grouped field set is a list of
+fields that share a response key (the alias if defined, otherwise the field
+name). This ensures all fields with the same response key (including those in
+referenced fragments) are executed at the same time.
+
+As an example, collecting the fields of this selection set would collect two
+instances of the field `a` and one of field `b`:
+
+```graphql example
+{
+  a {
+    subfield1
+  }
+  ...ExampleFragment
+}
+
+fragment ExampleFragment on Query {
+  a {
+    subfield2
+  }
+  b
+}
+```
+
+The depth-first-search order of the field groups produced by {CollectFields()}
+is maintained through execution, ensuring that fields appear in the executed
+response in a stable and predictable order.
+
+CollectFields(objectType, selectionSet, variableValues, visitedFragments):
+
+- If {visitedFragments} is not provided, initialize it to the empty set.
+- Initialize {groupedFields} to an empty ordered map of lists.
+- For each {selection} in {selectionSet}:
+  - If {selection} provides the directive `@skip`, let {skipDirective} be that
+    directive.
+    - If {skipDirective}'s {if} argument is {true} or is a variable in
+      {variableValues} with the value {true}, continue with the next {selection}
+      in {selectionSet}.
+  - If {selection} provides the directive `@include`, let {includeDirective} be
+    that directive.
+    - If {includeDirective}'s {if} argument is not {true} and is not a variable
+      in {variableValues} with the value {true}, continue with the next
+      {selection} in {selectionSet}.
+  - If {selection} is a {Field}:
+    - Let {responseKey} be the response key of {selection} (the alias if
+      defined, otherwise the field name).
+    - Let {groupForResponseKey} be the list in {groupedFields} for
+      {responseKey}; if no such list exists, create it as an empty list.
+    - Append {selection} to the {groupForResponseKey}.
+  - If {selection} is a {FragmentSpread}:
+    - Let {fragmentSpreadName} be the name of {selection}.
+    - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
+      {selection} in {selectionSet}.
+    - Add {fragmentSpreadName} to {visitedFragments}.
+    - Let {fragment} be the Fragment in the current Document whose name is
+      {fragmentSpreadName}.
+    - If no such {fragment} exists, continue with the next {selection} in
+      {selectionSet}.
+    - Let {fragmentType} be the type condition on {fragment}.
+    - If {DoesFragmentTypeApply(objectType, fragmentType)} is false, continue
+      with the next {selection} in {selectionSet}.
+    - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
+    - Let {fragmentGroupedFieldSet} be the result of calling
+      {CollectFields(objectType, fragmentSelectionSet, variableValues,
+      visitedFragments)}.
+    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
+      - Let {responseKey} be the response key shared by all fields in
+        {fragmentGroup}.
+      - Let {groupForResponseKey} be the list in {groupedFields} for
+        {responseKey}; if no such list exists, create it as an empty list.
+      - Append all items in {fragmentGroup} to {groupForResponseKey}.
+  - If {selection} is an {InlineFragment}:
+    - Let {fragmentType} be the type condition on {selection}.
+    - If {fragmentType} is not {null} and {DoesFragmentTypeApply(objectType,
+      fragmentType)} is false, continue with the next {selection} in
+      {selectionSet}.
+    - Let {fragmentSelectionSet} be the top-level selection set of {selection}.
+    - Let {fragmentGroupedFieldSet} be the result of calling
+      {CollectFields(objectType, fragmentSelectionSet, variableValues,
+      visitedFragments)}.
+    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
+      - Let {responseKey} be the response key shared by all fields in
+        {fragmentGroup}.
+      - Let {groupForResponseKey} be the list in {groupedFields} for
+        {responseKey}; if no such list exists, create it as an empty list.
+      - Append all items in {fragmentGroup} to {groupForResponseKey}.
+- Return {groupedFields}.
+
+DoesFragmentTypeApply(objectType, fragmentType):
+
+- If {fragmentType} is an Object Type:
+  - if {objectType} and {fragmentType} are the same type, return {true},
+    otherwise return {false}.
+- If {fragmentType} is an Interface Type:
+  - if {objectType} is an implementation of {fragmentType}, return {true}
+    otherwise return {false}.
+- If {fragmentType} is a Union:
+  - if {objectType} is a possible type of {fragmentType}, return {true}
+    otherwise return {false}.
+
+Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
+directives may be applied in either order since they apply commutatively.
+
 ## Executing a Grouped Field Set
 
 To execute a grouped field set, the object value being evaluated and the object
@@ -362,7 +468,7 @@ variableValues):
 - Return {resultMap}.
 
 Note: {resultMap} is ordered by which fields appear first in the operation. This
-is explained in greater detail in the Field Collection section below.
+is explained in greater detail in the Field Collection section above.
 
 **Errors and Non-Null Fields**
 
@@ -471,112 +577,6 @@ A correct executor must generate the following result for that selection set:
   }
 }
 ```
-
-### Field Collection
-
-Before execution, the selection set is converted to a grouped field set by
-calling {CollectFields()}. Each entry in the grouped field set is a list of
-fields that share a response key (the alias if defined, otherwise the field
-name). This ensures all fields with the same response key (including those in
-referenced fragments) are executed at the same time.
-
-As an example, collecting the fields of this selection set would collect two
-instances of the field `a` and one of field `b`:
-
-```graphql example
-{
-  a {
-    subfield1
-  }
-  ...ExampleFragment
-}
-
-fragment ExampleFragment on Query {
-  a {
-    subfield2
-  }
-  b
-}
-```
-
-The depth-first-search order of the field groups produced by {CollectFields()}
-is maintained through execution, ensuring that fields appear in the executed
-response in a stable and predictable order.
-
-CollectFields(objectType, selectionSet, variableValues, visitedFragments):
-
-- If {visitedFragments} is not provided, initialize it to the empty set.
-- Initialize {groupedFields} to an empty ordered map of lists.
-- For each {selection} in {selectionSet}:
-  - If {selection} provides the directive `@skip`, let {skipDirective} be that
-    directive.
-    - If {skipDirective}'s {if} argument is {true} or is a variable in
-      {variableValues} with the value {true}, continue with the next {selection}
-      in {selectionSet}.
-  - If {selection} provides the directive `@include`, let {includeDirective} be
-    that directive.
-    - If {includeDirective}'s {if} argument is not {true} and is not a variable
-      in {variableValues} with the value {true}, continue with the next
-      {selection} in {selectionSet}.
-  - If {selection} is a {Field}:
-    - Let {responseKey} be the response key of {selection} (the alias if
-      defined, otherwise the field name).
-    - Let {groupForResponseKey} be the list in {groupedFields} for
-      {responseKey}; if no such list exists, create it as an empty list.
-    - Append {selection} to the {groupForResponseKey}.
-  - If {selection} is a {FragmentSpread}:
-    - Let {fragmentSpreadName} be the name of {selection}.
-    - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
-      {selection} in {selectionSet}.
-    - Add {fragmentSpreadName} to {visitedFragments}.
-    - Let {fragment} be the Fragment in the current Document whose name is
-      {fragmentSpreadName}.
-    - If no such {fragment} exists, continue with the next {selection} in
-      {selectionSet}.
-    - Let {fragmentType} be the type condition on {fragment}.
-    - If {DoesFragmentTypeApply(objectType, fragmentType)} is false, continue
-      with the next {selection} in {selectionSet}.
-    - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
-    - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments)}.
-    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
-      - Let {responseKey} be the response key shared by all fields in
-        {fragmentGroup}.
-      - Let {groupForResponseKey} be the list in {groupedFields} for
-        {responseKey}; if no such list exists, create it as an empty list.
-      - Append all items in {fragmentGroup} to {groupForResponseKey}.
-  - If {selection} is an {InlineFragment}:
-    - Let {fragmentType} be the type condition on {selection}.
-    - If {fragmentType} is not {null} and {DoesFragmentTypeApply(objectType,
-      fragmentType)} is false, continue with the next {selection} in
-      {selectionSet}.
-    - Let {fragmentSelectionSet} be the top-level selection set of {selection}.
-    - Let {fragmentGroupedFieldSet} be the result of calling
-      {CollectFields(objectType, fragmentSelectionSet, variableValues,
-      visitedFragments)}.
-    - For each {fragmentGroup} in {fragmentGroupedFieldSet}:
-      - Let {responseKey} be the response key shared by all fields in
-        {fragmentGroup}.
-      - Let {groupForResponseKey} be the list in {groupedFields} for
-        {responseKey}; if no such list exists, create it as an empty list.
-      - Append all items in {fragmentGroup} to {groupForResponseKey}.
-- Return {groupedFields}.
-
-DoesFragmentTypeApply(objectType, fragmentType):
-
-- If {fragmentType} is an Object Type:
-  - if {objectType} and {fragmentType} are the same type, return {true},
-    otherwise return {false}.
-- If {fragmentType} is an Interface Type:
-  - if {objectType} is an implementation of {fragmentType}, return {true}
-    otherwise return {false}.
-- If {fragmentType} is a Union:
-  - if {objectType} is a possible type of {fragmentType}, return {true}
-    otherwise return {false}.
-
-Note: The steps in {CollectFields()} evaluating the `@skip` and `@include`
-directives may be applied in either order since they apply commutatively.
 
 ## Executing Fields
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -131,12 +131,8 @@ ExecuteQuery(query, schema, variableValues, initialValue):
 - Let {queryType} be the root Query type in {schema}.
 - Assert: {queryType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {query}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  queryType, initialValue, variableValues)} _normally_ (allowing
-  parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue, queryType,
+  selectionSet)}.
 
 ### Mutation
 
@@ -153,11 +149,8 @@ ExecuteMutation(mutation, schema, variableValues, initialValue):
 - Let {mutationType} be the root Mutation type in {schema}.
 - Assert: {mutationType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {mutation}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  mutationType, initialValue, variableValues)} _serially_.
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue, mutationType,
+  selectionSet, true)}.
 
 ### Subscription
 
@@ -301,12 +294,8 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 - Let {subscriptionType} be the root Subscription type in {schema}.
 - Assert: {subscriptionType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {subscription}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  subscriptionType, initialValue, variableValues)} _normally_ (allowing
-  parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue,
+  subscriptionType, selectionSet)}.
 
 Note: The {ExecuteSubscriptionEvent()} algorithm is intentionally similar to
 {ExecuteQuery()} since this is how each event result is produced.
@@ -321,6 +310,27 @@ the subscription.
 Unsubscribe(responseStream):
 
 - Cancel {responseStream}
+
+## Executing the Root Selection Set
+
+To execute the root selection set, the object value being evaluated and the
+object type need to be known, as well as whether it must be executed serially,
+or may be executed in parallel.
+
+Executing the root selection set works similarly for queries (parallel),
+mutations (serial), and subscriptions (where it is executed for each event in
+the underlying Source Stream).
+
+ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
+serial):
+
+- If {serial} is not provided, initialize it to {false}.
+- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
+  objectType, initialValue, variableValues)} _serially_ if {serial} is {true},
+  _normally_ (allowing parallelization) otherwise.
+- Let {errors} be the list of all _field error_ raised while executing the
+  selection set.
+- Return an unordered map containing {data} and {errors}.
 
 ## Executing Selection Sets
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -10,7 +10,7 @@ the case that any _field error_ was raised on a field and was replaced with
 
 ## Response Format
 
-A response to a GraphQL request must be a map.
+A response to a GraphQL request must be a map or a response stream of maps.
 
 If the request raised any errors, the response map must contain an entry with
 key `errors`. The value of this entry is described in the "Errors" section. If
@@ -22,14 +22,39 @@ key `data`. The value of this entry is described in the "Data" section. If the
 request failed before execution, due to a syntax error, missing information, or
 validation error, this entry must not be present.
 
+When the response of the GraphQL operation is a response stream, the first value
+will be the initial response. All subsequent values may contain an `incremental`
+entry, containing a list of Stream payloads.
+
+The `label` and `path` entries on Stream payloads are used by clients to
+identify the `@stream` directive from the GraphQL operation that triggered this
+response to be included in an `incremental` entry on a value returned by the
+response stream. When a label is provided, the combination of these two entries
+will be unique across all Stream payloads returned in the response stream.
+
+If the response of the GraphQL operation is a response stream, each response map
+must contain an entry with key `hasNext`. The value of this entry is `true` for
+all but the last response in the stream. The value of this entry is `false` for
+the last response of the stream. This entry must not be present for GraphQL
+operations that return a single response map.
+
+The GraphQL service may determine there are no more values in the response
+stream after a previous value with `hasNext` equal to `true` has been emitted.
+In this case the last value in the response stream should be a map without
+`data` and `incremental` entries, and a `hasNext` entry with a value of `false`.
+
 The response map may also contain an entry with key `extensions`. This entry, if
 set, must have a map as its value. This entry is reserved for implementors to
 extend the protocol however they see fit, and hence there are no additional
-restrictions on its contents.
+restrictions on its contents. When the response of the GraphQL operation is a
+response stream, implementors may send subsequent response maps containing only
+`hasNext` and `extensions` entries. Stream payloads may also contain an entry
+with the key `extensions`, also reserved for implementors to extend the protocol
+however they see fit.
 
 To ensure future changes to the protocol do not break existing services and
 clients, the top level response map must not contain any entries other than the
-three described above.
+five described above.
 
 Note: When `errors` is present in the response, it may be helpful for it to
 appear first when serialized to make it more clear when errors are present in a
@@ -107,14 +132,8 @@ syntax element.
 If an error can be associated to a particular field in the GraphQL result, it
 must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
-`null` result is intentional or caused by a runtime error.
-
-This field should be a list of path segments starting at the root of the
-response and ending with the field associated with the error. Path segments that
-represent fields should be strings, and path segments that represent list
-indices should be 0-indexed integers. If the error happens in an aliased field,
-the path to the error should use the aliased name, since it represents a path in
-the response, not in the request.
+`null` result is intentional or caused by a runtime error. The value of this
+field is described in the [Path](#sec-Path) section.
 
 For example, if fetching one of the friends' names fails in the following
 operation:
@@ -244,6 +263,136 @@ discouraged.
 }
 ```
 
+### Incremental Delivery
+
+The `pending` entry in the response is a non-empty list of references to pending
+Stream results. If the response of the GraphQL operation is a response stream,
+this field should appear on the initial and possibly subsequent payloads.
+
+The `incremental` entry in the response is a non-empty list of data fulfilling
+Stream results. If the response of the GraphQL operation is a response stream,
+this field may appear on the subsequent payloads.
+
+The `completed` entry in the response is a non-empty list of references to
+completed Stream results.
+
+For example:
+
+```graphql example
+query {
+  person(id: "cGVvcGxlOjE=") {
+    name
+    films @stream(initialCount: 1, label: "filmsStream") {
+      title
+    }
+  }
+}
+```
+
+The response stream might look like:
+
+Response 1, the initial response does not contain any streamed results.
+
+```json example
+{
+  "data": {
+    "person": {
+      "name": "Luke Skywalker",
+      "films": [{ "title": "A New Hope" }]
+    }
+  },
+  "pending": [{ "path": ["person", "films"], "label": "filmStream" }],
+  "hasNext": true
+}
+```
+
+Response 2, contains the first stream payload.
+
+```json example
+{
+  "incremental": [
+    {
+      "path": ["person", "films"],
+      "items": [{ "title": "The Empire Strikes Back" }]
+    }
+  ],
+  "hasNext": true
+}
+```
+
+Response 3, contains the final stream payload. In this example, the underlying
+iterator does not close synchronously so {hasNext} is set to {true}. If this
+iterator did close synchronously, {hasNext} would be set to {false} and this
+would be the final response.
+
+```json example
+{
+  "incremental": [
+    {
+      "path": ["person", "films"],
+      "items": [{ "title": "Return of the Jedi" }]
+    }
+  ],
+  "hasNext": true
+}
+```
+
+Response 4, contains no incremental payloads. {hasNext} set to {false} indicates
+the end of the response stream. This response is sent when the underlying
+iterator of the `films` field closes.
+
+```json example
+{
+  "completed": [{ "path": ["person", "films"], "label": "filmStream" }],
+  "hasNext": false
+}
+```
+
+#### Streamed data
+
+Streamed data may appear as an item in the `incremental` entry of a response.
+Streamed data is the result of an associated `@stream` directive in the
+operation. A stream payload must contain `items` and `path` entries and may
+contain `errors`, and `extensions` entries.
+
+##### Items
+
+The `items` entry in a stream payload is a list of results from the execution of
+the associated @stream directive. This output will be a list of the same type of
+the field with the associated `@stream` directive. If an error has caused a
+`null` to bubble up to a field higher than the list field with the associated
+`@stream` directive, then the stream will complete with errors.
+
+#### Path
+
+A `path` field allows for the association to a particular field in a GraphQL
+result. This field should be a list of path segments starting at the root of the
+response and ending with the field to be associated with. Path segments that
+represent fields should be strings, and path segments that represent list
+indices should be 0-indexed integers. If the path is associated to an aliased
+field, the path should use the aliased name, since it represents a path in the
+response, not in the request.
+
+When the `path` field is present on a Stream payload, it indicates that the
+`items` field represents the partial result of the list field containing the
+corresponding `@stream` directive. All but the non-final path segments must
+refer to the location of the list field containing the corresponding `@stream`
+directive. The final segment of the path list must be a 0-indexed integer. This
+integer indicates that this result is set at a range, where the beginning of the
+range is at the index of this integer, and the length of the range is the length
+of the data.
+
+When the `path` field is present on an "Error result", it indicates the response
+field which experienced the error.
+
+#### Label
+
+Stream may contain a string field `label`. This `label` is the same label passed
+to the `@stream` directive associated with the response. This allows clients to
+identify which `@stream` directive is associated with this value. `label` will
+not be present if the corresponding `@stream` directive is not passed a `label`
+argument.
+
 ## Serialization Format
 
 GraphQL does not require a specific serialization format. However, clients
@@ -303,10 +452,10 @@ enables more efficient parsing of responses if the order of properties can be
 anticipated.
 
 Serialization formats which represent an ordered map should preserve the order
-of requested fields as defined by {CollectFields()} in the Execution section.
-Serialization formats which only represent unordered maps but where order is
-still implicit in the serialization's textual order (such as JSON) should
-preserve the order of requested fields textually.
+of requested fields as defined by {AnalyzeSelectionSet()} in the Execution
+section. Serialization formats which only represent unordered maps but where
+order is still implicit in the serialization's textual order (such as JSON)
+should preserve the order of requested fields textually.
 
 For example, if the request was `{ name, age }`, a GraphQL service responding in
 JSON should respond with `{ "name": "Mark", "age": 30 }` and should not respond


### PR DESCRIPTION
depends on #1052

Maintains ordering of defers from operation, only sending a child deferred fragment after the parent is sent.  By contrast, #1052 will send a deferred fragment once it can be merged into the final reconcilable object.

since it depends on #1052, this is probably the more instructive diff: https://github.com/yaacovCR/graphql-spec/compare/deduplicate3...deduplicate5