### PR TITLE
Reformat the parts of an execution request

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -4,18 +4,21 @@ A GraphQL service generates a response from a request via execution.
 
 :: A _request_ for execution consists of a few pieces of information:
 
-- The schema to use, typically solely provided by the GraphQL service.
-- A {Document} which must contain GraphQL {OperationDefinition} and may contain
-  {FragmentDefinition}.
-- Optionally: The name of the Operation in the Document to execute.
-- Optionally: Values for any Variables defined by the Operation.
-- An initial value corresponding to the root type being executed. Conceptually,
-  an initial value represents the "universe" of data available via a GraphQL
-  Service. It is common for a GraphQL Service to always use the same initial
-  value for every request.
+- {schema}: The schema to use, typically solely provided by the GraphQL service.
+- {document}: A {Document} which must contain GraphQL {OperationDefinition} and
+  may contain {FragmentDefinition}.
+- {operationName} (optional): The name of the Operation in the Document to
+  execute.
+- {variableValues} (optional): Values for any Variables defined by the
+  Operation.
+- {initialValue} (optional): An initial value corresponding to the root type
+  being executed. Conceptually, an initial value represents the "universe" of
+  data available via a GraphQL Service. It is common for a GraphQL Service to
+  always use the same initial value for every request.
 
-Given this information, the result of {ExecuteRequest()} produces the response,
-to be formatted according to the Response section below.
+Given this information, the result of {ExecuteRequest(schema, document,
+operationName, variableValues, initialValue)} produces the response, to be
+formatted according to the Response section below.
 
 Note: GraphQL requests do not require any specific serialization format or
 transport mechanism. Message serialization and transport mechanisms should be


### PR DESCRIPTION
This PR adds names for each of the "pieces of information" that make up an execution request, and then shows how these values are passed into the `ExecuteRequest()` algorithm.

This is extracted from #976 as discussed at [last night's working group](https://github.com/graphql/graphql-wg/blob/main/notes/2024/2024-04.md#request-extensions-10m-benjie). @leebyron 
 mentioned that this change adds clarity and is a positive editorial change; splitting this change out will help keep the "extensions" PR focused as it undergoes a few iterations.

cc @michaelstaib

