### PR TITLE
[RFC] Implementation of June 2023 incremental delivery format with `@defer`

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -463,7 +463,7 @@ unambiguous. Therefore any two field selections which might both be encountered
 for the same object are only valid if they are equivalent.
 
 During execution, the simultaneous execution of fields with the same response
-name is accomplished by {MergeSelectionSets()} and {CollectFields()}.
+name is accomplished by {CollectSubfields()}.
 
 For simple hand-written GraphQL, this rule is obviously a clear developer error,
 however nested fragments can make this difficult to detect manually.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1030,11 +1030,12 @@ IncrementalStream(incrementalDetailsByPath, deliveryGroupsSet):
     - Append an unordered map containing {hasNext}, {id}, {data} and {errors} to
       {incremental}.
   - Let {pendingDeliveryGroups} be
-    {CollectDeliveryGroups(incrementalDetailsByPath, deliveryGroupsSet)}.
+    {CollectDeliveryGroups(remainingIncrementalDetailsByPath,
+    deliveryGroupsSet)}.
   - Let {pending} be {MakePending(pendingDeliveryGroups)}.
   - Let {sentInitial} be {false}.
   - Let {streams} and {runnableDeliveryGroupsSets} be
-    {IncrementalStreams(incrementalDetailsByPath)}.
+    {IncrementalStreams(remainingIncrementalDetailsByPath)}.
   - For each {deliveryGroupsSet} as {deliveryGroup}:
     - If {deliveryGroup} is not contained in any delivery group set in
       {runnableDeliveryGroupsSets}:

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -904,7 +904,7 @@ return `Non-Null` types, then the {"data"} entry in the response should be
 ### Delivery Group
 
 ::: A _delivery group_ represents either the root selection set or a particular
-`@stream` or `@defer` directive at a particular {path} in the response.
+`@defer` directive at a particular {path} in the response.
 
 ::: The _root delivery group_ is the _delivery group_ that represents the root
 selection set in the operation.
@@ -914,9 +914,9 @@ delivery group_. During field collection, the delivery group of each field is
 tracked, and this is used when determining when to execute and deliver defered
 fields and streamed list items.
 
-In an operation that does not utilise the `@stream` and `@defer` directives,
-there will only be a single delivery group, the _root delivery group_, and all
-fields will belong to it.
+In an operation that does not utilise the `@defer` directive, there will only be
+a single delivery group, the _root delivery group_, and all fields will belong
+to it.
 
 ### Incremental Event Stream
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -320,31 +320,34 @@ Executing the root selection set works similarly for queries (parallel),
 mutations (serial), and subscriptions (where it is executed for each event in
 the underlying Source Stream).
 
+First, the selection set is turned into a grouped field set; then, we execute
+this grouped field set and return the resulting {data} and {errors}.
+
 ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
 serial):
 
 - If {serial} is not provided, initialize it to {false}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
+- Let {groupedFieldSet} be the result of {CollectFields(objectType,
+  selectionSet, variableValues)}.
+- Let {data} be the result of running {ExecuteGroupedFieldSet(groupedFieldSet,
   objectType, initialValue, variableValues)} _serially_ if {serial} is {true},
   _normally_ (allowing parallelization) otherwise.
 - Let {errors} be the list of all _field error_ raised while executing the
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
-## Executing Selection Sets
+## Executing a Grouped Field Set
 
-To execute a selection set, the object value being evaluated and the object type
-need to be known, as well as whether it must be executed serially, or may be
-executed in parallel.
+To execute a grouped field set, the object value being evaluated and the object
+type need to be known, as well as whether it must be executed serially, or may
+be executed in parallel.
 
-First, the selection set is turned into a grouped field set; then, each
-represented field in the grouped field set produces an entry into a response
-map.
+Each represented field in the grouped field set produces an entry into a
+response map.
 
-ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues):
+ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+variableValues):
 
