### PR TITLE
Rename field error to execution error; define response position

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -329,8 +329,8 @@ A GraphQL schema may describe that a field represents a list of another type;
 the `List` type is provided for this reason, and wraps another type.
 
 Similarly, the `Non-Null` type wraps another type, and denotes that the
-resulting value will never be {null} (and that a _runtime error_ cannot result
-in a {null} value).
+resulting value will never be {null} (and that an _execution error_ cannot
+result in a {null} value).
 
 These two types are referred to as "wrapping types"; non-wrapping types are
 referred to as "named types". A wrapping type has an underlying named type,
@@ -461,14 +461,14 @@ more guidance.
 
 A GraphQL service, when preparing a field of a given scalar type, must uphold
 the contract the scalar type describes, either by coercing the value or
-producing a _runtime error_ if a value cannot be coerced or if coercion may
+producing an _execution error_ if a value cannot be coerced or if coercion may
 result in data loss.
 
 A GraphQL service may decide to allow coercing different internal types to the
 expected return type. For example when coercing a field of type {Int} a boolean
 {true} value may produce {1} or a string value {"123"} may be parsed as base-10
 {123}. However if internal type coercion cannot be reasonably performed without
-losing information, then it must raise a _runtime error_.
+losing information, then it must raise an _execution error_.
 
 Since this coercion behavior is not observable to clients of the GraphQL
 service, the precise rules of coercion are left to the implementation. The only
@@ -513,15 +513,15 @@ Fields returning the type {Int} expect to encounter 32-bit integer internal
 values.
 
 GraphQL services may coerce non-integer internal values to integers when
-reasonable without losing information, otherwise they must raise a _runtime
+reasonable without losing information, otherwise they must raise an _execution
 error_. Examples of this may include returning `1` for the floating-point number
 `1.0`, or returning `123` for the string `"123"`. In scenarios where coercion
-may lose data, raising a runtime error is more appropriate. For example, a
-floating-point number `1.2` should raise a runtime error instead of being
+may lose data, raising an execution error is more appropriate. For example, a
+floating-point number `1.2` should raise an execution error instead of being
 truncated to `1`.
 
 If the integer internal value represents a value less than -2<sup>31</sup> or
-greater than or equal to 2<sup>31</sup>, a _runtime error_ should be raised.
+greater than or equal to 2<sup>31</sup>, an _execution error_ should be raised.
 
 **Input Coercion**
 
@@ -548,12 +548,12 @@ Fields returning the type {Float} expect to encounter double-precision
 floating-point internal values.
 
 GraphQL services may coerce non-floating-point internal values to {Float} when
-reasonable without losing information, otherwise they must raise a _runtime
+reasonable without losing information, otherwise they must raise an _execution
 error_. Examples of this may include returning `1.0` for the integer number `1`,
 or `123.0` for the string `"123"`.
 
 Non-finite floating-point internal values ({NaN} and {Infinity}) cannot be
-coerced to {Float} and must raise a _runtime error_.
+coerced to {Float} and must raise an _execution error_.
 
 **Input Coercion**
 
@@ -579,7 +579,7 @@ that representation must be used to serialize this type.
 Fields returning the type {String} expect to encounter Unicode string values.
 
 GraphQL services may coerce non-string raw values to {String} when reasonable
-without losing information, otherwise they must raise a _runtime error_.
+without losing information, otherwise they must raise an _execution error_.
 Examples of this may include returning the string `"true"` for a boolean true
 value, or the string `"1"` for the integer `1`.
 
@@ -600,7 +600,7 @@ representation of the integers `1` and `0`.
 Fields returning the type {Boolean} expect to encounter boolean internal values.
 
 GraphQL services may coerce non-boolean raw values to {Boolean} when reasonable
-without losing information, otherwise they must raise a _runtime error_.
+without losing information, otherwise they must raise an _execution error_.
 Examples of this may include returning `true` for non-zero numbers.
 
 **Input Coercion**
