### PR TITLE
Be strict about error paths format

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -109,12 +109,12 @@ must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
 `null` result is intentional or caused by a runtime error.
 
-This field should be a list of path segments starting at the root of the
-response and ending with the field associated with the error. Path segments that
-represent fields should be strings, and path segments that represent list
-indices should be 0-indexed integers. If the error happens in an aliased field,
-the path to the error should use the aliased name, since it represents a path in
-the response, not in the request.
+This field must be a list of path segments starting at the root of the response
+and ending with the field associated with the error. Path segments that
+represent fields must be strings, and path segments that represent list indices
+must be 0-indexed integers. If the error happens in an aliased field, the path
+to the error must use the aliased name, since it represents a path in the
+response, not in the request.
 
 For example, if fetching one of the friends' names fails in the following
 operation:

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -109,12 +109,12 @@ must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
 `null` result is intentional or caused by a runtime error.
 
-If present, this field must be a list of path segments starting at the root of the response
-and ending with the field associated with the error. Path segments that
-represent fields must be strings, and path segments that represent list indices
-must be 0-indexed integers. If the error happens in an aliased field, the path
-to the error must use the aliased name, since it represents a path in the
-response, not in the request.
+If present, this field must be a list of path segments starting at the root of
+the response and ending with the field associated with the error. Path segments
+that represent fields must be strings, and path segments that represent list
+indices must be 0-indexed integers. If the error happens in an aliased field,
+the path to the error must use the aliased name, since it represents a path in
+the response, not in the request.
 
 For example, if fetching one of the friends' names fails in the following
 operation:

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -109,7 +109,7 @@ must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
 `null` result is intentional or caused by a runtime error.
 
-This field must be a list of path segments starting at the root of the response
+If present, this field must be a list of path segments starting at the root of the response
 and ending with the field associated with the error. Path segments that
 represent fields must be strings, and path segments that represent list indices
 must be 0-indexed integers. If the error happens in an aliased field, the path


### PR DESCRIPTION
Replace `should` with `must` in the description of error paths: `This field must be a list of path segments starting...`

```json
    {
      "message": "Name for character with ID 1002 could not be fetched.",
      "locations": [{ "line": 6, "column": 7 }],
      "path": ["hero", "heroFriends", 1, "name"]
    }
```

Anything else will make it impossible to handle errors in error-aware clients. This is especially important for [strict-nullability](https://github.com/graphql/graphql-wg/discussions/1410) or [semantic-non-nullability](https://github.com/graphql/graphql-spec/pull/1065)