### PR TITLE
Change 'original' to 'previous' to clarify multiple extensions

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -42,7 +42,7 @@ TypeSystemExtension :
 - TypeExtension
 
 Type system extensions are used to represent a GraphQL type system which has
-been extended from some original type system. For example, this might be used by
+been extended from some previous type system. For example, this might be used by
 a local service to represent data a GraphQL client only accesses locally, or by
 a GraphQL service which is itself an extension of another GraphQL service.
 
@@ -266,8 +266,8 @@ SchemaExtension :
 - extend schema Directives[Const]? { RootOperationTypeDefinition+ }
 - extend schema Directives[Const] [lookahead != `{`]
 
-Schema extensions are used to represent a schema which has been extended from an
-original schema. For example, this might be used by a GraphQL service which adds
+Schema extensions are used to represent a schema which has been extended from a
+previous schema. For example, this might be used by a GraphQL service which adds
 additional operation types, or additional directives to an existing schema.
 
 Note: Schema extensions without additional operation type definitions must not
@@ -279,7 +279,7 @@ The same limitation applies to the type definitions and extensions below.
 Schema extensions have the potential to be invalid if incorrectly defined.
 
 1. The Schema must already be defined.
-2. Any non-repeatable directives provided must not already apply to the original
+2. Any non-repeatable directives provided must not already apply to the previous
    Schema.
 
 ## Types
@@ -377,7 +377,7 @@ TypeExtension :
 - InputObjectTypeExtension
 
 Type extensions are used to represent a GraphQL type which has been extended
-from some original type. For example, this might be used by a local service to
+from some previous type. For example, this might be used by a local service to
 represent additional fields a GraphQL client only accesses locally.
 
 ## Scalars
@@ -640,7 +640,7 @@ ScalarTypeExtension :
 - extend scalar Name Directives[Const]
 
 Scalar type extensions are used to represent a scalar type which has been
-extended from some original scalar type. For example, this might be used by a
+extended from some previous scalar type. For example, this might be used by a
 GraphQL tool or service which adds directives to an existing scalar.
 
 **Type Validation**
@@ -648,7 +648,7 @@ GraphQL tool or service which adds directives to an existing scalar.
 Scalar type extensions have the potential to be invalid if incorrectly defined.
 
 1. The named type must already be defined and must be a Scalar type.
-2. Any non-repeatable directives provided must not already apply to the original
+2. Any non-repeatable directives provided must not already apply to the previous
    Scalar type.
 
 ## Objects
@@ -1048,7 +1048,7 @@ ObjectTypeExtension :
 - extend type Name ImplementsInterfaces [lookahead != `{`]
 
 Object type extensions are used to represent a type which has been extended from
-some original type. For example, this might be used to represent local data, or
+some previous type. For example, this might be used to represent local data, or
 by a GraphQL service which is itself an extension of another GraphQL service.
 
 In this example, a local data field is added to a `Story` type:
@@ -1076,10 +1076,10 @@ Object type extensions have the potential to be invalid if incorrectly defined.
 2. The fields of an Object type extension must have unique names; no two fields
    may share the same name.
 3. Any fields of an Object type extension must not be already defined on the
-   original Object type.
-4. Any non-repeatable directives provided must not already apply to the original
+   previous Object type.
+4. Any non-repeatable directives provided must not already apply to the previous
    Object type.
-5. Any interfaces provided must not be already implemented by the original
+5. Any interfaces provided must not be already implemented by the previous
    Object type.
 6. The resulting extended object type must be a super-set of all interfaces it
    implements.
@@ -1288,7 +1288,7 @@ InterfaceTypeExtension :
 - extend interface Name ImplementsInterfaces [lookahead != `{`]
 
 Interface type extensions are used to represent an interface which has been
-extended from some original interface. For example, this might be used to
+extended from some previous interface. For example, this might be used to
 represent common local data on many types, or by a GraphQL service which is
 itself an extension of another GraphQL service.
 
@@ -1328,11 +1328,11 @@ defined.
 2. The fields of an Interface type extension must have unique names; no two
    fields may share the same name.
 3. Any fields of an Interface type extension must not be already defined on the
-   original Interface type.
-4. Any Object or Interface type which implemented the original Interface type
+   previous Interface type.
+4. Any Object or Interface type which implemented the previous Interface type
    must also be a super-set of the fields of the Interface type extension (which
    may be due to Object type extension).
-5. Any non-repeatable directives provided must not already apply to the original
+5. Any non-repeatable directives provided must not already apply to the previous
    Interface type.
 6. The resulting extended Interface type must be a super-set of all Interfaces
    it implements.
@@ -1443,7 +1443,7 @@ UnionTypeExtension :
 - extend union Name Directives[Const]
 
 Union type extensions are used to represent a union type which has been extended
-from some original union type. For example, this might be used to represent
+from some previous union type. For example, this might be used to represent
 additional local data, or by a GraphQL service which is itself an extension of
 another GraphQL service.
 
@@ -1457,8 +1457,8 @@ Union type extensions have the potential to be invalid if incorrectly defined.
    Similarly, wrapping types must not be member types of a Union.
 3. All member types of a Union type extension must be unique.
 4. All member types of a Union type extension must not already be a member of
