### PR TITLE
Proposed spec changes for string literal aliases

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -460,7 +460,9 @@ These two operations are semantically identical:
 
 ## Field Alias
 
-Alias : Name :
+Alias
+- Name : 
+- StringValue : 
 
 By default a field's response key in the response object will use that field's
 name. However, you can define a different response key by specifying an alias.

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -461,6 +461,7 @@ These two operations are semantically identical:
 ## Field Alias
 
 Alias
+
 - Name : 
 - StringValue : 
 


### PR DESCRIPTION
At Meta, our GraphQL clients for both web and mobile care a lot about local data consistency. Local data consistency is when the client is able to reconcile data from multiple GraphQL responses in a local client-side cache which can be subscribed to. When data changes, we issue updates to these subscribers — which allows us to keep various screens "in-sync" and show the same view of the data.

The canonical example of this on Facebook is if you navigate to the Groups page from a Feed post and join the group, then when you navigate back to Feed we should update the "Join Group" button in the post to "Joined".

Local data consistency is supported today by Relay for JS clients (widely adopted within industry) and by Meta's internal mobile GraphQL client for Android/iOS clients.

To support consistency, we need to be able to remap aliases/field names into their "canonical names". The canonical name is what we use to keep two fields consistent, as it represents the true definition of a field.

Given a field selection:
```
alias: field(arg: "foo")
```
the canonical name would be:
```
field(arg:"foo")
```
Internally, we've explored various ways of doing this. We currently need to embed a lot of information about the schema and query in our clients; for example Relay creates a "normalization AST" with this information, and our internal mobile client requires all the information to be pre-compiled into the app binary. This leads to additional costs, e.g. binary size bloat or wire size costs.

We've found that we can more efficiently deliver the canonical name information by embedding it into our response instead, which removes the need for pre-compiled metadata. We run a transform on our queries to add aliases for each field, and use the canonical name as the alias. However since the canonical name may contain non-supported characters (e.g. (, ), $), we are proposing a spec change to allow StringValue tokens as the alias.

This would allow syntax such as:
```
"field(arg:\"foo\")": field(arg: "foo")
```

We've attempted alternative ways of implementing this, such as doing this transform during server-side execution (a spec violation, and high server overhead!) or delivering encoded aliases to abide by the NameValue specification (client parsing overhead for decoding!).

Potential side effects / outcomes of this change:
- Selection set conflict validation should still work out of the box, even if one selection is a string literal and the other is a normal NameValue.
- Here we parse the StringValue into a NameNode (same as when parsing a NameValue), which doesn't have any requirements on the name itself as far as I can tell. 
- We allow string literal aliases here but not number literals, which abides by the JSON specification. According to the JSON spec, map/object keys must be strings.
