### PR TITLE
Consistently spell 'implementers'

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -21,3 +21,6 @@ words:
   - tatooine
   - zuck
   - zuckerberg
+  # Alternative spellings
+  - !implementor
+  - !implementors

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -362,7 +362,7 @@ fragment aliasedLyingFieldTargetNotDefined on Dog {
 ```
 
 For interfaces, direct field selection can only be done on fields. Fields of
-concrete implementors are not relevant to the validity of the given
+concrete implementers are not relevant to the validity of the given
 interface-typed selection set.
 
 For example, the following is valid:
@@ -376,7 +376,7 @@ fragment interfaceFieldSelection on Pet {
 and the following is invalid:
 
 ```graphql counter-example
-fragment definedOnImplementorsButNotInterface on Pet {
+fragment definedOnImplementersButNotInterface on Pet {
   nickname
 }
 ```

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -23,7 +23,7 @@ request failed before execution, due to a syntax error, missing information, or
 validation error, this entry must not be present.
 
 The response map may also contain an entry with key `extensions`. This entry, if
-set, must have a map as its value. This entry is reserved for implementors to
+set, must have a map as its value. This entry is reserved for implementers to
 extend the protocol however they see fit, and hence there are no additional
 restrictions on its contents.
 
@@ -203,7 +203,7 @@ be the same:
 
 GraphQL services may provide an additional entry to errors with key
 `extensions`. This entry, if set, must have a map as its value. This entry is
-reserved for implementors to add additional information to errors however they
+reserved for implementers to add additional information to errors however they
 see fit, and there are no additional restrictions on its contents.
 
 ```json example


### PR DESCRIPTION
We spell it both "implementors" and "implementers" which makes searching for the term annoying. Apparently implementers is the modern spelling with a 4:1 ratio over implementors ([Oxford Dictionary](https://trends.google.com/trends/explore?q=implementor,implementer&hl=en), [Google Trends](https://trends.google.com/trends/explore?q=implementor,implementer&hl=en)), so I've asked cspell to forbid "implementors" and fixed the existing spellings.