-   the original Union type.
-5. Any non-repeatable directives provided must not already apply to the original
+   the previous Union type.
+5. Any non-repeatable directives provided must not already apply to the previous
    Union type.
 
 ## Enums
@@ -1520,7 +1520,7 @@ EnumTypeExtension :
 - extend enum Name Directives[Const] [lookahead != `{`]
 
 Enum type extensions are used to represent an enum type which has been extended
-from some original enum type. For example, this might be used to represent
+from some previous enum type. For example, this might be used to represent
 additional local data, or by a GraphQL service which is itself an extension of
 another GraphQL service.
 
@@ -1531,8 +1531,8 @@ Enum type extensions have the potential to be invalid if incorrectly defined.
 1. The named type must already be defined and must be an Enum type.
 2. All values of an Enum type extension must be unique.
 3. All values of an Enum type extension must not already be a value of the
-   original Enum.
-4. Any non-repeatable directives provided must not already apply to the original
+   previous Enum.
+4. Any non-repeatable directives provided must not already apply to the previous
    Enum type.
 
 ## Input Objects
@@ -1712,7 +1712,7 @@ InputObjectTypeExtension :
 - extend input Name Directives[Const] [lookahead != `{`]
 
 Input object type extensions are used to represent an input object type which
-has been extended from some original input object type. For example, this might
+has been extended from some previous input object type. For example, this might
 be used by a GraphQL service which is itself an extension of another GraphQL
 service.
 
@@ -1724,8 +1724,8 @@ defined.
 1. The named type must already be defined and must be a Input Object type.
 2. All fields of an Input Object type extension must have unique names.
 3. All fields of an Input Object type extension must not already be a field of
-   the original Input Object.
-4. Any non-repeatable directives provided must not already apply to the original
+   the previous Input Object.
+4. Any non-repeatable directives provided must not already apply to the previous
    Input Object type.
 
 ## List


### PR DESCRIPTION
@benhead described this well in https://github.com/graphql/graphql-spec/discussions/1116

Essentially the issue boils down to:

```
1  union MyUnion = Foo
2  extend union MyUnion = Bar | Baz
3  extend union MyUnion = Bar | Qux
```

- On line 1 we define a union.
- On line 2 we extend the "original" union (defined on line 1).
  - The rule "All member types of a Union type extension must not already be a member of the original Union type." passes, since neither `Bar` nor `Baz` exist in the original union (`Foo`)
- On line 3 we extend [the "original" union](https://spec.graphql.org/draft/#sel-GAHdhBFABABvDt4V). AMBIGUITY: is this "original" the true original, defined on line 1, or is it the previous version of the union which is the combination of line 1 and line 2?
  - If we go with the "true original" interpretation, this type extension passes the rule since neither `Bar` nor `Qux` are referenced in the union on line 1.
  - If we go with the "previous" interpretation, this type extensions fails the rule (as we would expect?) because `Bar` is already included in the composite union `Foo | Bar | Baz`.

I believe we actually mean the previous (i.e. combined) version. This is certainly what the reference implementation seems to do:

```ts
import { buildSchema, printSchema, validateSchema } from 'graphql';

const schema = buildSchema(/* GraphQL */ `
  union MyUnion = Foo
  extend union MyUnion = Bar | Baz
  extend union MyUnion = Bar | Qux

  type Query { u: MyUnion }
  type Foo { foo: Int }
  type Bar { bar: Int }
  type Baz { baz: Int }
  type Qux { qux: Int }
`);

const errors = validateSchema(schema);
if (errors.length > 0) {
  console.dir(errors);
  process.exit(1);
}

console.dir(printSchema(schema));
```

yields:

```
GraphQLError: Union type MyUnion can only include type Bar once.
```

> _Aside: I actually think the original intention was to extend a type once in a derived schema as implied by [the Type System Extensions opening paragraph](https://spec.graphql.org/draft/#sel-FAHPJABAB3J_2T); however that ship has long sailed and multiple extensions are common - in fact extending types defined in the same schema (as shown in the document below) is common practice._

I attempted to add a non-normative note to clarify that "original here means the previous version, which may itself be an extended type..." or something but couldn't get happy with the wording. Then I realised that simply changing `original` to `previous` would convey the intent well, and by sheer coincidence they happen to have the same number of characters!

There is one caveat to this solution, and that is that original type definitions are "hoisted", so though the order of type extensions in the document is significant, the original type (_actual_ original!) can occur anywhere, so the use of "previous" is arguably dubious in this case (though I'd argue that named type definitions always precede type extensions in order of processing, so this is still fine):

```graphql
extend union MyUnion = Bar | Baz
extend union MyUnion = Qux

type Query { u: MyUnion }
type Foo { foo: Int }
type Bar { bar: Int }
type Baz { baz: Int }
type Qux { qux: Int }

union MyUnion = Foo
```

_Also, I can no longer read the word `union` without seeing it as `onion`, so that's a fun [malapropism](https://en.wikipedia.org/wiki/Malapropism) that's going to haunt me now_ :roll_eyes: 