### PR TITLE
Editorial: move "Path" to it's own section

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -108,7 +108,7 @@ If an error can be associated to a particular field in the GraphQL result, it
 must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
 `null` result is intentional or caused by a runtime error. The value of this
-field is described in the [Path](#sec-Path) section.
+entry is described in the [Path](#sec-Path) section.
 
 For example, if fetching one of the friends' names fails in the following
 operation:
@@ -240,16 +240,16 @@ discouraged.
 
 ### Path
 
-:: A _path field_ allows for the association to a particular field in a GraphQL
-result. This field must be a list of path segments starting at the root of the
-response and ending with the field to be associated with. Path segments that
-represent fields must be strings, and path segments that represent list indices
-must be 0-indexed integers. If the path is associated to an aliased field, the
-path must use the aliased name, since it represents a path in the response, not
-in the request.
+:: A _path entry_ allows for the association with a particular field reached
+during GraphQL execution. The value for this entry must be a list of path
+segments starting at the root of the response and ending with the field to be
+associated with. Path segments that represent fields must be strings, and path
+segments that represent list indices must be 0-indexed integers. If a path
+segment is associated with an aliased field it must use the aliased name, since
+it represents a path in the response, not in the request.
 
-When the _path field_ is present on an "Error result", it indicates the response
-field which experienced the error.
+When the _path entry_ is present on an "Error result", it identifies the
+response field which experienced the error.
 
 ## Serialization Format
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -108,7 +108,7 @@ If an error can be associated to a particular field in the GraphQL result, it
 must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
 `null` result is intentional or caused by a runtime error. The value of this
-entry is described in the [Path](#sec-Path) section.
+_path entry_ is described in the [Path](#sec-Path) section.
 
 For example, if fetching one of the friends' names fails in the following
 operation:
@@ -240,15 +240,17 @@ discouraged.
 
 ### Path
 
-:: A _path entry_ allows for the association with a particular field reached
-during GraphQL execution. The value for this entry must be a list of path
-segments starting at the root of the response and ending with the field to be
-associated with. Path segments that represent fields must be strings, and path
-segments that represent list indices must be 0-indexed integers. If a path
-segment is associated with an aliased field it must use the aliased name, since
-it represents a path in the response, not in the request.
+:: A _path entry_ is an entry within an _error result_ that allows for
+association with a particular field reached during GraphQL execution.
 
-When the _path entry_ is present on an "Error result", it identifies the
+The value for a _path entry_ must be a list of path segments starting at the
+root of the response and ending with the field to be associated with. Path
+segments that represent fields must be strings, and path segments that represent
+list indices must be 0-indexed integers. If a path segment is associated with an
+aliased field it must use the aliased name, since it represents a path in the
+response, not in the request.
+
+When the _path entry_ is present on an _error result_, it identifies the
 response field which experienced the error.
 
 ## Serialization Format

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -240,7 +240,7 @@ discouraged.
 
 ### Path
 
-A `path` field allows for the association to a particular field in a GraphQL
+:: A _path field_ allows for the association to a particular field in a GraphQL
 result. This field must be a list of path segments starting at the root of the
 response and ending with the field to be associated with. Path segments that
 represent fields must be strings, and path segments that represent list indices
@@ -248,7 +248,7 @@ must be 0-indexed integers. If the path is associated to an aliased field, the
 path must use the aliased name, since it represents a path in the response, not
 in the request.
 
-When the `path` field is present on an "Error result", it indicates the response
+When the _path field_ is present on an "Error result", it indicates the response
 field which experienced the error.
 
 ## Serialization Format

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -107,14 +107,8 @@ syntax element.
 If an error can be associated to a particular field in the GraphQL result, it
 must contain an entry with the key `path` that details the path of the response
 field which experienced the error. This allows clients to identify whether a
-`null` result is intentional or caused by a runtime error.
-
-If present, this field must be a list of path segments starting at the root of
-the response and ending with the field associated with the error. Path segments
-that represent fields must be strings, and path segments that represent list
-indices must be 0-indexed integers. If the error happens in an aliased field,
-the path to the error must use the aliased name, since it represents a path in
-the response, not in the request.
+`null` result is intentional or caused by a runtime error. The value of this
+field is described in the [Path](#sec-Path) section.
 
 For example, if fetching one of the friends' names fails in the following
 operation:
@@ -243,6 +237,19 @@ discouraged.
   ]
 }
 ```
+
+### Path
+
+A `path` field allows for the association to a particular field in a GraphQL
+result. This field must be a list of path segments starting at the root of the
+response and ending with the field to be associated with. Path segments that
+represent fields must be strings, and path segments that represent list indices
+must be 0-indexed integers. If the path is associated to an aliased field, the
+path must use the aliased name, since it represents a path in the response, not
+in the request.
+
+When the `path` field is present on an "Error result", it indicates the response
+field which experienced the error.
 
 ## Serialization Format
 


### PR DESCRIPTION
Extracted from the `@defer`/`@stream` spec edits (https://github.com/graphql/graphql-spec/pull/1110) to minimize the diff there.

Since the incremental delivery response format also uses `Path`, I removed it from the Errors section and into it's own section.