### PR TITLE
Add missing .

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1248,7 +1248,7 @@ input type.
 Type : Name
 
 - Let {name} be the string value of {Name}.
-- Let {type} be the type defined in the Schema named {name}
+- Let {type} be the type defined in the Schema named {name}.
 - {type} must not be {null}.
 - Return {type}.
 


### PR DESCRIPTION
As [spotted](https://github.com/graphql/graphql-spec/pull/1069#discussion_r1516719435) by the eagle-eyed @BoD in #1069; since the `Type : Name` grammar construct is not explicitly an algorithm, the missing `.` was not detected by the script.