### PR TITLE
[RFC] ID must always serialize as String would

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -613,7 +613,7 @@ other input values must raise a _request error_ indicating an incorrect type.
 The ID scalar type represents a unique identifier, often used to refetch an
 object or as the key for a cache. The ID type is serialized in the same way as a
 {String}; however, it is not intended to be human-readable. While it is often
-numeric, it should always serialize as a {String}.
+numeric, it must always serialize as a {String}.
 
 **Result Coercion**
 


### PR DESCRIPTION
I believe the intention was for this `should` to have been an RFC2119 `must` and the `should` is just an English language issue.

I've marked this RFC0, but really I think it's editorial because we already state in multiple places that `ID` is serialized as `String`:

> The ID type is serialized in the same way as a String; however, it is not intended to be human-readable.

Statement of fact: ID _is_ serialized as a `String`

> While it is often numeric, it should always serialize as a String.

The `should` here doesn't override the fact above: not only should it serialize as a string, but it _does_ serialize as a string.

> GraphQL is agnostic to ID format, and serializes to string to ensure consistency across many formats ID could represent, from small auto-increment numbers, to large 128-bit random numbers, to base64 encoded values, or string values of a format like [GUID](https://en.wikipedia.org/wiki/Globally_unique_identifier).

Again: statement of fact: `ID` serializes to string.

cc @graphql/tsc 