### PR TITLE
When `sourceStream` errors, raise an error payload instead

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -306,12 +306,18 @@ MapSourceToResponseEvent(sourceStream, subscription, schema, variableValues):
     sourceValue)}.
   - If internal {error} was raised:
     - Cancel {sourceStream}.
-    - Perform {EmitErrorAndComplete(responseStream, error)}.
+    - Let {errors} be a list containing {error}.
+    - Let {response} be an unordered map containing {errors}.
+    - Emit {response} on {responseStream}.
+    - Complete {responseStream} normally.
   - Otherwise emit {response} on {responseStream}.
 - When {sourceStream} completes normally:
   - Complete {responseStream} normally.
 - When {sourceStream} completes with {error}:
-  - Perform {EmitErrorAndComplete(responseStream, error)}.
+  - Let {errors} be a list containing {error}.
+  - Let {response} be an unordered map containing {errors}.
+  - Emit {response} on {responseStream}.
+  - Complete {responseStream} normally.
 - When {responseStream} is cancelled:
   - Cancel {sourceStream}.
   - Complete {responseStream} normally.
@@ -336,13 +342,6 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 
 Note: The {ExecuteSubscriptionEvent()} algorithm is intentionally similar to
 {ExecuteQuery()} since this is how each event result is produced.
-
-EmitErrorAndComplete(responseStream, error):
-
-- Let {errors} be a list containing {error}.
-- Let {response} be an unordered map containing {errors}.
-- Emit {response} on {responseStream}.
-- Complete {responseStream} normally.
 
 #### Unsubscribe
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -306,10 +306,7 @@ MapSourceToResponseEvent(sourceStream, subscription, schema, variableValues):
     sourceValue)}.
   - If internal {error} was raised:
     - Cancel {sourceStream}.
-    - Let {errors} be a list containing {error}.
-    - Let {response} be an unordered map containing {errors}.
-    - Emit {response} on {responseStream}.
-    - Complete {responseStream} normally.
+    - Complete {responseStream} with {error}.
   - Otherwise emit {response} on {responseStream}.
 - When {sourceStream} completes normally:
   - Complete {responseStream} normally.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -306,12 +306,12 @@ MapSourceToResponseEvent(sourceStream, subscription, schema, variableValues):
     sourceValue)}.
   - If internal {error} was raised:
     - Cancel {sourceStream}.
-    - Complete {responseStream} with {error}.
+    - Perform {EmitErrorAndComplete(responseStream, error)}.
   - Otherwise emit {response} on {responseStream}.
 - When {sourceStream} completes normally:
   - Complete {responseStream} normally.
 - When {sourceStream} completes with {error}:
-  - Complete {responseStream} with {error}.
+  - Perform {EmitErrorAndComplete(responseStream, error)}.
 - When {responseStream} is cancelled:
   - Cancel {sourceStream}.
   - Complete {responseStream} normally.
@@ -336,6 +336,13 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 
 Note: The {ExecuteSubscriptionEvent()} algorithm is intentionally similar to
 {ExecuteQuery()} since this is how each event result is produced.
+
+EmitErrorAndComplete(responseStream, error):
+
+- Let {errors} be a list containing {error}.
+- Let {response} be an unordered map containing {errors}.
+- Emit {response} on {responseStream}.
+- Complete {responseStream} normally.
 
 #### Unsubscribe
 


### PR DESCRIPTION
See https://github.com/graphql/graphql-spec/pull/1099/files#r1799509253