### PR TITLE
Alternative spec implementation of deduplicated incremental delivery

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -4,6 +4,7 @@ ignoreRegExpList:
   - /[a-z]{2,}'s/
 words:
   # Terms of art
+  - deprioritization
   - endianness
   - interoperation
   - monospace

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -794,8 +794,9 @@ And will yield the subset of each object type queried:
 When querying an Object, the resulting mapping of fields are conceptually
 ordered in the same order in which they were encountered during execution,
 excluding fragments for which the type does not apply and fields or fragments
-that are skipped via `@skip` or `@include` directives. This ordering is
-correctly produced when using the {CollectFields()} algorithm.
+that are skipped via `@skip` or `@include` directives or temporarily skipped via
+`@defer`. This ordering is correctly produced when using the {CollectFields()}
+algorithm.
 
 Response serialization formats capable of representing ordered maps should
 maintain this ordering. Serialization formats which can only represent unordered
@@ -1942,6 +1943,11 @@ by a validator, executor, or client tool such as a code generator.
 
 GraphQL implementations should provide the `@skip` and `@include` directives.
 
+GraphQL implementations are not required to implement the `@defer` and `@stream`
+directives. If either or both of these directives are implemented, they must be
+implemented according to this specification. GraphQL implementations that do not
+support these directives must not make them available via introspection.
+
 GraphQL implementations that support the type system definition language must
 provide the `@deprecated` directive if representing deprecated portions of the
 schema.
@@ -2162,3 +2168,99 @@ to the relevant IETF specification.
 ```graphql example
 scalar UUID @specifiedBy(url: "https://tools.ietf.org/html/rfc4122")
 ```
+
+### @defer
+
+```graphql
+directive @defer(
+  label: String
+  if: Boolean! = true
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+```
+
+The `@defer` directive may be provided for fragment spreads and inline fragments
+to inform the executor to delay the execution of the current fragment to
+indicate deprioritization of the current fragment. A query with `@defer`
+directive will cause the request to potentially return multiple responses, where
+non-deferred data is delivered in the initial response and data deferred is
+delivered in a subsequent response. `@include` and `@skip` take precedence over
+`@defer`.
+
+```graphql example
+query myQuery($shouldDefer: Boolean) {
+  user {
+    name
+    ...someFragment @defer(label: "someLabel", if: $shouldDefer)
+  }
+}
+fragment someFragment on User {
+  id
+  profile_picture {
+    uri
+  }
+}
+```
+
+#### @defer Arguments
+
+- `if: Boolean! = true` - When `true`, fragment _should_ be deferred (see
+  related note below). When `false`, fragment will not be deferred and data will
+  be included in the initial response. Defaults to `true` when omitted.
+- `label: String` - May be used by GraphQL clients to identify the data from
+  responses and associate it with the corresponding defer directive. If
+  provided, the GraphQL service must add it to the corresponding pending object
+  in the response. `label` must be unique label across all `@defer` and
+  `@stream` directives in a document. `label` must not be provided as a
+  variable.
+
+### @stream
+
+```graphql
+directive @stream(
+  label: String
+  if: Boolean! = true
+  initialCount: Int = 0
+) on FIELD
+```
+
+The `@stream` directive may be provided for a field of `List` type so that the
+backend can leverage technology such as asynchronous iterators to provide a
+partial list in the initial response, and additional list items in subsequent
+responses. `@include` and `@skip` take precedence over `@stream`.
+
+```graphql example
+query myQuery($shouldStream: Boolean) {
+  user {
+    friends(first: 10) {
+      nodes @stream(label: "friendsStream", initialCount: 5, if: $shouldStream)
+    }
+  }
+}
+```
+
+#### @stream Arguments
+
+- `if: Boolean! = true` - When `true`, field _should_ be streamed (see related
+  note below). When `false`, the field will not be streamed and all list items
+  will be included in the initial response. Defaults to `true` when omitted.
+- `label: String` - May be used by GraphQL clients to identify the data from
+  responses and associate it with the corresponding stream directive. If
+  provided, the GraphQL service must add it to the corresponding pending object
+  in the response. `label` must be unique label across all `@defer` and
+  `@stream` directives in a document. `label` must not be provided as a
+  variable.
+- `initialCount: Int` - The number of list items the service should return as
+  part of the initial response. If omitted, defaults to `0`. A field error will
+  be raised if the value of this argument is less than `0`.
+
+Note: The ability to defer and/or stream parts of a response can have a
+potentially significant impact on application performance. Developers generally
+need clear, predictable control over their application's performance. It is
+highly recommended that GraphQL services honor the `@defer` and `@stream`
+directives on each execution. However, the specification allows advanced use
+cases where the service can determine that it is more performant to not defer
+and/or stream. Therefore, GraphQL clients _must_ be able to process a response
+that ignores the `@defer` and/or `@stream` directives. This also applies to the
+`initialCount` argument on the `@stream` directive. Clients _must_ be able to
+process a streamed response that contains a different number of initial list
+items than what was specified in the `initialCount` argument.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -422,6 +422,7 @@ FieldsInSetCanMerge(set):
   {set} including visiting fragments and inline fragments.
 - Given each pair of members {fieldA} and {fieldB} in {fieldsForName}:
   - {SameResponseShape(fieldA, fieldB)} must be true.
+  - {SameStreamDirective(fieldA, fieldB)} must be true.
   - If the parent types of {fieldA} and {fieldB} are equal or if either is not
     an Object Type:
     - {fieldA} and {fieldB} must have identical field names.
@@ -455,6 +456,16 @@ SameResponseShape(fieldA, fieldB):
 - Given each pair of members {subfieldA} and {subfieldB} in {fieldsForName}:
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
+
+SameStreamDirective(fieldA, fieldB):
+
+- If neither {fieldA} nor {fieldB} has a directive named `stream`.
+  - Return {true}.
+- If both {fieldA} and {fieldB} have a directive named `stream`.
+  - Let {streamA} be the directive named `stream` on {fieldA}.
+  - Let {streamB} be the directive named `stream` on {fieldB}.
+  - If {streamA} and {streamB} have identical sets of arguments, return {true}.
+- Return {false}.
 
 Note: In prior versions of the spec the term "composite" was used to signal a
 type that is either an Object, Interface or Union type.
