### PR TITLE
3.13 Directive validation edits

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2040,7 +2040,7 @@ repeatable directives.
    references itself directly.
 3. A Directive definition must not contain the use of a Directive which
    references itself indirectly by referencing a Type or Directive which
-   transitively includes a reference to this directive.
+   transitively includes a reference to this Directive.
 4. The Directive must not have a name which begins with the characters {"\_\_"}
    (two underscores).
 5. For each argument of the Directive:


### PR DESCRIPTION
The Validation section for Directive types is a little out of step with the validation sections for the other types. In particular, while the grammar definition of Directive requires one or more directive locations, this requirement isn't mentioned in the validation section.

Compare this to the validation sections for other types with "one or more" requirements:
- `1. An Object type must define one or more fields.`
- `1. A Union type must include one or more member types.`
- `1. An Enum type must define one or more unique enum values.`
- `1. An Input Object type must define one or more input fields.`
- `1. An Interface type must define one or more fields.`

This PR updates Directive validation to be more consistent with the validation sections of other types:
1. Add a "one or more" requirement as the first validation rule
1. Use "Directive" instead of "directive"
1. Rename the section from "Validation" to "Type Validation"

While this PR just clarifies the existing spec, I suspect it might be common for implementations to not check for non-empty directive locations. 
I've [updated graphql-java](https://github.com/graphql-java/graphql-java/pull/3552) and can do the same for graphql-js if I get a tentative OK on this PR.