-- Let {groupedFieldSet} be the result of {CollectFields(objectType,
-  selectionSet, variableValues)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -362,8 +365,8 @@ is explained in greater detail in the Field Collection section below.
 
 **Errors and Non-Null Fields**
 
-If during {ExecuteSelectionSet()} a field with a non-null {fieldType} raises a
-_field error_ then that error must propagate to this entire selection set,
+If during {ExecuteGroupedFieldSet()} a field with a non-null {fieldType} raises
+a _field error_ then that error must propagate to this entire selection set,
 either resolving to {null} if allowed or further propagated to a parent field.
 
 If this occurs, any sibling fields which have not yet executed or have not yet
@@ -701,8 +704,9 @@ CompleteValue(fieldType, fields, result, variableValues):
     - Let {objectType} be {fieldType}.
   - Otherwise if {fieldType} is an Interface or Union type.
     - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
-  - Let {subSelectionSet} be the result of calling {MergeSelectionSets(fields)}.
-  - Return the result of evaluating {ExecuteSelectionSet(subSelectionSet,
+  - Let {groupedFieldSet} be the result of calling {CollectSubfields(objectType,
+    fields, variableValues)}.
+  - Return the result of evaluating {ExecuteGroupedFieldSet(groupedFieldSet,
     objectType, result, variableValues)} _normally_ (allowing for
     parallelization).
 
@@ -749,9 +753,9 @@ ResolveAbstractType(abstractType, objectValue):
 
 **Merging Selection Sets**
 
-When more than one field of the same name is executed in parallel, their
-selection sets are merged together when completing the value in order to
-continue execution of the sub-selection sets.
+When more than one field of the same name is executed in parallel, during value
+completion their selection sets are collected together to produce a single
+grouped field set in order to continue execution of the sub-selection sets.
 
 An example operation illustrating parallel fields with the same name with
 sub-selections.
@@ -770,14 +774,19 @@ sub-selections.
 After resolving the value for `me`, the selection sets are merged together so
 `firstName` and `lastName` can be resolved for one value.
 
-MergeSelectionSets(fields):
+CollectSubfields(objectType, fields, variableValues):
 
-- Let {selectionSet} be an empty list.
+- Let {groupedFieldSet} be an empty map.
 - For each {field} in {fields}:
   - Let {fieldSelectionSet} be the selection set of {field}.
   - If {fieldSelectionSet} is null or empty, continue to the next field.
-  - Append all selections in {fieldSelectionSet} to {selectionSet}.
-- Return {selectionSet}.
+  - Let {subGroupedFieldSet} be the result of {CollectFields(objectType,
+    fieldSelectionSet, variableValues)}.
+  - For each {subGroupedFieldSet} as {responseKey} and {subfields}:
+    - Let {groupForResponseKey} be the list in {groupedFieldSet} for
+      {responseKey}; if no such list exists, create it as an empty list.
+    - Append all fields in {subfields} to {groupForResponseKey}.
+- Return {groupedFieldSet}.
 
 ### Handling Field Errors
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -911,7 +911,7 @@ selection set in the operation.
 
 Each _delivery group_ belongs to a {parent} delivery group, except for the _root
 delivery group_. During field collection, the delivery group of each field is
-tracked, and this is used when determining when to execute and deliver defered
+tracked, and this is used when determining when to execute and deliver deferred
 fields and streamed list items.
 
 In an operation that does not utilise the `@defer` directive, there will only be

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -378,8 +378,9 @@ path, currentDeliveryGroups):
         {ExecuteField(objectType, objectValue, fieldType, fieldDigests,
         variableValues, childPath, currentDeliveryGroups)}.
       - Set {responseValue} as the value for {responseKey} in {resultMap}.
-      - For each {childIncrementalDetailsByPath} as {childPath} and {fieldSet}:
-        - Set {fieldSet} as the value for {childPath} in
+      - For each {childIncrementalDetailsByPath} as {childPath} and
+        {childIncrementalDetails}:
+        - Set {childIncrementalDetails} as the value for {childPath} in
           {incrementalDetailsByPath}.
   - Otherwise:
     - Let {details} be the details object in {incrementalDetailsByPath} for
@@ -748,7 +749,7 @@ currentDeliveryGroups):
   - If {completedResult} is {null}, raise a _field error_.
   - Return {completedResult} and {incrementalDetailsByPath}.
 - If {result} is {null} (or another internal value similar to {null} such as
-  {undefined}), return {null}.
+  {undefined}), return {null} and an empty map.
 - If {fieldType} is a List type:
   - If {result} is not a collection of values, raise a _field error_.
   - Let {innerType} be the inner type of {fieldType}.