@@ -1518,6 +1529,174 @@ query ($foo: Boolean = true, $bar: Boolean = false) {
   field @skip(if: $bar) {
     subfieldB
   }
+}
+```
+
+### Defer And Stream Directives Are Used On Valid Root Field
+
+** Formal Specification **
+
+- For every {directive} in a document.
+- Let {directiveName} be the name of {directive}.
+- Let {mutationType} be the root Mutation type in {schema}.
+- Let {subscriptionType} be the root Subscription type in {schema}.
+- If {directiveName} is "defer" or "stream":
+  - The parent type of {directive} must not be {mutationType} or
+    {subscriptionType}.
+
+**Explanatory Text**
+
+The defer and stream directives are not allowed to be used on root fields of the
+mutation or subscription type.
+
+For example, the following document will not pass validation because `@defer`
+has been used on a root mutation field:
+
+```raw graphql counter-example
+mutation {
+  ... @defer {
+    mutationField
+  }
+}
+```
+
+### Defer And Stream Directives Are Used On Valid Operations
+
+** Formal Specification **
+
+- Let {subscriptionFragments} be the empty set.
+- For each {operation} in a document:
+  - If {operation} is a subscription operation:
+    - Let {fragments} be every fragment referenced by that {operation}
+      transitively.
+    - For each {fragment} in {fragments}:
+      - Let {fragmentName} be the name of {fragment}.
+      - Add {fragmentName} to {subscriptionFragments}.
+- For every {directive} in a document:
+  - If {directiveName} is not "defer" or "stream":
+    - Continue to the next {directive}.
+  - Let {ancestor} be the ancestor operation or fragment definition of
+    {directive}.
+  - If {ancestor} is a fragment definition:
+    - If the fragment name of {ancestor} is not present in
+      {subscriptionFragments}:
+      - Continue to the next {directive}.
+  - If {ancestor} is not a subscription operation:
+    - Continue to the next {directive}.
+  - Let {if} be the argument named "if" on {directive}.
+  - {if} must be defined.
+  - Let {argumentValue} be the value passed to {if}.
+  - {argumentValue} must be a variable, or the boolean value "false".
+
+**Explanatory Text**
+
+The defer and stream directives can not be used to defer or stream data in
+subscription operations. If these directives appear in a subscription operation
+they must be disabled using the "if" argument. This rule will not permit any
+defer or stream directives on a subscription operation that cannot be disabled
+using the "if" argument.
+
+For example, the following document will not pass validation because `@defer`
+has been used in a subscription operation with no "if" argument defined:
+
+```raw graphql counter-example
+subscription sub {
+  newMessage {
+    ... @defer {
+      body
+    }
+  }
+}
+```
+
+### Defer And Stream Directive Labels Are Unique
+
+** Formal Specification **
+
+- Let {labelValues} be an empty set.
+- For every {directive} in the document:
+  - Let {directiveName} be the name of {directive}.
+  - If {directiveName} is "defer" or "stream":
+    - For every {argument} in {directive}:
+      - Let {argumentName} be the name of {argument}.
+      - Let {argumentValue} be the value passed to {argument}.
+      - If {argumentName} is "label":
+        - {argumentValue} must not be a variable.
+        - {argumentValue} must not be present in {labelValues}.
+        - Append {argumentValue} to {labelValues}.
+
+**Explanatory Text**
+
+The `@defer` and `@stream` directives each accept an argument "label". This
+label may be used by GraphQL clients to uniquely identify response payloads. If
+a label is passed, it must not be a variable and it must be unique within all
+other `@defer` and `@stream` directives in the document.
+
+For example the following document is valid:
+
+```graphql example
+{
+  dog {
+    ...fragmentOne
+    ...fragmentTwo @defer(label: "dogDefer")
+  }
+  pets @stream(label: "petStream") {
+    name
+  }
+}
+
+fragment fragmentOne on Dog {
+  name
+}
+
+fragment fragmentTwo on Dog {
+  owner {
+    name
+  }
+}
+```
+
+For example, the following document will not pass validation because the same
+label is used in different `@defer` and `@stream` directives.:
+
+```raw graphql counter-example
+{
+  dog {
+    ...fragmentOne @defer(label: "MyLabel")
+  }
+  pets @stream(label: "MyLabel") {
+    name
+  }
+}
+
+fragment fragmentOne on Dog {
+  name
+}
+```
+
+### Stream Directives Are Used On List Fields
+
+**Formal Specification**
+
+- For every {directive} in a document.
+- Let {directiveName} be the name of {directive}.
+- If {directiveName} is "stream":
+  - Let {adjacent} be the AST node the directive affects.
+  - {adjacent} must be a List type.
+
+**Explanatory Text**
+
+GraphQL directive locations do not provide enough granularity to distinguish the
+type of fields used in a GraphQL document. Since the stream directive is only
+valid on list fields, an additional validation rule must be used to ensure it is
+used correctly.
+
+For example, the following document will only pass validation if `field` is
+defined as a List type in the associated schema.
+
+```graphql counter-example
+query {
+  field @stream(initialCount: 0)
 }
 ```
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -467,7 +467,7 @@ unambiguous. Therefore any two field selections which might both be encountered
 for the same object are only valid if they are equivalent.
 
 During execution, the simultaneous execution of fields with the same response
-name is accomplished by {MergeSelectionSets()} and {CollectFields()}.
+name is accomplished by {CollectSubfields()}.
 
 For simple hand-written GraphQL, this rule is obviously a clear developer error,
 however nested fragments can make this difficult to detect manually.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -526,7 +526,7 @@ variableValues, serial, path, deferUsageSet, deferMap):
   {incrementalDataRecords}.
 - Return {data} and {incrementalDataRecords}.
 
-### Mapping Deferred Fragments to Delivery Groups
+### Mapping @defer Directives to Delivery Groups
 
 Because `@defer` directives may be nested within list types, a map is required
 to associate a Defer Usage record as recorded within Field Details Records and

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -261,7 +261,7 @@ CreateSourceEventStream(subscription, schema, variableValues, initialValue):
 - Let {fieldName} be the name of {field}. Note: This value is unaffected if an
   alias is used.
 - Let {argumentValues} be the result of {CoerceArgumentValues(subscriptionType,
-  node, variableValues)}.
+  field, variableValues)}.
 - Let {fieldStream} be the result of running
   {ResolveFieldEventStream(subscriptionType, initialValue, fieldName,
   argumentValues)}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -507,9 +507,9 @@ GetInitialResult(data, errors, pendingResults):
 - Let {hasNext} be {true}.
 - Return an unordered map containing {data}, {errors}, {pending}, and {hasNext}.
 
-Formatting the `pending` of initial and subsequentResults is defined by the
-{GetPendingEntry()} algorithm. Given a set of new root nodes added to the graph,
-{GetPendingEntry()} returns a list of formatted `pending` entries.
+Formatting the `pending` entries of initial and subsequentResults is defined by
+the {GetPendingEntry()} algorithm. Given a set of new root nodes added to the
+graph, {GetPendingEntry()} returns a list of formatted `pending` entries.
 
 GetPendingEntry(newRootNodes):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -395,8 +395,7 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
     - Append {GetCompletedEntry(pendingResult)} to {completed}.
     - Remove {pendingResult} from {graph}, promoting its child Deferred Fragment
       nodes to root nodes.
-  - Let {newPendingResults} be a new set containing the result of
-    {GetNonEmptyNewPending(graph, pendingResults)}.
+  - Let {newPendingResults} be the result of {GetNonEmptyNewPending(graph)}.
   - Add all nodes in {newPendingResults} to {pendingResults}.
   - Update {graph} to the subgraph rooted at nodes in {pendingResults}.
   - Let {pending} be the result of {GetPendingEntry(newPendingResults)}.
@@ -416,18 +415,17 @@ BuildGraph(incrementalDataRecords, graph):
     until {incrementalDataRecord} is connected to {newGraph}.
 - Return {newGraph}.
 
-GetNonEmptyNewPending(graph, oldPendingResults):
+GetNonEmptyNewPending(graph):
 
-- If not provided, initialize {oldPendingResults} to the empty set.
-- Let {rootNodes} be the set of root nodes in {graph}.
+- Initialize {newPendingResults} to the empty set.
+- Initialize {rootNodes} to the set of root nodes in {graph}.
 - For each {rootNode} of {rootNodes}:
-  - If {rootNodes} is in {oldPendingResults}:
-    - Continue to the next {rootNode}.
   - If {rootNode} has no children Pending Incremental Data nodes:
     - Let {children} be the set of child Deferred Fragment nodes of {rootNode}.
-    - Remove {rootNode} from {rootNodes}.
     - Add each of the nodes in {children} to {rootNodes}.
-- Return {rootNodes}.
+    - Continue to the next {rootNode} of {rootNodes}.
+  - Add {rootNode} to {newPendingResults}.
+- Return {newPendingResults}.
 
 GetInitialResult(data, errors, pendingResults):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -570,8 +570,11 @@ visitedFragments):
     - If {DoesFragmentTypeApply(objectType, fragmentType)} is {false}, continue
       with the next {selection} in {selectionSet}.
     - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
-    - If {deferDirective} is defined, let {fragmentDeferUsage} be
-      {deferDirective} and append it to {newDeferUsages}.
+    - If {deferDirective} is defined:
+      - Let {path} be the corresponding entry on {deferDirective}.
+      - Let {parentDeferUsage} be {deferUsage}.
+      - Let {fragmentDeferUsage} be an unordered map containing {path} and
+        {parentDeferUsage}.
     - Otherwise, let {fragmentDeferUsage} be {deferUsage}.
     - Let {fragmentGroupedFieldSet} and {fragmentNewDeferUsages} be the result
       of calling {CollectFields(objectType, fragmentSelectionSet,
@@ -595,8 +598,11 @@ visitedFragments):
       - Let {deferDirective} be that directive.
       - If this execution is for a subscription operation, raise a _field
         error_.
-    - If {deferDirective} is defined, let {fragmentDeferUsage} be
-      {deferDirective} and append it to {newDeferUsages}.
+    - If {deferDirective} is defined:
+      - Let {path} be the corresponding entry on {deferDirective}.
+      - Let {parentDeferUsage} be {deferUsage}.
+      - Let {fragmentDeferUsage} be an unordered map containing {path} and
+        {parentDeferUsage}.
     - Otherwise, let {fragmentDeferUsage} be {deferUsage}.
     - Let {fragmentGroupedFieldSet} and {fragmentNewDeferUsages} be the result
       of calling {CollectFields(objectType, fragmentSelectionSet,

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -354,7 +354,7 @@ The procedure for yielding incremental results is specified by the
 
 YieldIncrementalResults(data, errors, incrementalDataRecords):
 
-- Let {graph} be the result of {BuildGraph(incrementalDataRecords)}.
+- Let {graph} be the result of {GraphFromRecords(incrementalDataRecords)}.
 - Let {pendingResults} be the result of {GetNonEmptyNewPending(graph)}.
 - Update {graph} to the subgraph rooted at nodes in {pendingResults}.
 - Yield the result of {GetInitialResult(data, errors, pendingResults)}.
@@ -377,7 +377,7 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
   - Replace {node} in {graph} with a new node corresponding to the Completed
     Incremental Data for {result}.
   - Let {resultIncrementalDataRecords} be {incrementalDataRecords} on {result}.
-  - Update {graph} to {BuildGraph(resultIncrementalDataRecords, graph)}.
+  - Update {graph} to {GraphFromRecords(resultIncrementalDataRecords, graph)}.
   - Let {completedDeferredFragments} be the set of root nodes in {graph} without
     any child Pending Data nodes.
   - Let {completedIncrementalDataNodes} be the set of completed Incremental Data
@@ -403,7 +403,7 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
     pending)}.
 - Complete this incremental result stream.
 
-BuildGraph(incrementalDataRecords, graph):
+GraphFromRecords(incrementalDataRecords, graph):
 
 - Let {newGraph} be a new directed acyclic graph containing all of the nodes and
   edges in {graph}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -593,7 +593,7 @@ path, deferUsageSet, deferMap):
 - Return {resultMap} and {incrementalDataRecords}.
 
 Note: {resultMap} is ordered by which fields appear first in the operation. This
-is explained in greater detail in the Field Collection section above.
+is explained in greater detail in the Field Collection section below.
 
 **Errors and Non-Null Fields**
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -359,23 +359,21 @@ The procedure for yielding incremental results is specified by the
 YieldIncrementalResults(data, errors, incrementalDataRecords):
 
 - Let {graph} be the result of {GraphFromRecords(incrementalDataRecords)}.
-- Let {pendingResults} be the result of {GetNonEmptyNewPending(graph)}.
-- Update {graph} to the subgraph rooted at nodes in {pendingResults}.
+- Let {rootNodes} be the result of {GetNewRootNodes(graph)}.
+- Update {graph} to the subgraph rooted at nodes in {rootNodes}.
 - Yield the result of {GetInitialResult(data, errors, pendingResults)}.
 - For each completed child Pending Incremental Data node of a root node in
   {graph}:
   - Let {incrementalDataRecord} be the Pending Incremental Data for that node;
     let {result} be the corresponding completed result.
   - If {data} on {result} is {null}:
-    - Initialize {completed} to an empty list.
     - Let {parents} be the parent nodes of {executionGroup}.
     - Initialize {completed} to an empty list.
-    - For each {pendingResult} of {parents}:
+    - For each {node} of {parents}:
       - Append {GetCompletedEntry(parent, errors)} to {completed}.
-      - Remove {pendingResult} and all of its descendant nodes from {graph},
-        except for any descendant Incremental Data Record nodes with other
-        parents.
-    - Let {hasNext} be {false}, if {graph} is empty.
+      - Remove {node} and all of its descendant nodes from {graph}, except for
+        any descendant Incremental Data Record nodes with other parents.
+    - Let {hasNext} be {false} if {graph} is empty; otherwise, {true}.
     - Yield an unordered map containing {completed} and {hasNext}.
     - Continue to the next completed Pending Incremental Data node.
   - Replace {node} in {graph} with a new node corresponding to the Completed
@@ -389,20 +387,21 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
   - If {completedIncrementalDataNodes} is empty, continue to the next completed
     Pending Incremental Data Node.
   - Initialize {incremental} to an empty list.
-  - For each {node} of {completedIncrementalDataNodes}:
-    - Let {incrementalDataRecord} be the corresponding record for {node}.
+  - For each {completedIncrementalDataNode} of {completedIncrementalDataNodes}:
+    - Let {incrementalDataRecord} be the corresponding record for
+      {completedIncrementalDataNode}.
     - Append {GetIncrementalEntry(incrementalDataRecord, graph)} to
       {incremental}.
     - Remove {node} from {graph}.
   - Initialize {completed} to an empty list.
-  - For each {pendingResult} of {completedDeferredFragments}:
-    - Append {GetCompletedEntry(pendingResult)} to {completed}.
-    - Remove {pendingResult} from {graph}, promoting its child Deferred Fragment
-      nodes to root nodes.
-  - Let {newPendingResults} be the result of {GetNonEmptyNewPending(graph)}.
-  - Add all nodes in {newPendingResults} to {pendingResults}.
-  - Update {graph} to the subgraph rooted at nodes in {pendingResults}.
-  - Let {pending} be the result of {GetPendingEntry(newPendingResults)}.
+  - For each {completedDeferredFragment} of {completedDeferredFragments}:
+    - Append {GetCompletedEntry(completedDeferredFragment)} to {completed}.
+    - Remove {completedDeferredFragment} from {graph}, promoting its child
+      Deferred Fragment nodes to root nodes.
+  - Let {newRootNodes} be the result of {GetNewRootNodes(graph)}.
+  - Add all nodes in {newRootNodes} to {rootNodes}.
+  - Update {graph} to the subgraph rooted at nodes in {rootNodes}.
+  - Let {pending} be the result of {GetPendingEntry(newRootNodes)}.
   - Yield the result of {GetIncrementalResult(graph, incremental, completed,
     pending)}.
 - Complete this incremental result stream.
@@ -420,7 +419,7 @@ GraphFromRecords(incrementalDataRecords, graph):
     to {newGraph}, or the {parent} is not defined.
 - Return {newGraph}.
 
-GetNonEmptyNewPending(graph):
+GetNewRootNodes(graph):
 
 - Initialize {newPendingResults} to the empty set.
 - Initialize {rootNodes} to the set of root nodes in {graph}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -526,6 +526,8 @@ variableValues, serial, path, deferUsageSet, deferMap):
   {incrementalDataRecords}.
 - Return {data} and {incrementalDataRecords}.
 
+### Mapping Deferred Fragments to Delivery Groups
+
 Because `@defer` directives may be nested within list types, a map is required
 to associate a Defer Usage record as recorded within Field Details Records and
 an actual Deferred Fragment so that any additional Execution Groups may be
@@ -547,6 +549,8 @@ GetNewDeferMap(newDeferUsages, path, deferMap):
     and {label}.
   - Set the entry for {deferUsage} in {newDeferMap} to {newDeferredFragment}.
 - Return {newDeferMap}.
+
+### Collecting Execution Groups
 
 The {CollectExecutionGroups()} algorithm is responsible for creating the
 Execution Groups, i.e. Incremental Data Records, for each partitioned grouped

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -376,8 +376,8 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
     - Continue to the next completed Pending Incremental Data node.
   - Replace {node} in {graph} with a new node corresponding to the Completed
     Incremental Data for {result}.
-  - Add each {incrementalDataRecord} of {incrementalDataRecords} on {result} to
-    {graph} via the same procedure as above.
+  - Let {resultIncrementalDataRecords} be {incrementalDataRecords} on {result}.
+  - Update {graph} to {BuildGraph(resultIncrementalDataRecords, graph)}.
   - Let {completedDeferredFragments} be the set of root nodes in {graph} without
     any child Pending Data nodes.
   - Let {completedIncrementalDataNodes} be the set of completed Incremental Data
@@ -404,17 +404,17 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
     pending)}.
 - Complete this incremental result stream.
 
-BuildGraph(incrementalDataRecords):
+BuildGraph(incrementalDataRecords, graph):
 
-- Initialize {graph} to an empty directed acyclic graph, where the root nodes
-  represent the pending Subsequent Results.
+- Let {newGraph} be a new directed acyclic graph containing all of the nodes and
+  edges in {graph}.
 - For each {incrementalDataRecord} of {incrementalDataRecords}:
-  - Add {incrementalDataRecord} to {graph} as a new Pending Data node directed
-    from the {pendingResults} that it completes, adding each of {pendingResults}
-    to {graph} as new nodes, if necessary, each directed from its {parent}, if
-    defined, recursively adding each {parent} as necessary until
-    {incrementalDataRecord} is connected to {graph}.
-- Return {graph}.
+  - Add {incrementalDataRecord} to {newGraph} as a new Pending Data node
+    directed from the {pendingResults} that it completes, adding each of
+    {pendingResults} to {newGraph} as new nodes, if necessary, each directed
+    from its {parent}, if defined, recursively adding each {parent} as necessary
+    until {incrementalDataRecord} is connected to {newGraph}.
+- Return {newGraph}.
 
 GetNonEmptyNewPending(graph, oldPendingResults):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -354,17 +354,10 @@ The procedure for yielding incremental results is specified by the
 
 YieldIncrementalResults(data, errors, incrementalDataRecords):
 
-- Initialize {graph} to an empty directed acyclic graph.
-- For each {incrementalDataRecord} of {incrementalDataRecords}:
-  - Add {incrementalDataRecord} to {graph} as a new Pending Data node directed
-    from the {pendingResults} that it completes, adding each of {pendingResults}
-    to {graph} as new nodes, if necessary, each directed from its {parent}, if
-    defined, recursively adding each {parent} as necessary until
-    {incrementalDataRecord} is connected to {graph}.
+- Let {graph} be the result of {BuildGraph(incrementalDataRecords)}.
 - Let {pendingResults} be the result of {GetNonEmptyNewPending(graph)}.
-- Prune root nodes from {graph} not in {pendingResults}, repeating as necessary
-  until all root nodes in {graph} are also in {pendingResults}.
-- Yield the result of {GetInitialResult(data, errors, pending)}.
+- Update {graph} to the subgraph rooted at nodes in {pendingResults}.
+- Yield the result of {GetInitialResult(data, errors, pendingResults)}.
 - For each completed child Pending Incremental Data node of a root node in
   {graph}:
   - Let {incrementalDataRecord} be the Pending Incremental Data for that node;
@@ -405,12 +398,23 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
   - Let {newPendingResults} be a new set containing the result of
     {GetNonEmptyNewPending(graph, pendingResults)}.
   - Add all nodes in {newPendingResults} to {pendingResults}.
-  - Prune root nodes from {graph} not in {pendingResults}, repeating as
-    necessary until all root nodes in {graph} are also in {pendingResults}.
+  - Update {graph} to the subgraph rooted at nodes in {pendingResults}.
   - Let {pending} be the result of {GetPendingEntry(newPendingResults)}.
   - Yield the result of {GetIncrementalResult(graph, incremental, completed,
     pending)}.
 - Complete this incremental result stream.
+
+BuildGraph(incrementalDataRecords):
+
+- Initialize {graph} to an empty directed acyclic graph, where the root nodes
+  represent the Subsequent Result nodes that have been released as pending.
+- For each {incrementalDataRecord} of {incrementalDataRecords}:
+  - Add {incrementalDataRecord} to {graph} as a new Pending Data node directed
+    from the {pendingResults} that it completes, adding each of {pendingResults}
+    to {graph} as new nodes, if necessary, each directed from its {parent}, if
+    defined, recursively adding each {parent} as necessary until
+    {incrementalDataRecord} is connected to {graph}.
+- Return {graph}.
 
 GetNonEmptyNewPending(graph, oldPendingResults):
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -400,8 +400,8 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
   - Initialize {completed} to an empty list.
   - For each {pendingResult} of {completedDeferredFragments}:
     - Append {GetCompletedEntry(pendingResult)} to {completed}.
-    - Remove {pendingResult} from {graph}, promoting its child nodes to root
-      nodes.
+    - Remove {pendingResult} from {graph}, promoting its child Deferred Fragment
+      nodes to root nodes.
   - Let {newPendingResults} be a new set containing the result of
     {GetNonEmptyNewPending(graph, pendingResults)}.
   - Add all nodes in {newPendingResults} to {pendingResults}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -334,9 +334,9 @@ serial):
 - If {serial} is not provided, initialize it to {false}.
 - Let {groupedFieldSet} and {newDeferUsages} be the result of
   {CollectFields(objectType, selectionSet, variableValues)}.
-- Let {fieldPlan} be the result of {BuildFieldPlan(groupedFieldSet)}.
+- Let {executionPlan} be the result of {BuildExecutionPlan(groupedFieldSet)}.
 - Let {data} and {incrementalDataRecords} be the result of
-  {ExecuteFieldPlan(newDeferUsages, fieldPlan, objectType, initialValue,
+  {ExecuteExecutionPlan(newDeferUsages, executionPlan, objectType, initialValue,
   variableValues, serial)}.
 - Let {errors} be the list of all _field error_ raised while completing {data}.
 - If {incrementalDataRecords} is empty, return an unordered map containing
@@ -493,20 +493,20 @@ BatchIncrementalResults(incrementalResults):
     of {hasNext} on the final item in the list.
   - Yield {batchedIncrementalResult}.
 
-## Executing a Field Plan
+## Executing an Execution Plan
 
-To execute a field plan, the object value being evaluated and the object type
-need to be known, as well as whether the non-deferred grouped field set must be
-executed serially, or may be executed in parallel.
+To execute a execution plan, the object value being evaluated and the object
+type need to be known, as well as whether the non-deferred grouped field set
+must be executed serially, or may be executed in parallel.
 
-ExecuteFieldPlan(newDeferUsages, fieldPlan, objectType, objectValue,
+ExecuteExecutionPlan(newDeferUsages, executionPlan, objectType, objectValue,
 variableValues, serial, path, deferUsageSet, deferMap):
 
 - If {path} is not provided, initialize it to an empty list.
 - Let {newDeferMap} be the result of {GetNewDeferMap(newDeferUsages, path,
   deferMap)}.
 - Let {groupedFieldSet} and {newGroupedFieldSets} be the corresponding entries
-  on {fieldPlan}.
+  on {executionPlan}.
 - Allowing for parallelization, perform the following steps:
   - Let {data} and {nestedIncrementalDataRecords} be the result of running
     {ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,
@@ -752,7 +752,7 @@ Defer Usages contain the following information:
   enclosing this `@defer` directive, if any, otherwise {undefined}.
 
 The {parentDeferUsage} entry is used to build distinct Execution Groups as
-discussed within the Field Plan Generation section below.
+discussed within the Execution Plan Generation section below.
 
 Field Details Records are unordered maps containing the following entries:
 
@@ -881,14 +881,14 @@ Note: When completing a List field, the {CollectFields} algorithm is invoked
 with the same arguments for each element of the list. GraphQL Services may
 choose to memoize their implementations of {CollectFields}.
 
-### Field Plan Generation
+### Execution Plan Generation
 
-BuildFieldPlan(originalGroupedFieldSet, parentDeferUsages):
+BuildExecutionPlan(originalGroupedFieldSet, parentDeferUsages):
 
 - If {parentDeferUsages} is not provided, initialize it to the empty set.
 - Initialize {groupedFieldSet} to an empty ordered map.
 - Initialize {newGroupedFieldSets} to an empty unordered map.
-- Let {fieldPlan} be an unordered map containing {groupedFieldSet} and
+- Let {executionPlan} be an unordered map containing {groupedFieldSet} and
   {newGroupedFieldSets}.
 - For each {responseKey} and {groupForResponseKey} of {groupedFieldSet}:
   - Let {filteredDeferUsageSet} be the result of
@@ -902,7 +902,7 @@ BuildFieldPlan(originalGroupedFieldSet, parentDeferUsages):
       empty ordered map.
     - Set the entry for {responseKey} in {newGroupedFieldSet} to
       {groupForResponseKey}.
-- Return {fieldPlan}.
+- Return {executionPlan}.
 
 GetFilteredDeferUsageSet(fieldDetailsList):
 
@@ -1054,9 +1054,9 @@ deferUsageSet, deferMap):
     - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
   - Let {groupedFieldSet} and {newDeferUsages} be the result of calling
     {CollectSubfields(objectType, fieldDetailsList, variableValues)}.
-  - Let {fieldPlan} be the result of {BuildFieldPlan(groupedFieldSet,
+  - Let {executionPlan} be the result of {BuildExecutionPlan(groupedFieldSet,
     deferUsageSet)}.
-  - Return the result of {ExecuteFieldPlan(newDeferUsages, fieldPlan,
+  - Return the result of {ExecuteExecutionPlan(newDeferUsages, executionPlan,
     objectType, result, variableValues, false, path, deferUsageSet, deferMap)}.
 
 CompleteListValue(innerType, fieldDetailsList, result, variableValues, path,

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -513,7 +513,7 @@ variableValues, serial, path, deferUsageSet, deferMap):
     variableValues, path, deferUsageSet, newDeferMap)} _serially_ if {serial} is
     {true}, _normally_ (allowing parallelization) otherwise.
   - Let {incrementalDataRecords} be the result of
-    {CollectExecutionGroup(objectType, objectValue, variableValues,
+    {CollectExecutionGroups(objectType, objectValue, variableValues,
     newGroupedFieldSets, path, newDeferMap)}.
 - Append all items in {nestedIncrementalDataRecords} to
   {incrementalDataRecords}.
@@ -542,7 +542,7 @@ newGroupedFieldSets, path, deferMap):
     - Let {deferredFragment} be the entry for {deferUsage} in {deferMap}.
     - Append {deferredFragment} to {deferredFragments}.
   - Let {incrementalDataRecord} represent the future execution of
-    {CollectExecutionGroup(groupedFieldSet, objectType, objectValue,
+    {ExecuteExecutionGroup(groupedFieldSet, objectType, objectValue,
     variableValues, deferredFragments, path, deferUsageSet, deferMap)},
     incrementally completing {deferredFragments} at {path}.
   - Append {incrementalDataRecord} to {incrementalDataRecords}.
@@ -553,7 +553,7 @@ newGroupedFieldSets, path, deferMap):
 Note: {incrementalDataRecord} can be safely initiated without blocking
 higher-priority data once any of {deferredFragments} are released as pending.
 
-CollectExecutionGroup(groupedFieldSet, objectType, objectValue, variableValues,
+ExecuteExecutionGroup(groupedFieldSet, objectType, objectValue, variableValues,
 path, deferUsageSet, deferMap):
 
 - Let {data} and {incrementalDataRecords} be the result of running

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -338,7 +338,8 @@ serial):
 - Let {data} and {incrementalDataRecords} be the result of
   {ExecuteExecutionPlan(newDeferUsages, executionPlan, objectType, initialValue,
   variableValues, serial)}.
-- Let {errors} be the list of all _field error_ raised while completing {data}.
+- Let {errors} be the list of all _field error_ raised while executing the
+  execution plan.
 - If {incrementalDataRecords} is empty, return an unordered map containing
   {data} and {errors}.
 - Let {incrementalResults} be the result of {YieldIncrementalResults(data,
@@ -346,6 +347,9 @@ serial):
 - Wait for the first result in {incrementalResults} to be available.
 - Let {initialResult} be that result.
 - Return {initialResult} and {BatchIncrementalResults(incrementalResults)}.
+
+Note: {ExecuteExecutionPlan()} does not directly raise field errors from the
+incremental portion of the Execution Plan.
 
 ### Yielding Incremental Results
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -866,10 +866,10 @@ BuildFieldPlan(originalGroupedFieldSet, parentDeferUsages):
       {groupForResponseKey}.
 - Return {fieldPlan}.
 
-GetFilteredDeferUsageSet(fieldGroup):
+GetFilteredDeferUsageSet(fieldDetailsList):
 
 - Initialize {filteredDeferUsageSet} to the empty set.
-- For each {fieldDetails} of {fieldGroup}:
+- For each {fieldDetails} of {fieldDetailsList}:
   - Let {deferUsage} be the corresponding entry on {fieldDetails}.
   - If {deferUsage} is not defined:
     - Remove all entries from {filteredDeferUsageSet}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -817,9 +817,9 @@ visitedFragments):
       with the next {selection} in {selectionSet}.
     - Let {fragmentSelectionSet} be the top-level selection set of {fragment}.
     - If {deferDirective} is defined:
-      - Let {path} be the corresponding entry on {deferDirective}.
+      - Let {label} be the corresponding entry on {deferDirective}.
       - Let {parentDeferUsage} be {deferUsage}.
-      - Let {fragmentDeferUsage} be an unordered map containing {path} and
+      - Let {fragmentDeferUsage} be an unordered map containing {label} and
         {parentDeferUsage}.
     - Otherwise, let {fragmentDeferUsage} be {deferUsage}.
     - Let {fragmentGroupedFieldSet} and {fragmentNewDeferUsages} be the result
@@ -845,9 +845,9 @@ visitedFragments):
       - If this execution is for a subscription operation, raise a _field
         error_.
     - If {deferDirective} is defined:
-      - Let {path} be the corresponding entry on {deferDirective}.
+      - Let {label} be the corresponding entry on {deferDirective}.
       - Let {parentDeferUsage} be {deferUsage}.
-      - Let {fragmentDeferUsage} be an unordered map containing {path} and
+      - Let {fragmentDeferUsage} be an unordered map containing {label} and
         {parentDeferUsage}.
     - Otherwise, let {fragmentDeferUsage} be {deferUsage}.
     - Let {fragmentGroupedFieldSet} and {fragmentNewDeferUsages} be the result

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -407,7 +407,7 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
 BuildGraph(incrementalDataRecords):
 
 - Initialize {graph} to an empty directed acyclic graph, where the root nodes
-  represent the Subsequent Result nodes that have been released as pending.
+  represent the pending Subsequent Results.
 - For each {incrementalDataRecord} of {incrementalDataRecords}:
   - Add {incrementalDataRecord} to {graph} as a new Pending Data node directed
     from the {pendingResults} that it completes, adding each of {pendingResults}

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -686,7 +686,7 @@ variableValues, serial, path, deferUsageSet, deferMap):
     variableValues, path, deferUsageSet, newDeferMap)} _serially_ if {serial} is
     {true}, _normally_ (allowing parallelization) otherwise.
   - Let {incrementalDataRecords} be the result of
-    {ExecuteExecutionGroups(objectType, objectValue, variableValues,
+    {CollectExecutionGroup(objectType, objectValue, variableValues,
     newGroupedFieldSets, path, newDeferMap)}.
 - Append all items in {nestedIncrementalDataRecords} to
   {incrementalDataRecords}.
@@ -705,7 +705,7 @@ GetNewDeferMap(newDeferUsages, path, deferMap):
   - Set the entry for {deferUsage} in {newDeferMap} to {newDeferredFragment}.
 - Return {newDeferMap}.
 
-ExecuteExecutionGroups(objectType, objectValue, variableValues,
+CollectExecutionGroups(objectType, objectValue, variableValues,
 newGroupedFieldSets, path, deferMap):
 
 - Initialize {incrementalDataRecords} to an empty list.
@@ -715,7 +715,7 @@ newGroupedFieldSets, path, deferMap):
     - Let {deferredFragment} be the entry for {deferUsage} in {deferMap}.
     - Append {deferredFragment} to {deferredFragments}.
   - Let {incrementalDataRecord} represent the future execution of
-    {ExecuteExecutionGroup(groupedFieldSet, objectType, objectValue,
+    {CollectExecutionGroup(groupedFieldSet, objectType, objectValue,
     variableValues, deferredFragments, path, deferUsageSet, deferMap)},
     incrementally completing {deferredFragments} at {path}.
   - Append {incrementalDataRecord} to {incrementalDataRecords}.
@@ -726,7 +726,7 @@ newGroupedFieldSets, path, deferMap):
 Note: {incrementalDataRecord} can be safely initiated without blocking
 higher-priority data once any of {deferredFragments} are released as pending.
 
-ExecuteExecutionGroup(groupedFieldSet, objectType, objectValue, variableValues,
+CollectExecutionGroup(groupedFieldSet, objectType, objectValue, variableValues,
 path, deferUsageSet, deferMap):
 
 - Let {data} and {incrementalDataRecords} be the result of running

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -1154,7 +1154,7 @@ CollectSubfields(objectType, fieldDetailsList, variableValues):
       {responseKey}; if no such list exists, create it as an empty list.
     - Append all fields in {subfields} to {groupForResponseKey}.
   - Append all defer usages in {subNewDeferUsages} to {newDeferUsages}.
-- Return {groupedFieldSet}.
+- Return {groupedFieldSet} and {newDeferUsages}.
 
 ### Handling Field Errors
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -324,31 +324,34 @@ Executing the root selection set works similarly for queries (parallel),
 mutations (serial), and subscriptions (where it is executed for each event in
 the underlying Source Stream).
 
+First, the selection set is turned into a grouped field set; then, we execute
+this grouped field set and return the resulting {data} and {errors}.
+
 ExecuteRootSelectionSet(variableValues, initialValue, objectType, selectionSet,
 serial):
 
 - If {serial} is not provided, initialize it to {false}.
-- Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
+- Let {groupedFieldSet} be the result of {CollectFields(objectType,
+  selectionSet, variableValues)}.
+- Let {data} be the result of running {ExecuteGroupedFieldSet(groupedFieldSet,
   objectType, initialValue, variableValues)} _serially_ if {serial} is {true},
   _normally_ (allowing parallelization) otherwise.
 - Let {errors} be the list of all _field error_ raised while executing the
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
-## Executing Selection Sets
+## Executing a Grouped Field Set
 
-To execute a _selection set_, the object value being evaluated and the object
+To execute a grouped field set, the object value being evaluated and the object
 type need to be known, as well as whether it must be executed serially, or may
 be executed in parallel.
 
-First, the selection set is turned into a grouped field set; then, each
-represented field in the grouped field set produces an entry into a response
-map.
+Each represented field in the grouped field set produces an entry into a
+response map.
 
-ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues):
+ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+variableValues):
 
-- Let {groupedFieldSet} be the result of {CollectFields(objectType,
-  selectionSet, variableValues)}.
 - Initialize {resultMap} to an empty ordered map.
 - For each {groupedFieldSet} as {responseKey} and {fields}:
   - Let {fieldName} be the name of the first entry in {fields}. Note: This value
@@ -366,8 +369,8 @@ is explained in greater detail in the Field Collection section below.
 
 **Errors and Non-Null Fields**
 
-If during {ExecuteSelectionSet()} a field with a non-null {fieldType} raises a
-_field error_ then that error must propagate to this entire selection set,
+If during {ExecuteGroupedFieldSet()} a field with a non-null {fieldType} raises
+a _field error_ then that error must propagate to this entire selection set,
 either resolving to {null} if allowed or further propagated to a parent field.
 
 If this occurs, any sibling fields which have not yet executed or have not yet
@@ -707,8 +710,9 @@ CompleteValue(fieldType, fields, result, variableValues):
     - Let {objectType} be {fieldType}.
   - Otherwise if {fieldType} is an Interface or Union type.
     - Let {objectType} be {ResolveAbstractType(fieldType, result)}.
-  - Let {subSelectionSet} be the result of calling {MergeSelectionSets(fields)}.
-  - Return the result of evaluating {ExecuteSelectionSet(subSelectionSet,
+  - Let {groupedFieldSet} be the result of calling {CollectSubfields(objectType,
+    fields, variableValues)}.
+  - Return the result of evaluating {ExecuteGroupedFieldSet(groupedFieldSet,
     objectType, result, variableValues)} _normally_ (allowing for
     parallelization).
 
@@ -755,9 +759,9 @@ ResolveAbstractType(abstractType, objectValue):
 
 **Merging Selection Sets**
 
-When more than one field of the same name is executed in parallel, the
-_selection set_ for each of the fields are merged together when completing the
-value in order to continue execution of the sub-selection sets.
+When more than one field of the same name is executed in parallel, during value
+completion their selection sets are collected together to produce a single
+grouped field set in order to continue execution of the sub-selection sets.
 
 An example operation illustrating parallel fields with the same name with
 sub-selections.
@@ -776,14 +780,19 @@ sub-selections.
 After resolving the value for `me`, the selection sets are merged together so
 `firstName` and `lastName` can be resolved for one value.
 
-MergeSelectionSets(fields):
+CollectSubfields(objectType, fields, variableValues):
 
-- Let {selectionSet} be an empty list.
+- Let {groupedFieldSet} be an empty map.
 - For each {field} in {fields}:
   - Let {fieldSelectionSet} be the selection set of {field}.
   - If {fieldSelectionSet} is null or empty, continue to the next field.
-  - Append all selections in {fieldSelectionSet} to {selectionSet}.
-- Return {selectionSet}.
+  - Let {subGroupedFieldSet} be the result of {CollectFields(objectType,
+    fieldSelectionSet, variableValues)}.
+  - For each {subGroupedFieldSet} as {responseKey} and {subfields}:
+    - Let {groupForResponseKey} be the list in {groupedFieldSet} for
+      {responseKey}; if no such list exists, create it as an empty list.
+    - Append all fields in {subfields} to {groupForResponseKey}.
+- Return {groupedFieldSet}.
 
 ### Handling Field Errors
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -410,9 +410,9 @@ GraphFromRecords(incrementalDataRecords, graph):
 - For each {incrementalDataRecord} of {incrementalDataRecords}:
   - Add {incrementalDataRecord} to {newGraph} as a new Pending Data node
     directed from the {pendingResults} that it completes, adding each of
-    {pendingResults} to {newGraph} as new nodes, if necessary, each directed
-    from its {parent}, if defined, recursively adding each {parent} as necessary
-    until {incrementalDataRecord} is connected to {newGraph}.
+    {pendingResults} to {newGraph} as a new node directed from its {parent},
+    recursively adding each {parent} until {incrementalDataRecord} is connected
+    to {newGraph}, or the {parent} is not defined.
 - Return {newGraph}.
 
 GetNonEmptyNewPending(graph):

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -409,6 +409,7 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
 
 GraphFromRecords(incrementalDataRecords, graph):
 
+- If {graph} is not provided, initialize to an empty graph.
 - Let {newGraph} be a new directed acyclic graph containing all of the nodes and
   edges in {graph}.
 - For each {incrementalDataRecord} of {incrementalDataRecords}:

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -586,7 +586,7 @@ path, deferUsageSet, deferMap):
   - If {fieldType} is defined:
     - Let {responseValue} and {fieldIncrementalDataRecords} be the result of
       {ExecuteField(objectType, objectValue, fieldType, fields, variableValues,
-      path)}.
+      path, deferUsageSet, deferMap)}.
     - Set {responseValue} as the value for {responseKey} in {resultMap}.
     - Append all items in {fieldIncrementalDataRecords} to
       {incrementalDataRecords}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -364,7 +364,7 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
     let {result} be the corresponding completed result.
   - If {data} on {result} is {null}:
     - Initialize {completed} to an empty list.
-    - Let {parents} be the parent nodes of {deferredGroupedFieldSetRecord}.
+    - Let {parents} be the parent nodes of {executionGroup}.
     - Initialize {completed} to an empty list.
     - For each {pendingResult} of {parents}:
       - Append {GetCompletedEntry(parent, errors)} to {completed}.
@@ -686,7 +686,7 @@ variableValues, serial, path, deferUsageSet, deferMap):
     variableValues, path, deferUsageSet, newDeferMap)} _serially_ if {serial} is
     {true}, _normally_ (allowing parallelization) otherwise.
   - Let {incrementalDataRecords} be the result of
-    {ExecuteDeferredGroupedFieldSets(objectType, objectValue, variableValues,
+    {ExecuteExecutionGroups(objectType, objectValue, variableValues,
     newGroupedFieldSets, path, newDeferMap)}.
 - Append all items in {nestedIncrementalDataRecords} to
   {incrementalDataRecords}.
@@ -705,7 +705,7 @@ GetNewDeferMap(newDeferUsages, path, deferMap):
   - Set the entry for {deferUsage} in {newDeferMap} to {newDeferredFragment}.
 - Return {newDeferMap}.
 
-ExecuteDeferredGroupedFieldSets(objectType, objectValue, variableValues,
+ExecuteExecutionGroups(objectType, objectValue, variableValues,
 newGroupedFieldSets, path, deferMap):
 
 - Initialize {incrementalDataRecords} to an empty list.
@@ -715,7 +715,7 @@ newGroupedFieldSets, path, deferMap):
     - Let {deferredFragment} be the entry for {deferUsage} in {deferMap}.
     - Append {deferredFragment} to {deferredFragments}.
   - Let {incrementalDataRecord} represent the future execution of
-    {ExecuteDeferredGroupedFieldSet(groupedFieldSet, objectType, objectValue,
+    {ExecuteExecutionGroup(groupedFieldSet, objectType, objectValue,
     variableValues, deferredFragments, path, deferUsageSet, deferMap)},
     incrementally completing {deferredFragments} at {path}.
   - Append {incrementalDataRecord} to {incrementalDataRecords}.
@@ -726,8 +726,8 @@ newGroupedFieldSets, path, deferMap):
 Note: {incrementalDataRecord} can be safely initiated without blocking
 higher-priority data once any of {deferredFragments} are released as pending.
 
-ExecuteDeferredGroupedFieldSet(groupedFieldSet, objectType, objectValue,
-variableValues, path, deferUsageSet, deferMap):
+ExecuteExecutionGroup(groupedFieldSet, objectType, objectValue, variableValues,
+path, deferUsageSet, deferMap):
 
 - Let {data} and {incrementalDataRecords} be the result of running
   {ExecuteGroupedFieldSet(groupedFieldSet, objectType, objectValue,

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -373,8 +373,7 @@ YieldIncrementalResults(data, errors, incrementalDataRecords):
       - Append {GetCompletedEntry(parent, errors)} to {completed}.
       - Remove {node} and all of its descendant nodes from {graph}, except for
         any descendant Incremental Data Record nodes with other parents.
-    - Let {hasNext} be {false} if {graph} is empty; otherwise, {true}.
-    - Yield an unordered map containing {completed} and {hasNext}.
+    - Yield the result of {GetIncrementalResult(graph, completed)}.
     - Continue to the next completed Pending Incremental Data node.
   - Replace {node} in {graph} with a new node corresponding to the Completed
     Incremental Data for {result}.
@@ -447,15 +446,15 @@ GetPendingEntry(pendingResults):
   - Append {pendingEntry} to {pending}.
 - Return {pending}.
 
-GetIncrementalResult(graph, incremental, completed, pending):
+GetIncrementalResult(graph, completed, incremental, pending):
 
 - Let {hasNext} be {false} if {graph} is empty, otherwise, {true}.
 - Let {incrementalResult} be an unordered map containing {hasNext}.
-- If {incremental} is not empty:
+- If {incremental} is provided and not empty:
   - Set the corresponding entry on {incrementalResult} to {incremental}.
 - If {completed} is not empty:
   - Set the corresponding entry on {incrementalResult} to {completed}.
-- If {pending} is not empty:
+- If {pending} is provided and not empty:
   - Set the corresponding entry on {incrementalResult} to {pending}.
 - Return {incrementalResult}.
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -10,7 +10,12 @@ the case that any _field error_ was raised on a field and was replaced with
 
 ## Response Format
 
-A response to a GraphQL request must be a map.
+A response to a GraphQL request must be a map or a stream of incrementally
+delivered results. The response will be a stream of incrementally delivered
+results when the GraphQL service has deferred or streamed data as a result of
+the `@defer` or `@stream` directives. When the response of the GraphQL operation
+contains incrementally delivered results, the first value will be an initial
+payload, followed by one or more subsequent payloads.
 
 If the request raised any errors, the response map must contain an entry with
 key `errors`. The value of this entry is described in the "Errors" section. If
@@ -22,14 +27,31 @@ key `data`. The value of this entry is described in the "Data" section. If the
 request failed before execution, due to a syntax error, missing information, or
 validation error, this entry must not be present.
 
+When the response of the GraphQL operation contains incrementally delivered
+results, both the initial payload and all subsequent payloads must contain an
+entry with key `hasNext`. The value of this entry must be {true} for all but the
+last response in the stream. The value of this entry must be {false} for the
+last response of the stream. This entry must not be present for GraphQL
+operations that return a single response map.
+
+When the response of the GraphQL operation contains incrementally delivered
+results, both the initial payload and any subsequent payloads may contain
+entries with the keys `pending`, `incremental`, and/or `completed`. The value of
+these entries are described in the "Pending", "Incremental", and "Completed"
+sections below.
+
 The response map may also contain an entry with key `extensions`. This entry, if
 set, must have a map as its value. This entry is reserved for implementers to
 extend the protocol however they see fit, and hence there are no additional
-restrictions on its contents.
+restrictions on its contents. When the response of the GraphQL operation is a
+response stream, the initial payload and any subsequent payloads may contain an
+entry with the key `extensions`, also reserved for implementers to extend the
+protocol however they see fit. Additionally, implementers may send subsequent
+payloads containing only `hasNext` and `extensions` entries.
 
 To ensure future changes to the protocol do not break existing services and
 clients, the top level response map must not contain any entries other than the
-three described above.
+entries described above.
 
 Note: When `errors` is present in the response, it may be helpful for it to
 appear first when serialized to make it more clear when errors are present in a
@@ -47,6 +69,10 @@ present in the result.
 
 If an error was raised during the execution that prevented a valid response, the
 `data` entry in the response should be `null`.
+
+When the response of the GraphQL operation contains incrementally delivered
+results, `data` may only be present in the initial payload. `data` must not be
+present in any subsequent payloads.
 
 ### Errors
 
@@ -107,14 +133,8 @@ syntax element.
 If an error can be associated to a particular field in the GraphQL result, it
 must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
-`null` result is intentional or caused by a runtime error.
-
-If present, this field must be a list of path segments starting at the root of
-the response and ending with the field associated with the error. Path segments
-that represent fields must be strings, and path segments that represent list
-indices must be 0-indexed integers. If the error happens in an aliased field,
-the path to the error must use the aliased name, since it represents a path in
-the response, not in the request.
+`null` result is intentional or caused by a runtime error. The value of this
+field is described in the [Path](#sec-Path) section.
 
 For example, if fetching one of the friends' names fails in the following
 operation:
@@ -243,6 +263,170 @@ discouraged.
   ]
 }
 ```
