### PR TITLE
GraphQL Subscriptions should handle errors in the source stream

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -297,7 +297,12 @@ MapSourceToResponseEvent(sourceStream, subscription, schema, variableValues):
     - Let {response} be the result of running
       {ExecuteSubscriptionEvent(subscription, schema, variableValues, event)}.
     - Yield an event containing {response}.
-  - When {sourceStream} completes: complete {responseStream}.
+  - When {sourceStream} completes:
+    - If {sourceStream} completed with an {error}:
+      - Let {errors} be a list containing {error}.
+      - Let {response} be an unordered map containing {errors}.
+      - Yield an event containing {response}.
+    - Complete {responseStream}.
 
 ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 


### PR DESCRIPTION
Currently if `sourceStream` generates an error, then `responseStream` repeats the error. This is the behavior implemented in graphql-js and [is problematic](https://github.com/graphql/graphql-js/issues/4001).

GraphQL captures execution errors and wraps them in an `{ errors: [...] }` payload for query and mutation operations; it should do the same for stream errors in a subscription operation.

This PR makes this behavior explicit.

