### PR TITLE
Be explicit how to handle unknown request information

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -16,8 +16,8 @@ A GraphQL service generates a response from a request via execution.
   data available via a GraphQL Service. It is common for a GraphQL Service to
   always use the same initial value for every request.
 
-As this specification evolves, new information may be added. Implementation
-must ignore any value they do not recognize.
+As this specification evolves, new information may be added. Implementation must
+ignore any value they do not recognize.
 
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -28,7 +28,6 @@ Note: GraphQL requests do not require any specific serialization format or
 transport mechanism. Message serialization and transport mechanisms should be
 chosen by the implementing service.
 
-
 ## Executing Requests
 
 To execute a request, the executor must have a parsed {Document} and a selected

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -21,7 +21,7 @@ operationName, variableValues, initialValue)} produces the response, to be
 formatted according to the Response section below.
 
 A GraphQL service must ignore unrecognized information in a request. This allows
-a service to remain resilient to future changes in future versions of this 
+a service to remain resilient to changes in future versions of this 
 specification.
 
 Note: GraphQL requests do not require any specific serialization format or

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -16,6 +16,9 @@ A GraphQL service generates a response from a request via execution.
   data available via a GraphQL Service. It is common for a GraphQL Service to
   always use the same initial value for every request.
 
+As this specification evolves, new information may be added. Implementation
+must ignore any value they do not recognize.
+
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be
 formatted according to the Response section below.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -21,7 +21,7 @@ operationName, variableValues, initialValue)} produces the response, to be
 formatted according to the Response section below.
 
 A GraphQL service must ignore unrecognized information in a request. This allows
-a service to remain resilient to changes in future versions of this 
+a service to remain resilient to changes in future versions of this
 specification.
 
 Note: GraphQL requests do not require any specific serialization format or

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -16,16 +16,18 @@ A GraphQL service generates a response from a request via execution.
   data available via a GraphQL Service. It is common for a GraphQL Service to
   always use the same initial value for every request.
 
-As this specification evolves, new information may be added. Implementation must
-ignore any value they do not recognize.
-
 Given this information, the result of {ExecuteRequest(schema, document,
 operationName, variableValues, initialValue)} produces the response, to be
 formatted according to the Response section below.
 
+A GraphQL service must ignore unrecognized information in a request. This allows
+a service to remain resilient to future changes in future versions of this 
+specification.
+
 Note: GraphQL requests do not require any specific serialization format or
 transport mechanism. Message serialization and transport mechanisms should be
 chosen by the implementing service.
+
 
 ## Executing Requests
 


### PR DESCRIPTION
As we are discussing adding [a new request parameter](https://github.com/graphql/nullability-wg/discussions/86) for disabling error propagation, we'll need this. This should probably have been added 5 years ago but now is better than later. I think this is what most implementations are doing anyway.