### PR TITLE
Clarify 'Values of Correct Type' rule relates to literals

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1319,8 +1319,9 @@ which may be a variable usage. The
 [All Variable Usages Are Allowed](#sec-All-Variable-Usages-Are-Allowed)
 validation rule ensures that each {variableUsage} is of a type allowed in its
 position. The [Coercing Variable Values](#sec-Coercing-Variable-Values)
-algorithm ensures runtime values for variables coerce correctly. Therefore we
-can assume the runtime value of each {variableUsage} is valid for usage in its
+algorithm ensures runtime values for variables coerce correctly. Therefore, for
+the purposes of the coercibility assertion in this validation rule, we can
+assume the runtime value of each {variableUsage} is valid for usage in its
 position.
 
 The type expected in a position includes the type defined by the argument a

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1306,22 +1306,22 @@ fragment resourceFragment on Resource {
 - For each literal Input Value {value} in the document:
   - Let {type} be the type expected in the position {value} is found.
   - {value} must be coercible to {type} (with the assumption that any
-    {variableUsage} nested within {value} will represent a runtime value
-    suitable for usage in its position).
+    {variableUsage} nested within {value} will represent a runtime value valid
+    for usage in its position).
 
 **Explanatory Text**
 
 Literal values must be compatible with the type expected in the position they
 are found as per the coercion rules defined in the Type System chapter.
 
-A {ListValue} or {ObjectValue} may nest additional Input Values, some of which
-may be a {variableUsage}. The
+Note: A {ListValue} or {ObjectValue} may contain nested Input Values, some of
+which may be a variable usage. The
 [All Variable Usages Are Allowed](#sec-All-Variable-Usages-Are-Allowed)
-validation rule asserts that each {variableUsage} is of a type allowed in that
-position, and the [Coercing Variable Values](#sec-Coercing-Variable-Values)
-algorithm will ensure runtime values of these variables coerce correctly, thus
-we can assume the runtime value of each {variableUsage} will be suitable for
-usage in its position.
+validation rule ensures that each {variableUsage} is of a type allowed in its
+position. The [Coercing Variable Values](#sec-Coercing-Variable-Values)
+algorithm ensures runtime values for variables coerce correctly. Therefore we
+can assume the runtime value of each {variableUsage} is valid for usage in its
+position.
 
 The type expected in a position includes the type defined by the argument a
 value is provided for, the type defined by an input object field a value is

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1306,20 +1306,22 @@ fragment resourceFragment on Resource {
 - For each literal Input Value {value} in the document:
   - Let {type} be the type expected in the position {value} is found.
   - {value} must be coercible to {type} (with the assumption that any
-    {variableUsage} nested within {value} will represent a runtime value of the
-    referenced variable's type).
+    {variableUsage} nested within {value} will represent a runtime value
+    suitable for usage in its position).
 
 **Explanatory Text**
 
 Literal values must be compatible with the type expected in the position they
-are found as per the coercion rules defined in the Type System chapter. Variable
-values are handled by the rule
-[All Variable Usages Are Allowed](#sec-All-Variable-Usages-Are-Allowed).
-{ListValue} and {ObjectValue} may nest additional Input Values, some of which
-may be a {variableUsage}. Each nested {variableUsage} will be coerced during
-execution - see [Coercing Variable Values](#sec-Coercing-Variable-Values) - thus
-we assume their runtime value will coerce to the type of the referenced
-variable.
+are found as per the coercion rules defined in the Type System chapter.
+
+A {ListValue} or {ObjectValue} may nest additional Input Values, some of which
+may be a {variableUsage}. The
+[All Variable Usages Are Allowed](#sec-All-Variable-Usages-Are-Allowed)
+validation rule asserts that each {variableUsage} is of a type allowed in that
+position, and the [Coercing Variable Values](#sec-Coercing-Variable-Values)
+algorithm will ensure runtime values of these variables coerce correctly, thus
+we can assume the runtime value of each {variableUsage} will be suitable for
+usage in its position.
 
 The type expected in a position includes the type defined by the argument a
 value is provided for, the type defined by an input object field a value is

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1303,9 +1303,11 @@ fragment resourceFragment on Resource {
 
 **Formal Specification**
 
-- For each literal input Value {value} in the document:
+- For each literal Input Value {value} in the document:
   - Let {type} be the type expected in the position {value} is found.
-  - {value} must be coercible to {type}.
+  - {value} must be coercible to {type} (with the assumption that any
+    {variableUsage} nested within {value} will represent a runtime value of the
+    referenced variable's type).
 
 **Explanatory Text**
 
@@ -1313,6 +1315,11 @@ Literal values must be compatible with the type expected in the position they
 are found as per the coercion rules defined in the Type System chapter. Variable
 values are handled by the rule
 [All Variable Usages Are Allowed](#sec-All-Variable-Usages-Are-Allowed).
+{ListValue} and {ObjectValue} may nest additional Input Values, some of which
+may be a {variableUsage}. Each nested {variableUsage} will be coerced during
+execution - see [Coercing Variable Values](#sec-Coercing-Variable-Values) - thus
+we assume their runtime value will coerce to the type of the referenced
+variable.
 
 The type expected in a position includes the type defined by the argument a
 value is provided for, the type defined by an input object field a value is

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1320,9 +1320,8 @@ which may be a variable usage. The
 validation rule ensures that each {variableUsage} is of a type allowed in its
 position. The [Coercing Variable Values](#sec-Coercing-Variable-Values)
 algorithm ensures runtime values for variables coerce correctly. Therefore, for
-the purposes of the coercibility assertion in this validation rule, we can
-assume the runtime value of each {variableUsage} is valid for usage in its
-position.
+the purposes of the "coercible" assertion in this validation rule, we can assume
+the runtime value of each {variableUsage} is valid for usage in its position.
 
 The type expected in a position includes the type defined by the argument a
 value is provided for, the type defined by an input object field a value is

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1303,14 +1303,16 @@ fragment resourceFragment on Resource {
 
 **Formal Specification**
 
-- For each input Value {value} in the document:
+- For each literal input Value {value} in the document:
   - Let {type} be the type expected in the position {value} is found.
   - {value} must be coercible to {type}.
 
 **Explanatory Text**
 
 Literal values must be compatible with the type expected in the position they
-are found as per the coercion rules defined in the Type System chapter.
+are found as per the coercion rules defined in the Type System chapter. Variable
+values are handled by the rule
+[All Variable Usages Are Allowed](#sec-All-Variable-Usages-Are-Allowed).
 
 The type expected in a position includes the type defined by the argument a
 value is provided for, the type defined by an input object field a value is


### PR DESCRIPTION
An [Input Value](https://spec.graphql.org/draft/#sec-Input-Values) is defined as being either a variable (if not const) or one of the literal types (IntValue, FloatValue, StringValue, BooleanValue, NullValue, EnumValue, ListValue or ObjectValue).

The rule ["Values of Correct Type"](https://spec.graphql.org/draft/#sec-Values-of-Correct-Type) states:

> - For each input Value `value` in the document:
>   - Let `type` be the type expected in the position `value` is found.
>   - `value` must be coercible to `type`.

However, an input value can be a variable, and variable coercion is handled at runtime (by [CoerceVariableValues](https://spec.graphql.org/draft/#sec-Coercing-Variable-Values)). Further, we already have a rule that validates that variables are only used in the positions in which they are allowed: [All Variable Usages Are Allowed](https://spec.graphql.org/draft/#sec-All-Variable-Usages-Are-Allowed).

It seems to me that "Values of Correct Type" only meant to handle _literal_ input values, so I've added the word "literal" for clarity. I've also expanded the explanation to reference where to look for variable input value validation. Since input coercion for Input Object references "runtime value", and validation doesn't have access to runtime values, I've made explicit the assumption that values represented by variables will be of the requisite type.

This is an alternative solution to, and

- fixes https://github.com/graphql/graphql-spec/pull/1113

Thank you to @yaacovCR for pointing out this deficiency :raised_hands: 