@@ -936,10 +937,10 @@ An execution group consists of:
   write the data,
 - {status}: {PENDING}, {EXECUTING}, {COMPLETE} or {FAILED},
 - {dependencies}: a list of execution groups on which it is dependent, and
-- {detailsByPath}: a map of response path to a details object containing
-  {groupedFieldSet}, {objectType} and {objectValue}.
+- {incrementalDetailsByPath}: a map of response path to a details object
+  containing {groupedFieldSet}, {objectType} and {objectValue}.
 
-Note: {dependencies} and {detailsByPath} may be added to over time.
+Note: {dependencies} and {incrementalDetailsByPath} may be added to over time.
 
 ExecutionGroupPath(executionGroup):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -131,12 +131,8 @@ ExecuteQuery(query, schema, variableValues, initialValue):
 - Let {queryType} be the root Query type in {schema}.
 - Assert: {queryType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {query}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  queryType, initialValue, variableValues)} _normally_ (allowing
-  parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue, queryType,
+  selectionSet)}.
 
 ### Mutation
 
@@ -153,11 +149,8 @@ ExecuteMutation(mutation, schema, variableValues, initialValue):
 - Let {mutationType} be the root Mutation type in {schema}.
 - Assert: {mutationType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {mutation}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  mutationType, initialValue, variableValues)} _serially_.
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue, mutationType,
+  selectionSet, true)}.
 
 ### Subscription
 
@@ -300,12 +293,8 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 - Let {subscriptionType} be the root Subscription type in {schema}.
 - Assert: {subscriptionType} is an Object type.
 - Let {selectionSet} be the top level Selection Set in {subscription}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
-  subscriptionType, initialValue, variableValues)} _normally_ (allowing
-  parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
-  selection set.
-- Return an unordered map containing {data} and {errors}.
+- Return {ExecuteRootSelectionSet(variableValues, initialValue,
+  subscriptionType, selectionSet)}.
 
 Note: The {ExecuteSubscriptionEvent()} algorithm is intentionally similar to
 {ExecuteQuery()} since this is how each event result is produced.
@@ -320,6 +309,27 @@ the subscription.
 Unsubscribe(responseStream):
 
 - Cancel {responseStream}
+
+## Executing the Root Selection Set
+
+To execute the root selection set, the object value being evaluated and the
+object type need to be known, as well as whether it must be executed serially,
+or may be executed in parallel.
+
+Executing the root selection set works similarly for queries (parallel),
+mutations (serial), and subscriptions (where it is executed for each event in
+the underlying Source Stream).
+
+ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
+serial):
+
+- If {serial} is not provided, initialize it to {false}.
+- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
+  objectType, initialValue, variableValues)} _serially_ if {serial} is {true},
+  _normally_ (allowing parallelization) otherwise.
+- Let {errors} be the list of all _field error_ raised while executing the
+  selection set.
+- Return an unordered map containing {data} and {errors}.
 
 ## Executing Selection Sets
 


