### PR TITLE
Distinguish between executing (a selection set) vs processing (a response)

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -8,7 +8,7 @@ A GraphQL service generates a response from a request via execution.
 - {document}: A {Document} which must contain GraphQL {OperationDefinition} and
   may contain {FragmentDefinition}.
 - {operationName} (optional): The name of the Operation in the Document to
-  process.
+  execute.
 - {variableValues} (optional): Values for any Variables defined by the
   Operation.
 - {initialValue} (optional): An initial value corresponding to the root type

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -66,9 +66,9 @@ GetOperation(document, operationName):
 ### Validating Requests
 
 As explained in the Validation section, only requests which pass all validation
-rules should be processed. If validation errors are known, they should be reported
-in the list of "errors" in the response and the request must fail without
-processing.
+rules should be processed. If validation errors are known, they should be
+reported in the list of "errors" in the response and the request must fail
+without processing.
 
 Typically validation is performed in the context of a request immediately before
 processing, however a GraphQL service may process a request without immediately

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -66,7 +66,7 @@ GetOperation(document, operationName):
 ### Validating Requests
 
 As explained in the Validation section, only requests which pass all validation
-rules should be process. If validation errors are known, they should be reported
+rules should be processed. If validation errors are known, they should be reported
 in the list of "errors" in the response and the request must fail without
 processing.
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -165,7 +165,7 @@ ProcessMutation(mutation, schema, variableValues, initialValue):
 
 If the operation is a subscription, the result is an _event stream_ called the
 _response stream_ where each event in the event stream is the result of
-executing the operation ’s root _selection set_ for each new event on an
+executing the operation’s root _selection set_ for each new event on an
 underlying _source stream_.
 
 Processing a subscription operation creates a persistent function on the service


### PR DESCRIPTION
This PR is based on https://github.com/graphql/graphql-spec/pull/1039 ("Replace ExecuteSelectionSet with ExecuteGroupedFieldSet")

See context in https://github.com/graphql/graphql-spec/pull/1152#discussion_r2016335214 and https://github.com/graphql/graphql-spec/pull/894

------

This PR clarifies that execution is for selection sets and fields. Requests and operations are "processed" instead. 

This is especially important for subscription that will execute their root selection set multiple times. It's also in line with variable coercion errors being "request errors" and not "execution errors"


