### PR TITLE
Type "must not be {null}" -> "must exist"

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -1253,7 +1253,7 @@ Type : Name
 
 - Let {name} be the string value of {Name}.
 - Let {type} be the type defined in the Schema named {name}.
-- {type} must not be {null}.
+- {type} must exist.
 - Return {type}.
 
 Type : [ Type ]


### PR DESCRIPTION
Minor editorial fix, we use "must exist" throughout the spec, and in this case it's appropriate to use "must exist" rather than "must not be null".