### PR DESCRIPTION
This RFC introduces an alternative solution to incremental delivery,
implementing the
[June 2023 response format](https://github.com/graphql/defer-stream-wg/discussions/69).

This solution aims to minimize changes to the existing execution algorithm, when
comparing you should compare against `benjie/incremental-common`
(https://github.com/graphql/graphql-spec/pull/1039) to make the diff easier to
understand. I've raised this PR against that branch to make it clearer.

The RFC aims to avoid mutations and side effects across algorithms, so as to fit
with the existing patterns in the GraphQL spec. It also aims to leverage the
features we already have in the spec to minimize the introduction of new
concepts.

**WORK IN PROGRESS**: there's likely mistakes all over this currently; and a lot
will need to be done to maintain consistency of the prose and algorithms.

This RFC works by adjusting the execution algorithms in a few small ways:

1. **It introduces the concept of "delivery groups".**  
   Previously GraphQL can be thought of has having just a single delivery group
   (called the "root delivery group" in this RFC) - everything was delivered at
   once. With "incremental delivery", we're deliverying the data in multiple
   phases, or groups. A "delivery group" keeps track of which fields belong to
   which `@defer`, such that we can complete one delivery group before moving on
   to its children.
1. **`CollectFields()` now returns a map of "field digests" rather than just
   fields.**  
   `CollectFields()` used to generate a map between response key and field
   selection (`Record<string, FieldNode>`), but now it creates a map between
   response key and a "field digest", an object which contains both the field
   selection _and_ the delivery group to which it belongs
   (`Record<string, { field: FieldNode, deliveryGroup: DeliveryGroup }>`). As
   such, `CollectFields()` is now passed the current path and delivery group as
   arguments.
1. **`ExecuteRootSelectionSet()` may return an "incremental event stream".**  
    If there's no `@defer` then `ExecuteRootSelectionSet()` will return `data`/`errors`
   as before. However, if there are active `@defer`s then it will instead return
   an event stream which will consist of multiple incremental delivery payloads.
1. **`ExecuteGroupedFieldSet()` runs against a set of "current delivery
   groups".**  
   If multiple sibling delivery groups overlap, the algorithm will first run the
   fields common to all the overlapping delivery groups, and only when these are
   complete will it execute the remaining fields in each delivery group (in
   parallel). This might happen over multiple layers. This is tracked via a set
   of "current delivery groups", and only fields which exist in _all_ of these
   current delivery groups will be executed by `ExecuteGroupedFieldSet()`.
1. **`ExecuteGroupedFieldSet()` returns the currently executed data, as before,
   _plus_ details of incremental fields yet to be delivered.**  
   When there exists fields _not_ executed in `ExecuteGroupedFieldSet()`
   (because they aren't in every one of the "current delivery groups"), we store
   "**incremental details**" of the current grouped field set (by its path), for
   later execution. The incremental details consists of:
   - `objectType` - the type of the concrete object the field exists on (i.e.
     the object type passed to `ExecuteGroupedFieldSet()`)
   - `objectValue` - the value of this object (as would be passed as the first
     argument to the resolver for the field)
   - `groupedFieldSet` - similar to the result of `CollectFields()`, but only
     containing the response keys that have not yet been executed
1. **`CompleteValue()` continues execution in the "current delivery groups".**  
   We must pass the path and current delivery groups so that we can execute the
   current delivery groups recursively.
1. **`CompleteValue()` returns the field data, as before, _plus_ details of
   incremental subfields yet to be delivered.**  
   As with `ExecuteGroupedFieldSet()`, `CompleteValue()` must pass down details
   of any incremental subfields that need to be executed later.

At a `@defer` boundary, a new DeliveryGroup is created, and field collection
then happens within this new delivery group. This can happen multiple times in
the same level, for example:

```graphql
{
  # root delivery group
  currentUser {
    name
  }
  ... @defer {
    # Child delivery group
    expensiveField {
      id
    }
    ... @defer {
      # Grandchild delivery group
      veryExpensiveField {
        title
      }
    }
  }
}
```

If no `@defer` exists then no new delivery groups are created, and thus the
request executes as it would have done previously. However, if there is at least
one active `@defer` then the client will be sent the initial response along with
a list of `pending` delivery groups. We will then commence executing the
delivery groups, delivering them as they are ready.

Note: when an error occurs in a non-null field, the incremental details gathered
in that selection set will be blown up alongside the sibling fields - we use the
existing error handling mechanisms for this.

This PR is nowhere near complete. I've spent 2 days on this latest iteration
(coming up with the new stream and partition approach as the major breakthrough)
but I've had to stop and I'm not sure if I've left gaps. Further, I need to
integrate Rob's hard work in #742 into it.

To make life a bit easier on myself, I've written some TypeScript-style
declarations of the various algorithms used in execute, according to this RFC.
This may not be correct and is definitely non-normative, but might be useful to
ease understanding.

```ts
type RawVariables = { [variableName: string]: any };
type CoercedVariables = { [variableName: string]: any };

function ExecuteRequest(
  schema: GraphQLSchema,
  document: Document,
  operationName: string | null,
  variableValues: RawVariables,
  initialValue: any
):
  | ReturnType<typeof ExecuteQuery>
  | ReturnType<typeof ExecuteMutation>
  | ReturnType<typeof Subscribe>;

function GetOperation(
  document: Document,
  operationName: string | null
): Operation;

function CoerceVariableValues(
  schema: GraphQLSchema,
  operation: Operation,
  variableValues: RawVariables
): CoercedVariables;

function ExecuteQuery(
  query: Document,
  schema: GraphQLSchema,
  variableValues: CoercedVariables,
  initialValue: any
): ReturnType<typeof ExecuteRootSelectionSet>;

function ExecuteMutation(
  mutation: Document,
  schema: GraphQLSchema,
  variableValues: CoercedVariables,
  initialValue: any
): ReturnType<typeof ExecuteRootSelectionSet>;

function Subscribe(
  subscription: Document,
  schema: GraphQLSchema,
  variableValues: CoercedVariables,
  initialValue: any
): ReturnType<typeof MapSourceToResponseEvent>;

function CreateSourceEventStream(
  subscription: Document,
  schema: GraphQLSchema,
  variableValues: CoercedVariables,
  initialValue: any
): ReturnType<typeof ResolveFieldEventStream>;

function ResolveFieldEventStream(
  subscriptionType: GraphQLObjectType,
  rootValue: any,
  fieldName: string,
  argumentValues: { [argumentName: string]: any }
): EventStream<any>;

interface ExecutionResult {
  data?: any;
  errors?: GraphQLError[];
}

type Path = Array<string | number>;

interface Pending {
  id: number;
  path: Path;
  label?: string;
}

interface InitialIncrementalResult {
  data: Record<string, any>;
  errors?: GraphQLError[];
  hasNext: true;
  pending: Pending[];
}

interface Completed {
  id: number;
  // Errors that bubbled to the root of the defer/stream
  errors?: GraphQLError[];
}

type IncrementalPayload = DeferredPayload | StreamedPayload;

interface DeferredPayload {
  id: number;
  subpath?: Path;
  data: Record<string, any>;
  // Errors that happened _successfully_ (i.e. did not bubble up to the @defer)
  errors?: GraphQLError[];
}

interface StreamedPayload {
  id: number;
  items: Array<any | null>;
  // Errors that happened _successfully_ (i.e. did not invalidate the stream)
  errors?: GraphQLError[];
  data: any;
}

interface SubsequentIncrementalResult {
  hasNext: boolean;
  pending?: Pending[];
  completed?: Completed[];
  incremental?: IncrementalPayload[];
}

function MapSourceToResponseEvent(
  sourceStream: EventStream<any>,
  subscription: Document,
  schema: GraphQLSchema,
  variableValues: CoercedVariables
): EventStream<
  ExecutionResult | InitialIncrementalResult | SubsequentIncrementalResult
>;

function ExecuteSubscriptionEvent(
  subscription: Document,
  schema: GraphQLSchema,
  variableValues: CoercedVariables,
  initialValue: any
): ExecutionResult | ReturnType<typeof IncrementalEventStream>;

function Unsubscribe(responseStream: EventStream<any>): void;

function ExecuteRootSelectionSet(
  variableValues: CoercedVariables,
  initialValue: any,
  objectType: GraphQLObjectType,
  selectionSet: SelectionSet,
  serial: boolean = false
): ExecutionResult | ReturnType<typeof IncrementalEventStream>;

interface DeliveryGroup {
  id: number;
  path: Path;
  parent: DeliveryGroup | null;
  label?: string;
}

interface IncrementalDetails {
  groupedFieldSet: FieldSet;
  objectType: GraphQLObjectType;
  objectValue: any;
}

type IncrementalDetailsByPath = { [path: Path]: IncrementalDetails };

function ExecuteGroupedFieldSet(
  groupedFieldSet: GroupedFieldSet,
  objectType: GraphQLObjectType,
  objectValue: any,
  variableValues: CoercedVariables,
  path: Path,
  currentDeliveryGroups: DeliveryGroup[]
): [
  resultMap: Record<string, any>,
  incrementalDetailsByPath: IncrementalDetailsByPath
];

interface FieldDigest {
  selection: FieldNode;
  deliveryGroup: DeliveryGroup;
}

function CollectFields(
  objectType: GraphQLObjectType,
  selectionSet: SelectionSet,
  variableValues: CoercedVariables,
  path: Path,
  deliveryGroup: DeliveryGroup,
  visitedFragments: Set<string> = new Set()
): { [responseKey: string]: FieldDigest[] };

function DoesFragmentTypeApply(
  objectType: GraphQLObjectType,
  fragmentType: GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType
): boolean;

function ExecuteField(
  objectType: GraphQLObjectType,
  objectValue: any,
  fieldType: GraphQLType,
  fieldDigests: FieldDigest[], // All for this field
  variableValues: CoercedVariables,
  path: Path,
  currentDeliveryGroups: DeliveryGroup[]
): ReturnType<typeof CompleteValue>;

function CompleteValue(
  fieldType: GraphQLType,
  fieldDigests: FieldDigest[], // All for this field
  result: any,
  variableValues: CoercedVariables,
  path: Path,
  currentDeliveryGroups: DeliveryGroup[]
): [
  result:
    | null
    | ScalarValue
    | EnumValue
    | Record<string, any>
    | Array<null | ScalarValue | EnumValue | Record<string, any>>,
  incrementalDetailsByPath: IncrementalDetailsByPath
];

function CoerceResult(
  leafType: GraphQLScalarType | GraphQLEnumType,
  value: any
): any;

function ResolveAbstractType(
  abstractType: GraphQLInterfaceType | GraphQLUnionType,
  objectValue: any
): GraphQLObjectType;

function CollectSubfields(
  objectType: GraphQLObjectType,
  fieldDigests: FieldDigest[],
  variableValues: CoercedVariables,
  path: Path
): { [responseKey: string]: FieldDigest[] };

function IncrementalEventStream(
  data: Record<string, any>,
  errors: GraphQLError[] | undefined,
  initialIncrementalDetailsByPath: IncrementalDetailsByPath,
  variableValues: CoercedVariables
): EventStream<InitialIncrementalResult | SubsequentIncrementalResult>;

function CollectDeliveryGroups(
  incrementalDetailsByPath: IncrementalDetailsByPath,
  excludingDeliveryGroups: Set<DeliveryGroup> = new Set()
): DeliveryGroup[];

function MakePending(deliveryGroups: DeliveryGroup[]): Pending[];

function IncrementalStreams(
  incrementalDetailsByPath: IncrementalDetailsByPath
): EventStream<SubsequentIncrementalResult>;

function PartitionDeliveryGroupsSets(
  incrementalDetailsByPath: IncrementalDetailsByPath
): Array<Set<DeliveryGroup>>;

function IncrementalStream(
  incrementalDetailsByPath: IncrementalDetailsByPath,
  deliveryGroupsSet: Set<DeliveryGroup>
): EventStream<SubsequentIncrementalResult>;

function SplitRunnable(
  incrementalDetailsByPath: IncrementalDetailsByPath,
  runnableDeliveryGroupsSet: Set<DeliveryGroup>
): [
  remainingIncrementalDetailsByPath: IncrementalDetailsByPath,
  runnable: IncrementalDetailsByPath
];

function MergeIncrementalDetailsByPath(
  incrementalDetailsByPath1: IncrementalDetailsByPath,
  incrementalDetailsByPath2: IncrementalDetailsByPath
): IncrementalDetailsByPath;
```