+
+### Path
+
+A `path` field allows for the association to a particular field in a GraphQL
+result. This field should be a list of path segments starting at the root of the
+response and ending with the field to be associated with. Path segments that
+represent fields should be strings, and path segments that represent list
+indices should be 0-indexed integers. If the path is associated to an aliased
+field, the path should use the aliased name, since it represents a path in the
+response, not in the request.
+
+When the `path` field is present on an "Error result", it indicates the response
+field which experienced the error.
+
+### Pending
+
+The `pending` entry in the response is a non-empty list of Pending Results. If
+the response of the GraphQL operation contains incrementally delivered results,
+this field may appear on both the initial and subsequent payloads. If present,
+the `pending` entry must contain at least one Pending Result.
+
+Each Pending Result corresponds to either a `@defer` or `@stream` directive
+located at a specific path in the response data. The Pending Result is used to
+communicate that the GraphQL service has chosen to incrementally deliver the
+data associated with this `@defer` or `@stream` directive and clients should
+expect the associated data in either the current payload, or one of the
+following payloads.
+
+**Pending Result Format**
+
+Every Pending Result must contain an entry with the key `id` with a string
+value. This `id` should be used by clients to correlate Pending Results with
+Completed Results. The `id` value must be unique for the entire response stream.
+There must not be any other Pending Result in any payload that contains the same
+`id`.
+
+Every Pending Result must contain an entry with the key `path`. When the Pending
+Result is associated with a `@stream` directive, it indicates the response list
+field that is not known to be complete. Clients should expect the GraphQL
+Service to incrementally deliver the remainder of indicated list field. When the
+Pending Result is associated with a `@defer` directive, it indicates that the
+response fields contained in the deferred fragment are not known to be complete.
+Clients should expect the the GraphQL Service to incrementally deliver the
+remainder of the fields contained in the deferred fragment.
+
+If a Pending Result is not returned for a `@defer` or `@stream` directive,
+clients must assume that the GraphQL service chose not to incrementally deliver
+this data, and the data can be found either in the `data` entry in the initial
+payload, or one of the Incremental Results in a prior payload.
+
+### Incremental
+
+The `incremental` entry in the response is a non-empty list of Incremental
+Results. If the response of the GraphQL operation contains incrementally
+delivered results, this field may appear on both the initial and subsequent
+values. If present, the `incremental` entry must contain at least one
+Incremental Result.
+
+The Incremental Result is used to deliver data that the GraphQL service has
+chosen to incrementally deliver. An Incremental Result may be ether an
+Incremental List Result or an Incremental Object Result.
+
+An Incremental List Result is used to deliver additional list items for a list
+field with a `@stream` directive.
+
+An Incremental Object Result is used to deliver additional response fields that
+were contained in one or more fragments with a `@defer` directive.
+
+**Incremental Result Format**
+
+Every Incremental Result must contain an entry with the key `id` with a string
+value. This `id` must match the `id` that was returned in a prior Pending
+Result.
+
+Additionally, Incremental List Results and Incremental Object Results have
+further requirements.
+
+**Incremental List Result Format**
+
+An Incremental List Result's `id` entry must match the `id` that was returned in
+a prior Pending Result. This Pending Result must be associated with a `@stream`
+directive.
+
+The Incremental List Result's `path` can be determined using the prior Pending
+Result with the same `id` as this Incremental Result. The Incremental List
+Result's `path` is the same as the Pending Result's `path`.
+
+Every Incremental List Result must contain an `items` entry. The `items` entry
+must contain a list of additional list items for the response field at the
+Incremental List Result's `path`. This output will be a list of the same type of
+the response field at this path.
+
+If any field errors were raised during the execution of the results in `items`
+and these errors bubbled to a path higher than the Incremental List Result's
+path, The Incremental List Result is considered failed and should not be
+included in the response stream. The errors that caused this failure will be
+included in a Completed Result.
+
+If any field errors were raised during the execution of the results in `items`
+and these errors did not bubble to a path higher than the Incremental List
+Result's path, the Incremental List Result must contain an entry with key
+`errors` containing these field errors. The value of this entry is described in
+the "Errors" section.
+
+**Incremental Object Result Format**
+
+An Incremental List Result's `id` entry must match the `id` that was returned in
+a prior Pending Result. This Pending Result must be associated with a `@defer`
+directive.
+
+The Incremental Object Result's `path` can be determined using the prior Pending
+Result with the same `id` as this Incremental Result. The Incremental Object
+Result may contain a `subPath` entry. If the `subPath` entry is present, The
+Incremental Object Record's path can be determined by concatenating the Pending
+Result's `path` with this `subPath`. If no `subPath` entry is present, the path
+is the same as the Pending Result's `path`.
+
+Every Incremental Object Result must contain an `data` entry. The `data` entry
+must contain a map of additional response fields. The `data` entry in an
+Incremental Object Result will be of the type of a particular field in the
+GraphQL result. The Incremental Object Result's `path` will contain the path
+segments of the field this data is associated with.
+
+An Incremental Object Result's data may contain response fields that were
+contained in more than one deferred fragments. In that case, the `id` of the
+Incremental Object Result must point to the Pending Result that results in the
+shortest `subPath`.
+
+If any field errors were raised during the execution of the results in `data`
+and these errors bubbled to a path higher than the Incremental Object Result's
+path, The Incremental Object Result is considered failed and should not be
+included in the response stream. The errors that caused this failure will be
+included in a Completed Result.
+
+If any field errors were raised during the execution of the results in `data`
+and these errors did not bubble to a path higher than the Incremental Object
+Result's path, the Incremental Object Result must contain an entry with key
+`errors` containing these field errors. The value of this entry is described in
+the "Errors" section.
+
+### Completed
+
+The `completed` entry in the response is a non-empty list of Completed Results.
+If the response of the GraphQL operation contains incrementally delivered
+results, this field may appear on both the initial and subsequent payloads. If
+present, the `completed` entry must contain at least one Completed Result.
+
+Each Completed Result corresponds to a prior Pending Result. The Completed
+Result is used to communicate that the GraphQL service has completed the
+incremental delivery of the data associated with the corresponding Pending
+Result. The associated data must have been completed in the current payload.
+
+**Completed Result Format**
+
+Every Completed Result must contain an entry with the key `id` with a string
+value. The `id` entry must match the `id` that was returned in a prior Pending
+Result.
+
+A Completed Result may contain an `errors` entry. When the `errors` entry is
+present, it informs clients that the delivery of the data associated with the
+corresponding Pending Result has failed, due to an error bubbling to a path
+higher than the Incremental Data Result's path. The `errors` entry must contain
+these field errors. The value of this entry is described in the "Errors"
+section.e
 
 ## Serialization Format
 


### PR DESCRIPTION
This is an alternative to my most recent PR #1052 with an eye to describing the algorithm in a bit less detail to decrease the size of the spec edits. We also introduce the idea of an observable stream to which events can be pushed using a callback.

This is an alternative as well to @benjie's most recent proposal at #1074.

The main differences as I see them within the given proposal are as follows.

This PR:

1. will kick off incremental entries shared between sibling defers and unique to sibling defers in parallel rather than waiting for the former to complete.
2. generates a path-independent field plan for each field within the operation; implementations can use this to memoize/deduplicate if using defer on list items; as well as persisting this across operations.
3. provides a single-line difference in implementation between early and delayed execution; the algorithm is otherwise the same.

This is also of course an alternative to  #742 -- the original PR without deduplication.