@@ -623,7 +623,7 @@ large 128-bit random numbers, to base64 encoded values, or string values of a
 format like [GUID](https://en.wikipedia.org/wiki/Globally_unique_identifier).
 
 GraphQL services should coerce as appropriate given the ID formats they expect.
-When coercion is not possible they must raise a _runtime error_.
+When coercion is not possible they must raise an _execution error_.
 
 **Input Coercion**
 
@@ -1492,7 +1492,7 @@ enum Direction {
 **Result Coercion**
 
 GraphQL services must return one of the defined set of possible values. If a
-reasonable coercion is not possible they must raise a _runtime error_.
+reasonable coercion is not possible they must raise an _execution error_.
 
 **Input Coercion**
 
@@ -1654,9 +1654,9 @@ is constructed with the following rules:
 
 - If a variable is provided for an input object field, the runtime value of that
   variable must be used. If the runtime value is {null} and the field type is
-  non-null, a _runtime error_ must be raised. If no runtime value is provided,
-  the variable definition's default value should be used. If the variable
-  definition does not provide a default value, the input object field
+  non-null, an _execution error_ must be raised. If no runtime value is
+  provided, the variable definition's default value should be used. If the
+  variable definition does not provide a default value, the input object field
   definition's default value should be used.
 
 Following are examples of input coercion for an input object type with a
@@ -1742,16 +1742,16 @@ brackets like this: `pets: [Pet]`. Nesting lists is allowed: `matrix: [[Int]]`.
 
 GraphQL services must return an ordered list as the result of a list type. Each
 item in the list must be the result of a result coercion of the item type. If a
-reasonable coercion is not possible it must raise a _runtime error_. In
+reasonable coercion is not possible it must raise an _execution error_. In
 particular, if a non-list is returned, the coercion should fail, as this
 indicates a mismatch in expectations between the type system and the
 implementation.
 
 If a list's item type is nullable, then errors occurring during preparation or
 coercion of an individual item in the list must result in a the value {null} at
-that position in the list along with a _runtime error_ added to the response. If
-a list's item type is non-null, a runtime error occurring at an individual item
-in the list must result in a runtime error for the entire list.
+that position in the list along with an _execution error_ added to the response.
+If a list's item type is non-null, an execution error occurring at an individual
+item in the list must result in an execution error for the entire list.
 
 Note: See [Handling Runtime Errors](#sec-Handling-Runtime-Errors) for more about
 this behavior.
@@ -1812,10 +1812,10 @@ always optional and non-null types are always required.
 In all of the above result coercions, {null} was considered a valid value. To
 coerce the result of a Non-Null type, the coercion of the wrapped type should be
 performed. If that result was not {null}, then the result of coercing the
-Non-Null type is that result. If that result was {null}, then a _runtime error_
-must be raised.
+Non-Null type is that result. If that result was {null}, then an _execution
+error_ must be raised.
 
-Note: When a _runtime error_ is raised on a non-null _response position_, the
+Note: When an _execution error_ is raised on a non-null _response position_, the
 error propagates to the parent _response position_. For more information on this
 process, see
 [Errors and Non-Null Types](#sec-Executing-Selection-Sets.Errors-and-Non-Null-Types)

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -329,8 +329,8 @@ A GraphQL schema may describe that a field represents a list of another type;
 the `List` type is provided for this reason, and wraps another type.
 
 Similarly, the `Non-Null` type wraps another type, and denotes that the
-resulting value will never be {null} (and that a _field error_ cannot result in
-a {null} value).
+resulting value will never be {null} (and that a _runtime error_ cannot result
+in a {null} value).
 
 These two types are referred to as "wrapping types"; non-wrapping types are
 referred to as "named types". A wrapping type has an underlying named type,
@@ -461,14 +461,14 @@ more guidance.
 
 A GraphQL service, when preparing a field of a given scalar type, must uphold
 the contract the scalar type describes, either by coercing the value or
-producing a _field error_ if a value cannot be coerced or if coercion may result
-in data loss.
+producing a _runtime error_ if a value cannot be coerced or if coercion may
+result in data loss.
 
 A GraphQL service may decide to allow coercing different internal types to the
 expected return type. For example when coercing a field of type {Int} a boolean
 {true} value may produce {1} or a string value {"123"} may be parsed as base-10
 {123}. However if internal type coercion cannot be reasonably performed without
-losing information, then it must raise a _field error_.
+losing information, then it must raise a _runtime error_.
 
 Since this coercion behavior is not observable to clients of the GraphQL
 service, the precise rules of coercion are left to the implementation. The only
@@ -513,15 +513,15 @@ Fields returning the type {Int} expect to encounter 32-bit integer internal
 values.
 
 GraphQL services may coerce non-integer internal values to integers when
-reasonable without losing information, otherwise they must raise a _field
+reasonable without losing information, otherwise they must raise a _runtime
 error_. Examples of this may include returning `1` for the floating-point number
 `1.0`, or returning `123` for the string `"123"`. In scenarios where coercion
-may lose data, raising a field error is more appropriate. For example, a
-floating-point number `1.2` should raise a field error instead of being
+may lose data, raising a runtime error is more appropriate. For example, a
+floating-point number `1.2` should raise a runtime error instead of being
 truncated to `1`.
 
 If the integer internal value represents a value less than -2<sup>31</sup> or
-greater than or equal to 2<sup>31</sup>, a _field error_ should be raised.
+greater than or equal to 2<sup>31</sup>, a _runtime error_ should be raised.
 
 **Input Coercion**
 
@@ -548,12 +548,12 @@ Fields returning the type {Float} expect to encounter double-precision
 floating-point internal values.
 
 GraphQL services may coerce non-floating-point internal values to {Float} when
-reasonable without losing information, otherwise they must raise a _field
+reasonable without losing information, otherwise they must raise a _runtime
 error_. Examples of this may include returning `1.0` for the integer number `1`,
 or `123.0` for the string `"123"`.
 
 Non-finite floating-point internal values ({NaN} and {Infinity}) cannot be
-coerced to {Float} and must raise a _field error_.
+coerced to {Float} and must raise a _runtime error_.
 
 **Input Coercion**
 
@@ -579,9 +579,9 @@ that representation must be used to serialize this type.
 Fields returning the type {String} expect to encounter Unicode string values.
 
 GraphQL services may coerce non-string raw values to {String} when reasonable
-without losing information, otherwise they must raise a _field error_. Examples
-of this may include returning the string `"true"` for a boolean true value, or
-the string `"1"` for the integer `1`.
+without losing information, otherwise they must raise a _runtime error_.
+Examples of this may include returning the string `"true"` for a boolean true
+value, or the string `"1"` for the integer `1`.
 
 **Input Coercion**
 
@@ -600,8 +600,8 @@ representation of the integers `1` and `0`.
 Fields returning the type {Boolean} expect to encounter boolean internal values.
 
 GraphQL services may coerce non-boolean raw values to {Boolean} when reasonable
-without losing information, otherwise they must raise a _field error_. Examples
-of this may include returning `true` for non-zero numbers.
+without losing information, otherwise they must raise a _runtime error_.
+Examples of this may include returning `true` for non-zero numbers.
 
 **Input Coercion**
 
@@ -623,7 +623,7 @@ large 128-bit random numbers, to base64 encoded values, or string values of a
 format like [GUID](https://en.wikipedia.org/wiki/Globally_unique_identifier).
 
 GraphQL services should coerce as appropriate given the ID formats they expect.
-When coercion is not possible they must raise a _field error_.
+When coercion is not possible they must raise a _runtime error_.
 
 **Input Coercion**
 
@@ -1492,7 +1492,7 @@ enum Direction {
 **Result Coercion**
 
 GraphQL services must return one of the defined set of possible values. If a
-reasonable coercion is not possible they must raise a _field error_.
+reasonable coercion is not possible they must raise a _runtime error_.
 
 **Input Coercion**
 
@@ -1654,10 +1654,10 @@ is constructed with the following rules:
 
 - If a variable is provided for an input object field, the runtime value of that
   variable must be used. If the runtime value is {null} and the field type is
-  non-null, a _field error_ must be raised. If no runtime value is provided, the
-  variable definition's default value should be used. If the variable definition
-  does not provide a default value, the input object field definition's default
-  value should be used.
+  non-null, a _runtime error_ must be raised. If no runtime value is provided,
+  the variable definition's default value should be used. If the variable
+  definition does not provide a default value, the input object field
+  definition's default value should be used.
 
 Following are examples of input coercion for an input object type with a
 `String` field `a` and a required (non-null) `Int!` field `b`:
@@ -1742,18 +1742,18 @@ brackets like this: `pets: [Pet]`. Nesting lists is allowed: `matrix: [[Int]]`.
 
 GraphQL services must return an ordered list as the result of a list type. Each
 item in the list must be the result of a result coercion of the item type. If a
-reasonable coercion is not possible it must raise a _field error_. In
+reasonable coercion is not possible it must raise a _runtime error_. In
 particular, if a non-list is returned, the coercion should fail, as this
 indicates a mismatch in expectations between the type system and the
 implementation.
 
 If a list's item type is nullable, then errors occurring during preparation or
 coercion of an individual item in the list must result in a the value {null} at
-that position in the list along with a _field error_ added to the response. If a
-list's item type is non-null, a field error occurring at an individual item in
-the list must result in a field error for the entire list.
+that position in the list along with a _runtime error_ added to the response. If
+a list's item type is non-null, a runtime error occurring at an individual item
+in the list must result in a runtime error for the entire list.
 
-Note: See [Handling Field Errors](#sec-Handling-Field-Errors) for more about
+Note: See [Handling Runtime Errors](#sec-Handling-Runtime-Errors) for more about
 this behavior.
 
 **Input Coercion**
@@ -1812,12 +1812,13 @@ always optional and non-null types are always required.
 In all of the above result coercions, {null} was considered a valid value. To
 coerce the result of a Non-Null type, the coercion of the wrapped type should be
 performed. If that result was not {null}, then the result of coercing the
-Non-Null type is that result. If that result was {null}, then a _field error_
+Non-Null type is that result. If that result was {null}, then a _runtime error_
 must be raised.
 
-Note: When a _field error_ is raised on a non-null value, the error propagates
-to the parent field. For more information on this process, see
-[Errors and Non-Null Fields](#sec-Executing-Selection-Sets.Errors-and-Non-Null-Fields)
+Note: When a _runtime error_ is raised on a non-null _response position_, the
+error propagates to the parent _response position_. For more information on this
+process, see
+[Errors and Non-Null Types](#sec-Executing-Selection-Sets.Errors-and-Non-Null-Types)
 within the Execution section.
 
 **Input Coercion**

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1753,8 +1753,8 @@ that position in the list along with an _execution error_ added to the response.
 If a list's item type is non-null, an execution error occurring at an individual
 item in the list must result in an execution error for the entire list.
 
-Note: See [Handling Runtime Errors](#sec-Handling-Runtime-Errors) for more about
-this behavior.
+Note: See [Handling Execution Errors](#sec-Handling-Execution-Errors) for more
+about this behavior.
 
 **Input Coercion**
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -2010,4 +2010,4 @@ query booleanArgQueryWithDefault($booleanArg: Boolean = true) {
 ```
 
 Note: The value {null} could still be provided to such a variable at runtime. A
-non-null argument must raise a _field error_ if provided a {null} value.
+non-null argument must raise a _runtime error_ if provided a {null} value.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -2010,4 +2010,4 @@ query booleanArgQueryWithDefault($booleanArg: Boolean = true) {
 ```
 
 Note: The value {null} could still be provided to such a variable at runtime. A
-non-null argument must raise a _runtime error_ if provided a {null} value.
+non-null argument must raise an _execution error_ if provided a {null} value.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -846,6 +846,6 @@ resolves to {null}, then the entire list must resolve to {null}. If the `List`
 type is also wrapped in a `Non-Null`, the execution error continues to propagate
 upwards.
 
-If all response positions from the root of the request to the source of the
-execution error return `Non-Null` types, then the {"data"} entry in the response
-should be {null}.
+If every _response position_ from the root of the request to the source of the
+execution error returns a `Non-Null` type, then the {"data"} entry in the
+response should be {null}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -387,9 +387,9 @@ If during {ExecuteSelectionSet()} a _response position_ with a non-null type
 raises a _runtime error_ then that error must propagate to the parent response
 position (the entire selection set in the case of a field, or the entire list in
 the case of a list position), either resolving to {null} if allowed or being
-further propagated to a parent _response position_.
+further propagated to a parent response position.
 
-If this occurs, any sibling response position which have not yet executed or
+If this occurs, any sibling response positions which have not yet executed or
 have not yet yielded a value may be cancelled to avoid unnecessary work.
 
 Note: See [Handling Runtime Errors](#sec-Handling-Runtime-Errors) for more about

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -376,11 +376,11 @@ ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues):
 Note: {resultMap} is ordered by which fields appear first in the operation. This
 is explained in greater detail in the Field Collection section below.
 
-<a name="sec-Executing-Selection-Sets.Errors-and-Non-Null-Fields">
-  <!-- This link exists for legacy hyperlink support -->
-</a>
-
 **Errors and Non-Null Types**
+
+<a name="sec-Executing-Selection-Sets.Errors-and-Non-Null-Fields">
+  <!-- Legacy link, this section was previously titled "Errors and Non-Null Fields" -->
+</a>
 
 If during {ExecuteSelectionSet()} a _response position_ with a non-null type
 raises an _execution error_ then that error must propagate to the parent
@@ -626,9 +626,6 @@ the type system to have a specific input type.
 At each argument position in an operation may be a literal {Value}, or a
 {Variable} to be provided at runtime.
 
-Any _request error_ raised during {CoerceArgumentValues()} should be treated
-instead as an _execution error_.
-
 CoerceArgumentValues(objectType, field, variableValues):
 
 - Let {coercedValues} be an empty unordered Map.
@@ -671,6 +668,9 @@ CoerceArgumentValues(objectType, field, variableValues):
       - Add an entry to {coercedValues} named {argumentName} with the value
         {coercedValue}.
 - Return {coercedValues}.
+
+Any _request error_ raised as a result of input coercion during
+{CoerceArgumentValues()} should be treated instead as an _execution error_.
 
 Note: Variable values are not coerced because they are expected to be coerced
 before executing the operation in {CoerceVariableValues()}, and valid operations
@@ -807,33 +807,33 @@ MergeSelectionSets(fields):
   - Append all selections in {fieldSelectionSet} to {selectionSet}.
 - Return {selectionSet}.
 
-<a name="sec-Handling-Field-Errors">
-  <!-- This link exists for legacy hyperlink support -->
-</a>
-
 ### Handling Execution Errors
 
-An _execution error_ is an error raised from a particular field during value
-resolution or coercion. While these errors should be reported in the response,
-they are "handled" by producing a partial response.
+<a name="sec-Handling-Field-Errors">
+  <!-- Legacy link, this section was previously titled "Handling Execution Errors" -->
+</a>
+
+An _execution error_ is an error raised during field execution, value resolution
+or coercion, at a specific _response position_. While these errors should be
+reported in the response, they are "handled" by producing a partial response.
 
 Note: This is distinct from a _request error_ which results in a response with
 no data.
 
 If an execution error is raised while resolving a field (either directly or
-nested inside any lists), it is handled as though the position at which the
-error occurred resulted in {null}, and the error must be added to the {"errors"}
-list in the response.
+nested inside any lists), it is handled as though the _response position_ at
+which the error occurred resolved to {null}, and the error must be added to the
+{"errors"} list in the response.
 
 If the result of resolving a _response position_ is {null} (either due to the
 result of {ResolveFieldValue()} or because an execution error was raised), and
 that position is of a `Non-Null` type, then an execution error is raised at that
 position. The error must be added to the {"errors"} list in the response.
 
-If a _response position_ returns {null} because of an execution error which has
-already been added to the {"errors"} list in the response, the {"errors"} list
-must not be further affected. That is, only one error should be added to the
-errors list per _response position_.
+If a _response position_ resolves to {null} because of an execution error which
+has already been added to the {"errors"} list in the response, the {"errors"}
+list must not be further affected. That is, only one error should be added to
+the errors list per _response position_.
 
 Since `Non-Null` response positions cannot be {null}, execution errors are
 propagated to be handled by the parent _response position_. If the parent
@@ -841,11 +841,11 @@ response position may be {null} then it resolves to {null}, otherwise if it is a
 `Non-Null` type, the execution error is further propagated to its parent
 _response position_.
 
-If a `List` type wraps a `Non-Null` type, and one of the elements of that list
-resolves to {null}, then the entire list must resolve to {null}. If the `List`
-type is also wrapped in a `Non-Null`, the execution error continues to propagate
-upwards.
+If a `List` type wraps a `Non-Null` type, and one of the _response position_
+elements of that list resolves to {null}, then the entire list _response
+position_ must resolve to {null}. If the `List` type is also wrapped in a
+`Non-Null`, the execution error continues to propagate upwards.
 
 If every _response position_ from the root of the request to the source of the
-execution error returns a `Non-Null` type, then the {"data"} entry in the
-response should be {null}.
+execution error has a `Non-Null` type, then the {"data"} entry in the response
+should be {null}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -137,7 +137,7 @@ ExecuteQuery(query, schema, variableValues, initialValue):
 - Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
   queryType, initialValue, variableValues)} _normally_ (allowing
   parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
+- Let {errors} be the list of all _runtime error_ raised while executing the
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
@@ -158,7 +158,7 @@ ExecuteMutation(mutation, schema, variableValues, initialValue):
 - Let {selectionSet} be the top level selection set in {mutation}.
 - Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
   mutationType, initialValue, variableValues)} _serially_.
-- Let {errors} be the list of all _field error_ raised while executing the
+- Let {errors} be the list of all _runtime error_ raised while executing the
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
@@ -317,10 +317,10 @@ MapSourceToResponseEvent(sourceStream, subscription, schema, variableValues):
   - Complete {responseStream} normally.
 - Return {responseStream}.
 
-Note: Since {ExecuteSubscriptionEvent()} handles all _field error_, and _request
-error_ only occur during {CreateSourceEventStream()}, the only remaining error
-condition handled from {ExecuteSubscriptionEvent()} are internal exceptional
-errors not described by this specification.
+Note: Since {ExecuteSubscriptionEvent()} handles all _runtime error_, and
+_request error_ only occur during {CreateSourceEventStream()}, the only
+remaining error condition handled from {ExecuteSubscriptionEvent()} are internal
+exceptional errors not described by this specification.
 
 ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 
@@ -330,7 +330,7 @@ ExecuteSubscriptionEvent(subscription, schema, variableValues, initialValue):
 - Let {data} be the result of running {ExecuteSelectionSet(selectionSet,
   subscriptionType, initialValue, variableValues)} _normally_ (allowing
   parallelization).
-- Let {errors} be the list of all _field error_ raised while executing the
+- Let {errors} be the list of all _runtime error_ raised while executing the
   selection set.
 - Return an unordered map containing {data} and {errors}.
 
@@ -377,16 +377,22 @@ ExecuteSelectionSet(selectionSet, objectType, objectValue, variableValues):
 Note: {resultMap} is ordered by which fields appear first in the operation. This
 is explained in greater detail in the Field Collection section below.
 
-**Errors and Non-Null Fields**
+<a name="sec-Executing-Selection-Sets.Errors-and-Non-Null-Fields">
+  <!-- This link exists for legacy hyperlink support -->
+</a>
 
-If during {ExecuteSelectionSet()} a field with a non-null {fieldType} raises a
-_field error_ then that error must propagate to this entire selection set,
-either resolving to {null} if allowed or further propagated to a parent field.
+**Errors and Non-Null Types**
 
-If this occurs, any sibling fields which have not yet executed or have not yet
-yielded a value may be cancelled to avoid unnecessary work.
+If during {ExecuteSelectionSet()} a _response position_ with a non-null type
+raises a _runtime error_ then that error must propagate to the parent response
+position (the entire selection set in the case of a field, or the entire list in
+the case of a list position), either resolving to {null} if allowed or being
+further propagated to a parent _response position_.
 
-Note: See [Handling Field Errors](#sec-Handling-Field-Errors) for more about
+If this occurs, any sibling response position which have not yet executed or
+have not yet yielded a value may be cancelled to avoid unnecessary work.
+
+Note: See [Handling Runtime Errors](#sec-Handling-Runtime-Errors) for more about
 this behavior.
 
 ### Normal and Serial Execution
@@ -647,7 +653,7 @@ CoerceArgumentValues(objectType, field, variableValues):
     - Add an entry to {coercedValues} named {argumentName} with the value
       {defaultValue}.
   - Otherwise if {argumentType} is a Non-Nullable type, and either {hasValue} is
-    not {true} or {value} is {null}, raise a _field error_.
+    not {true} or {value} is {null}, raise a _runtime error_.
   - Otherwise if {hasValue} is {true}:
     - If {value} is {null}:
       - Add an entry to {coercedValues} named {argumentName} with the value
@@ -657,7 +663,7 @@ CoerceArgumentValues(objectType, field, variableValues):
         {value}.
     - Otherwise:
       - If {value} cannot be coerced according to the input coercion rules of
-        {argumentType}, raise a _field error_.
+        {argumentType}, raise a _runtime error_.
       - Let {coercedValue} be the result of coercing {value} according to the
         input coercion rules of {argumentType}.
       - Add an entry to {coercedValues} named {argumentName} with the value
@@ -704,12 +710,12 @@ CompleteValue(fieldType, fields, result, variableValues):
   - Let {innerType} be the inner type of {fieldType}.
   - Let {completedResult} be the result of calling {CompleteValue(innerType,
     fields, result, variableValues)}.
-  - If {completedResult} is {null}, raise a _field error_.
+  - If {completedResult} is {null}, raise a _runtime error_.
   - Return {completedResult}.
 - If {result} is {null} (or another internal value similar to {null} such as
   {undefined}), return {null}.
 - If {fieldType} is a List type:
-  - If {result} is not a collection of values, raise a _field error_.
+  - If {result} is not a collection of values, raise a _runtime error_.
   - Let {innerType} be the inner type of {fieldType}.
   - Return a list where each list item is the result of calling
     {CompleteValue(innerType, fields, resultItem, variableValues)}, where
@@ -744,7 +750,7 @@ CoerceResult(leafType, value):
 - Return the result of calling the internal method provided by the type system
   for determining the "result coercion" of {leafType} given the value {value}.
   This internal method must return a valid value for the type and not {null}.
-  Otherwise raise a _field error_.
+  Otherwise raise a _runtime error_.
 
 Note: If a field resolver returns {null} then it is handled within
 {CompleteValue()} before {CoerceResult()} is called. Therefore both the input
@@ -799,39 +805,45 @@ MergeSelectionSets(fields):
   - Append all selections in {fieldSelectionSet} to {selectionSet}.
 - Return {selectionSet}.
 
-### Handling Field Errors
+<a name="sec-Handling-Field-Errors">
+  <!-- This link exists for legacy hyperlink support -->
+</a>
 
-A _field error_ is an error raised from a particular field during value
+### Handling Runtime Errors
+
+A _runtime error_ is an error raised from a particular field during value
 resolution or coercion. While these errors should be reported in the response,
 they are "handled" by producing a partial response.
 
 Note: This is distinct from a _request error_ which results in a response with
 no data.
 
-If a field error is raised while resolving a field, it is handled as though the
-field returned {null}, and the error must be added to the {"errors"} list in the
-response.
+If a runtime error is raised while resolving a field (either directly or nested
+inside any lists), it is handled as though the position at which the error
+occurred resulted in {null}, and the error must be added to the {"errors"} list
+in the response.
 
-If the result of resolving a field is {null} (either because the function to
-resolve the field returned {null} or because a field error was raised), and that
-field is of a `Non-Null` type, then a field error is raised. The error must be
-added to the {"errors"} list in the response.
+If the result of resolving a _response position_ is {null} (either due to the
+result of {ResolveFieldValue()} or because a runtime error was raised), and that
+position is of a `Non-Null` type, then a runtime error is raised at that
+position. The error must be added to the {"errors"} list in the response.
 
-If the field returns {null} because of a field error which has already been
-added to the {"errors"} list in the response, the {"errors"} list must not be
-further affected. That is, only one error should be added to the errors list per
-field.
+If a _response position_ returns {null} because of a runtime error which has
+already been added to the {"errors"} list in the response, the {"errors"} list
+must not be further affected. That is, only one error should be added to the
+errors list per _response position_.
 
-Since `Non-Null` type fields cannot be {null}, field errors are propagated to be
-handled by the parent field. If the parent field may be {null} then it resolves
-to {null}, otherwise if it is a `Non-Null` type, the field error is further
-propagated to its parent field.
+Since `Non-Null` response positions cannot be {null}, runtime errors are
+propagated to be handled by the parent _response position_. If the parent
+response position may be {null} then it resolves to {null}, otherwise if it is a
+`Non-Null` type, the runtime error is further propagated to its parent _response
+position_.
 
 If a `List` type wraps a `Non-Null` type, and one of the elements of that list
 resolves to {null}, then the entire list must resolve to {null}. If the `List`
-type is also wrapped in a `Non-Null`, the field error continues to propagate
+type is also wrapped in a `Non-Null`, the runtime error continues to propagate
 upwards.
 
-If all fields from the root of the request to the source of the field error
-return `Non-Null` types, then the {"data"} entry in the response should be
-{null}.
+If all response positions from the root of the request to the source of the
+runtime error return `Non-Null` types, then the {"data"} entry in the response
+should be {null}.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -627,6 +627,9 @@ the type system to have a specific input type.
 At each argument position in an operation may be a literal {Value}, or a
 {Variable} to be provided at runtime.
 
+Any _request error_ raised during {CoerceArgumentValues()} should be treated
+instead as a _runtime error_.
+
 CoerceArgumentValues(objectType, field, variableValues):
 
 - Let {coercedValues} be an empty unordered Map.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -814,8 +814,9 @@ MergeSelectionSets(fields):
 </a>
 
 An _execution error_ is an error raised during field execution, value resolution
-or coercion, at a specific _response position_. While these errors should be
-reported in the response, they are "handled" by producing a partial response.
+or coercion, at a specific _response position_. While these errors must be
+reported in the response, they are "handled" by producing partial {"data"} in
+the _response_.
 
 Note: This is distinct from a _request error_ which results in a response with
 no data.

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -392,8 +392,8 @@ allowed or being further propagated to a parent response position.
 If this occurs, any sibling response positions which have not yet executed or
 have not yet yielded a value may be cancelled to avoid unnecessary work.
 
-Note: See [Handling Runtime Errors](#sec-Handling-Runtime-Errors) for more about
-this behavior.
+Note: See [Handling Execution Errors](#sec-Handling-Execution-Errors) for more
+about this behavior.
 
 ### Normal and Serial Execution
 
@@ -812,7 +812,7 @@ MergeSelectionSets(fields):
   <!-- This link exists for legacy hyperlink support -->
 </a>
 
-### Handling Runtime Errors
+### Handling Execution Errors
 
 An _execution error_ is an error raised from a particular field during value
 resolution or coercion. While these errors should be reported in the response,

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -57,6 +57,36 @@ present in the response.
 If an error was raised during the execution that prevented a valid response, the
 `data` entry in the response should be `null`.
 
+**Response Position**
+
+:: A _response position_ is a uniquely identifiable position in the response
+data produced during execution. It is either a direct entry in the {resultMap}
+of a {ExecuteSelectionSet()}, or it is a position in a (potentially nested) List
+value.
+
+The response data is the result of accumulating the result of all response
+positions during execution.
+
+Each _response position_ is uniquely identifiable via a _path entry_.
+
+A single field execution may result in multiple response positions. For example,
+
+```graphql example
+{
+  hero(episode: $episode) {
+    name
+    friends {
+      name
+    }
+  }
+}
+```
+
+The hero's name would be found in the _response position_ identified by
+`["hero", "name"]`. The List of the hero's friends would be found at
+`["hero", "friends"]`, the hero's first friend at `["hero", "friends", 0]` and
+that friend's name at `["hero", "friends", 0, "name"]`.
+
 ### Errors
 
 The `errors` entry in the response is a non-empty list of errors raised during
@@ -88,33 +118,31 @@ If a request error is raised, the `data` entry in the response must not be
 present, the `errors` entry must include the error, and request execution should
 be halted.
 
-<a name="sec-Errors.Field-Errors">
-  <!-- This link exists for legacy hyperlink support -->
-</a>
-
 **Execution Errors**
+
+<a name="sec-Errors.Field-Errors">
+  <!-- Legacy link, this section was previously titled "Field Errors" -->
+</a>
 
 :: An _execution error_ is an error raised during the execution of a particular
 field which results in partial response data. This may occur due to failure to
 coerce the arguments for the field, an internal error during value resolution,
-or failure to coerce the resulting value. An _execution error_ may occur in any
-_response position_.
+or failure to coerce the resulting value.
 
 Note: In previous versions of this specification _execution error_ was called
 _field error_.
 
-:: A _response position_ is an identifiable position in the response: either a
-_field_, or a (potentially nested) list position within a field if the field has
-a `List` type. An _execution error_ may only occur within a _response position_.
-The _response position_ is indicated in the _response_ via the error's _path
-entry_.
-
 An execution error is typically the fault of a GraphQL service.
 
-If an execution error is raised, execution attempts to continue and a partial
-result is produced (see
-[Handling Execution Errors](#sec-Handling-Execution-Errors)). The `data` entry
-in the response must be present. The `errors` entry must include this error.
+An _execution error_ must occur at a specific _response position_, and may occur
+in any response position. The response position of an execution error is
+indicated via the error's `path` _path entry_.
+
+When an execution error is raised at a given _response position_, then that
+response position must not be present within the _response_ `data` entry (except
+{null}), and the `errors` entry must include the error. Nested execution is
+halted and sibling execution attempts to continue, producing partial result (see
+[Handling Execution Errors](#sec-Handling-Execution-Errors)).
 
 **Error Result Format**
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -5,7 +5,7 @@ response. The service's response describes the result of executing the requested
 operation if successful, and describes any errors raised during the request.
 
 A response may contain both a partial response as well as a list of errors in
-the case that any _runtime error_ was raised and replaced with {null}.
+the case that any _execution error_ was raised and replaced with {null}.
 
 ## Response Format
 
@@ -72,8 +72,8 @@ present. It must contain at least one _request error_ indicating why no data was
 able to be returned.
 
 If the `data` entry in the response is present (including if it is the value
-{null}), the `errors` entry must be present if and only if one or more _runtime
-error_ was raised during execution.
+{null}), the `errors` entry must be present if and only if one or more
+_execution error_ was raised during execution.
 
 **Request Errors**
 
@@ -92,29 +92,29 @@ be halted.
   <!-- This link exists for legacy hyperlink support -->
 </a>
 
-**Runtime Errors**
+**Execution Errors**
 
-:: A _runtime error_ is an error raised during the execution of a particular
+:: An _execution error_ is an error raised during the execution of a particular
 field which results in partial response data. This may occur due to failure to
 coerce the arguments for the field, an internal error during value resolution,
-or failure to coerce the resulting value. A _runtime error_ may occur in any
+or failure to coerce the resulting value. An _execution error_ may occur in any
 _response position_.
 
-Note: In previous versions of this specification _runtime error_ was called
+Note: In previous versions of this specification _execution error_ was called
 _field error_.
 
 :: A _response position_ is an identifiable position in the response: either a
 _field_, or a (potentially nested) list position within a field if the field has
-a `List` type. A _runtime error_ may only occur within a _response position_.
+a `List` type. An _execution error_ may only occur within a _response position_.
 The _response position_ is indicated in the _response_ via the error's _path
 entry_.
 
-A runtime error is typically the fault of a GraphQL service.
+An execution error is typically the fault of a GraphQL service.
 
-If a runtime error is raised, execution attempts to continue and a partial
+If an execution error is raised, execution attempts to continue and a partial
 result is produced (see
-[Handling Runtime Errors](#sec-Handling-Runtime-Errors)). The `data` entry in
-the response must be present. The `errors` entry must include this error.
+[Handling Execution Errors](#sec-Handling-Execution-Errors)). The `data` entry
+in the response must be present. The `errors` entry must include this error.
 
 **Error Result Format**
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -17,12 +17,12 @@ A GraphQL request returns either a _response_ or a _response stream_.
 or mutation. A _response_ must be a map.
 
 If the request raised any errors, the response map must contain an entry with
-key `errors`. The value of this entry is described in the "Errors" section. If
+key {"errors"}. The value of this entry is described in the "Errors" section. If
 the request completed without raising any errors, this entry must not be
 present.
 
 If the request included execution, the response map must contain an entry with
-key `data`. The value of this entry is described in the "Data" section. If the
+key {"data"}. The value of this entry is described in the "Data" section. If the
 request failed before execution, due to a syntax error, missing information, or
 validation error, this entry must not be present.
 
@@ -35,7 +35,7 @@ To ensure future changes to the protocol do not break existing services and
 clients, the top level response map must not contain any entries other than the
 three described above.
 
-Note: When `errors` is present in the response, it may be helpful for it to
+Note: When {"errors"} is present in the response, it may be helpful for it to
 appear first when serialized to make it more clear when errors are present in a
 response during debugging.
 
@@ -44,30 +44,29 @@ response during debugging.
 :: A GraphQL request returns a _response stream_ when the GraphQL operation is a
 subscription. A _response stream_ must be a stream of _response_.
 
-### Data
+### Response Position
 
-The `data` entry in the response will be the result of the execution of the
-requested operation. If the operation was a query, this output will be an object
-of the query root operation type; if the operation was a mutation, this output
-will be an object of the mutation root operation type.
-
-If an error was raised before execution begins, the `data` entry should not be
-present in the response.
-
-If an error was raised during the execution that prevented a valid response, the
-`data` entry in the response should be `null`.
-
-**Response Position**
+<a name="sec-Path">
+  <!-- Legacy link, this section was previously titled "Path" -->
+</a>
 
 :: A _response position_ is a uniquely identifiable position in the response
 data produced during execution. It is either a direct entry in the {resultMap}
 of a {ExecuteSelectionSet()}, or it is a position in a (potentially nested) List
-value.
+value. Each response position is uniquely identifiable via a _response path_.
 
-The response data is the result of accumulating the result of all response
-positions during execution.
+:: A _response path_ uniquely identifies a _response position_ via a list of
+path segments (response keys or list indices) starting at the root of the
+response and ending with the associated response position.
 
-Each _response position_ is uniquely identifiable via a _path entry_.
+The value for a _response path_ must be a list of path segments. Path segments
+that represent field response keys must be strings, and path segments that
+represent list indices must be 0-indexed integers. If a path segment is
+associated with an aliased field it must use the aliased name, since it
+represents a path in the response, not in the request.
+
+When a _response path_ is present on an _error result_, it identifies the
+_response position_ which raised the error.
 
 A single field execution may result in multiple response positions. For example,
 
@@ -82,27 +81,44 @@ A single field execution may result in multiple response positions. For example,
 }
 ```
 
-The hero's name would be found in the _response position_ identified by
-`["hero", "name"]`. The List of the hero's friends would be found at
-`["hero", "friends"]`, the hero's first friend at `["hero", "friends", 0]` and
-that friend's name at `["hero", "friends", 0, "name"]`.
+The hero's name would be found in the _response position_ identified by the
+_response path_ `["hero", "name"]`. The List of the hero's friends would be
+found at `["hero", "friends"]`, the hero's first friend at
+`["hero", "friends", 0]` and that friend's name at
+`["hero", "friends", 0, "name"]`.
+
+### Data
+
+The {"data"} entry in the response will be the result of the execution of the
+requested operation. If the operation was a query, this output will be an object
+of the query root operation type; if the operation was a mutation, this output
+will be an object of the mutation root operation type.
+
+The response data is the result of accumulating the resolved result of all
+response positions during execution.
+
+If an error was raised before execution begins, the {"data"} entry should not be
+present in the response.
+
+If an error was raised during the execution that prevented a valid response, the
+{"data"} entry in the response should be `null`.
 
 ### Errors
 
-The `errors` entry in the response is a non-empty list of errors raised during
+The {"errors"} entry in the response is a non-empty list of errors raised during
 the _request_, where each error is a map of data described by the error result
 format below.
 
-If present, the `errors` entry in the response must contain at least one error.
-If no errors were raised during the request, the `errors` entry must not be
-present in the response.
+If present, the {"errors"} entry in the response must contain at least one
+error. If no errors were raised during the request, the {"errors"} entry must
+not be present in the response.
 
-If the `data` entry in the response is not present, the `errors` entry must be
-present. It must contain at least one _request error_ indicating why no data was
-able to be returned.
+If the {"data"} entry in the response is not present, the {"errors"} entry must
+be present. It must contain at least one _request error_ indicating why no data
+was able to be returned.
 
-If the `data` entry in the response is present (including if it is the value
-{null}), the `errors` entry must be present if and only if one or more
+If the {"data"} entry in the response is present (including if it is the value
+{null}), the {"errors"} entry must be present if and only if one or more
 _execution error_ was raised during execution.
 
 **Request Errors**
@@ -114,9 +130,9 @@ to determine which operation to execute, or invalid input values for variables.
 
 A request error is typically the fault of the requesting client.
 
-If a request error is raised, the `data` entry in the response must not be
-present, the `errors` entry must include the error, and request execution should
-be halted.
+If a request error is raised, the {"data"} entry in the response must not be
+present, the {"errors"} entry must include the error, and request execution
+should be halted.
 
 **Execution Errors**
 
@@ -136,31 +152,32 @@ An execution error is typically the fault of a GraphQL service.
 
 An _execution error_ must occur at a specific _response position_, and may occur
 in any response position. The response position of an execution error is
-indicated via the error's `path` _path entry_.
+indicated via a _response path_ in the error response's {"path"} entry.
 
 When an execution error is raised at a given _response position_, then that
-response position must not be present within the _response_ `data` entry (except
-{null}), and the `errors` entry must include the error. Nested execution is
-halted and sibling execution attempts to continue, producing partial result (see
+response position must not be present within the _response_ {"data"} entry
+(except {null}), and the {"errors"} entry must include the error. Nested
+execution is halted and sibling execution attempts to continue, producing
+partial result (see
 [Handling Execution Errors](#sec-Handling-Execution-Errors)).
 
 **Error Result Format**
 
-Every error must contain an entry with the key `message` with a string
+Every error must contain an entry with the key {"message"} with a string
 description of the error intended for the developer as a guide to understand and
 correct the error.
 
 If an error can be associated to a particular point in the requested GraphQL
-document, it should contain an entry with the key `locations` with a list of
-locations, where each location is a map with the keys `line` and `column`, both
-positive numbers starting from `1` which describe the beginning of an associated
-syntax element.
+document, it should contain an entry with the key {"locations"} with a list of
+locations, where each location is a map with the keys {"line"} and {"column"},
+both positive numbers starting from `1` which describe the beginning of an
+associated syntax element.
 
 If an error can be associated to a particular field in the GraphQL result, it
-must contain an entry with the key `path` that details the path of the response
-field which experienced the error. This allows clients to identify whether a
-`null` result is intentional or caused by a runtime error. The value of this
-_path entry_ is described in the [Path](#sec-Path) section.
+must contain an entry with the key {"path"} with a _response path_ which
+describes the _response position_ which raised the error. This allows clients to
+identify whether a {null} resolved result is a true value or the result of an
+_execution error_.
 
 For example, if fetching one of the friends' names fails in the following
 operation:
@@ -289,21 +306,6 @@ discouraged.
   ]
 }
 ```
-
-### Path
-
-:: A _path entry_ is an entry within an _error result_ that indicates the
-_response position_ at which the error occurred.
-
-The value for a _path entry_ must be a list of path segments starting at the
-root of the response and ending with the field to be associated with. Path
-segments that represent fields must be strings, and path segments that represent
-list indices must be 0-indexed integers. If a path segment is associated with an
-aliased field it must use the aliased name, since it represents a path in the
-response, not in the request.
-
-When the _path entry_ is present on an _error result_, it identifies the
-response field which experienced the error.
 
 ## Serialization Format
 

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -5,8 +5,7 @@ response. The service's response describes the result of executing the requested
 operation if successful, and describes any errors raised during the request.
 
 A response may contain both a partial response as well as a list of errors in
-the case that any _field error_ was raised on a field and was replaced with
-{null}.
+the case that any _runtime error_ was raised and replaced with {null}.
 
 ## Response Format
 
@@ -73,7 +72,7 @@ present. It must contain at least one _request error_ indicating why no data was
 able to be returned.
 
 If the `data` entry in the response is present (including if it is the value
-{null}), the `errors` entry must be present if and only if one or more _field
+{null}), the `errors` entry must be present if and only if one or more _runtime
 error_ was raised during execution.
 
 **Request Errors**
@@ -89,18 +88,33 @@ If a request error is raised, the `data` entry in the response must not be
 present, the `errors` entry must include the error, and request execution should
 be halted.
 
-**Field Errors**
+<a name="sec-Errors.Field-Errors">
+  <!-- This link exists for legacy hyperlink support -->
+</a>
 
-:: A _field error_ is an error raised during the execution of a particular field
-which results in partial response data. This may occur due to an internal error
-during value resolution or failure to coerce the resulting value.
+**Runtime Errors**
 
-A field error is typically the fault of a GraphQL service.
+:: A _runtime error_ is an error raised during the execution of a particular
+field which results in partial response data. This may occur due to failure to
+coerce the arguments for the field, an internal error during value resolution,
+or failure to coerce the resulting value. A _runtime error_ may occur in any
+_response position_.
 
-If a field error is raised, execution attempts to continue and a partial result
-is produced (see [Handling Field Errors](#sec-Handling-Field-Errors)). The
-`data` entry in the response must be present. The `errors` entry should include
-this error.
+Note: In previous versions of this specification _runtime error_ was called
+_field error_.
+
+:: A _response position_ is an identifiable position in the response: either a
+_field_, or a (potentially nested) list position within a field if the field has
+a `List` type. A _runtime error_ may only occur within a _response position_.
+The _response position_ is indicated in the _response_ via the error's _path
+entry_.
+
+A runtime error is typically the fault of a GraphQL service.
+
+If a runtime error is raised, execution attempts to continue and a partial
+result is produced (see
+[Handling Runtime Errors](#sec-Handling-Runtime-Errors)). The `data` entry in
+the response must be present. The `errors` entry must include this error.
 
 **Error Result Format**
 
@@ -250,8 +264,8 @@ discouraged.
 
 ### Path
 
-:: A _path entry_ is an entry within an _error result_ that allows for
-association with a particular field reached during GraphQL execution.
+:: A _path entry_ is an entry within an _error result_ that indicates the
+_response position_ at which the error occurred.
 
 The value for a _path entry_ must be a list of path segments starting at the
 root of the response and ending with the field to be associated with. Path


### PR DESCRIPTION
This has bugged me for years, but it turns out to be a blocker around disabling error propagation... so I'm proposing we finally fix it.

The GraphQL spec is _wrong_ when it refers to field errors. Case in point:

> If all fields from the root of the request to the source of the field error return Non-Null types, then the "data" entry in the response should be null. 

This is not true for the schema `type Query { foo: [Foo]! } type Foo { throws: Int! }` with the query `{ foo { throws } }`. All fields from the root of the request to the source of the field error return Non-Null types, but the _list position_ inside the `foo` return type is nullable, and thus the error should (and does!) stop at that error boundary, returning `{ data: {foo: [null]}, errors: [...]}` and not `{ data: null, errors: [...] }` as the spec (incorrectly) states.

This seems to be an oversight of the list type throughout the spec; there are a lot of incidences where we refer to errors happening at a "field" when actually we mean they're happening at an errorable position - that is to say, a position that can be identified by the `path` in the response. Factoring in that this `path` will also want to be used by incremental delivery, rather than calling it an "error position" I've called it a "response position". I did moot calling it simply "position", which I really like, but we do have instances of referring to argument positions, which are distinct from response positions, so I opted for the longer but less ambiguous name.

To make this clearer I've renamed "field error" to "execution error". Technically all execution errors originate in fields, but not necessarily at the field itself - it could be nested within a list. There are three main sources:

- Argument coercion - happens at the field
- Errors thrown by the resolver and caught by GraphQL - happens at the field[^1]
- Errors occurring during result coercion - happens at the field, **and within any nested list positions**

[^1]: in spec terms, though in GraphQL.js it's possible to return e.g. `[1, new Error("two"), 3]` and have the second item be treated as an error thrown in that response position.

I've introduced `<a name="...">` tags in the spec text to maintain these key hyperlinks even after changing titles of sections.

I've also fixed a number of bugs, ambiguities, and omissions in the spec relating to error handling.

These all reflect the behavior of GraphQL.js (and, I believe, all other GraphQL implementations) and thus I've marked this as editorial.

@graphql/implementers Do any of your implementations handle errors in the way that the spec _currently_ states, as opposed to the way that the reference implementation works? If so, speak now and we can turn this into an RFC process rather than editorial!

cc @JoviDeCroock @yaacovCR Please confirm that my spec edits correctly represent the way in which GraphQL.js operates.