### PR TITLE
chore: add clarifying note for composite and expand term

### DIFF
--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -352,7 +352,7 @@ Fields\:
 
 **Input Object**
 
-Input objects are composite types defined as a list of named input values. They
+Input objects are types defined as a list of named input values. They
 are only used as inputs to arguments and variables and cannot be a field return
 type.
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -352,7 +352,7 @@ Fields\:
 
 **Input Object**
 
-Input objects are types defined as a list of named input values. They
+Input objects are composite types defined as a list of named input values. They
 are only used as inputs to arguments and variables and cannot be a field return
 type.
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -446,7 +446,8 @@ SameResponseShape(fieldA, fieldB):
 - If {typeA} or {typeB} is Scalar or Enum:
   - If {typeA} and {typeB} are the same type return {true}, otherwise return
     {false}.
-- Assert: {typeA} and {typeB} are both Object, Interface or Union types.
+- Assert: {typeA} is an object, union or interface type.
+- Assert: {typeB} is an object, union or interface type.
 - Let {mergedSet} be the result of adding the selection set of {fieldA} and the
   selection set of {fieldB}.
 - Let {fieldsForName} be the set of selections with a given response name in

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -910,7 +910,7 @@ fragment inlineNotExistingType on Dog {
 }
 ```
 
-#### Fragments on object, interface or union Types
+#### Fragments on Object, Interface or Union Types
 
 **Formal Specification**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -455,6 +455,9 @@ SameResponseShape(fieldA, fieldB):
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
 
+Note: composite is used to signal a type that is either an object-, interface-
+or union-type.
+
 **Explanatory Text**
 
 If multiple field selections with the same response names are encountered during
@@ -910,7 +913,7 @@ fragment inlineNotExistingType on Dog {
 }
 ```
 
-#### Fragments on Object, Interface or Union Types
+#### Fragments on Composite Types
 
 **Formal Specification**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -446,7 +446,7 @@ SameResponseShape(fieldA, fieldB):
 - If {typeA} or {typeB} is Scalar or Enum:
   - If {typeA} and {typeB} are the same type return {true}, otherwise return
     {false}.
-- Assert: {typeA} and {typeB} are both composite types.
+- Assert: {typeA} and {typeB} are both Object, Interface or Union types.
 - Let {mergedSet} be the result of adding the selection set of {fieldA} and the
   selection set of {fieldB}.
 - Let {fieldsForName} be the set of selections with a given response name in
@@ -455,8 +455,8 @@ SameResponseShape(fieldA, fieldB):
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
 
-Note: Composite is used to signal a type that is either an object-, interface-
-or union-type.
+Note: In prior vresions of the spec the term "composite" wass used to signal
+a type that is either an object-, interface- or union-type.
 
 **Explanatory Text**
 
@@ -913,7 +913,7 @@ fragment inlineNotExistingType on Dog {
 }
 ```
 
-#### Fragments on Composite Types
+#### Fragments on Object, Interface or Union Types
 
 **Formal Specification**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -456,8 +456,8 @@ SameResponseShape(fieldA, fieldB):
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
 
-Note: In prior versions of the spec the term "composite" was used to signal
-a type that is either an Object, Interface or Union type.
+Note: In prior versions of the spec the term "composite" was used to signal a
+type that is either an Object, Interface or Union type.
 
 **Explanatory Text**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -455,8 +455,8 @@ SameResponseShape(fieldA, fieldB):
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
 
-Note: In prior versions of the spec the term "composite" wass used to signal
-a type that is either an object-, interface- or union-type.
+Note: In prior versions of the spec the term "composite" was used to signal
+a type that is either an Object, Interface or Union type.
 
 **Explanatory Text**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -910,7 +910,7 @@ fragment inlineNotExistingType on Dog {
 }
 ```
 
-#### Fragments on Composite Types
+#### Fragments on object, interface or union Types
 
 **Formal Specification**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -455,7 +455,7 @@ SameResponseShape(fieldA, fieldB):
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
 
-Note: composite is used to signal a type that is either an object-, interface-
+Note: Composite is used to signal a type that is either an object-, interface-
 or union-type.
 
 **Explanatory Text**

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -455,7 +455,7 @@ SameResponseShape(fieldA, fieldB):
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
 
-Note: In prior vresions of the spec the term "composite" wass used to signal
+Note: In prior versions of the spec the term "composite" wass used to signal
 a type that is either an object-, interface- or union-type.
 
 **Explanatory Text**


### PR DESCRIPTION
Resolves https://github.com/graphql/graphql-spec/issues/1076

This PR adds a clarifying note for the term composite in prior versions of the spec and expands the term into `Object, Interface or Union type` wherever it was found
