### PR TITLE
Fixed unclear wording in the validation section

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -32,7 +32,8 @@ free of any validation errors, and have not changed since.
 
 **Examples**
 
-In this section, we will assume the following type system to demonstrate examples:
+In this section, we will assume the following type system to demonstrate
+examples:
 
 ```graphql example
 type Query {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -32,8 +32,7 @@ free of any validation errors, and have not changed since.
 
 **Examples**
 
-For this section of this schema, we will assume the following type system in
-order to demonstrate examples:
+In this section, we will assume the following type system to demonstrate examples:
 
 ```graphql example
 type Query {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -32,8 +32,7 @@ free of any validation errors, and have not changed since.
 
 **Examples**
 
-In this section, we will assume the following type system to demonstrate
-examples:
+The examples in this section will use the following types:
 
 ```graphql example
 type Query {


### PR DESCRIPTION
The start of the sentence (`For this section of this schema,`) does currently not really make sense.