### PR TITLE
Allow `schema @behavior(onError: ...)` without explicit root operations

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -258,8 +258,11 @@ TypeSystemExtension :
 - SchemaExtension
 - TypeExtension
 
-SchemaDefinition : Description? schema Directives[Const]? {
-RootOperationTypeDefinition+ }
+SchemaDefinition :
+
+- Description? schema Directives[Const]? { RootOperationTypeDefinition+ }
+- Description? schema Directives[Const] [lookahead != `{`]
+- Description schema [lookahead != {`{`, `@`}]
 
 SchemaExtension :
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -227,8 +227,9 @@ The type system definition language can omit the schema definition entirely when
 all of the following hold:
 
 - each _root operation type_ uses its respective _default root type name_,
-- no other type uses any _default root type name_, and
-- the schema does not have a description.
+- no other type uses any _default root type name_,
+- the schema does not have a description, and
+- the schema uses the {"PROPAGATE"} _default error behavior_.
 
 Likewise, when representing a GraphQL schema using the type system definition
 language, a schema definition should be omitted if all of the above conditions
@@ -270,14 +271,17 @@ type Mutation {
 }
 ```
 
-This example describes a valid GraphQL schema with a description and both a
-{`query`} and {`mutation`} operation type:
+<!-- https://github.com/prettier/prettier/issues/17286 -->
+<!-- prettier-ignore -->
+This example describes a valid GraphQL schema with a description, _default
+error behavior_ of {"NO\_PROPAGATE"}, and both a {`query`} and {`mutation`}
+operation type:
 
 ```graphql example
 """
 Example schema
 """
-schema
+schema @behavior(onError: NO_PROPAGATE)
 
 type Query {
   someField: String
@@ -2216,7 +2220,5 @@ In this example, the schema indicates it is using the {"NO\_PROPAGATE"} _default
 error behavior_:
 
 ```graphql example
-schema @behavior(onError: NO_PROPAGATE) {
-  query: Query
-}
+schema @behavior(onError: NO_PROPAGATE)
 ```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -115,8 +115,11 @@ enum Language {
 
 ## Schema
 
-SchemaDefinition : Description? schema Directives[Const]? {
-RootOperationTypeDefinition+ }
+SchemaDefinition :
+
+- Description? schema Directives[Const]? { RootOperationTypeDefinition+ }
+- Description? schema Directives[Const] [lookahead != `{`]
+- Description schema [lookahead != {`{`, `@`}]
 
 RootOperationTypeDefinition : OperationType : NamedType
 
@@ -216,14 +219,22 @@ type MyMutationRootType {
 {`subscription`} _root operation type_ are {"Query"}, {"Mutation"}, and
 {"Subscription"} respectively.
 
-The type system definition language can omit the schema definition when each
-_root operation type_ uses its respective _default root type name_ and no other
-type uses any _default root type name_.
+The type system definition language can omit the schema definition's root
+operation type definitions when each _root operation type_ uses its respective
+_default root type name_ and no other type uses any _default root type name_.
+
+The type system definition language can omit the schema definition entirely when
+all of the following hold:
+
+- each _root operation type_ uses its respective _default root type name_,
+- no other type uses any _default root type name_, and
+- the schema does not have a description.
 
 Likewise, when representing a GraphQL schema using the type system definition
-language, a schema definition should be omitted if each _root operation type_
-uses its respective _default root type name_ and no other type uses any _default
-root type name_.
+language, a schema definition should be omitted if all of the above conditions
+hold; otherwise the schema definition's root operation type definitions should
+be omitted if each _root operation type_ uses its respective _default root type
+name_ and no other type uses any _default root type name_.
 
 This example describes a valid complete GraphQL schema, despite not explicitly
 including a {`schema`} definition. The {"Query"} type is presumed to be the
@@ -256,6 +267,24 @@ type Virus {
 
 type Mutation {
   name: String
+}
+```
+
+This example describes a valid GraphQL schema with a description and both a
+{`query`} and {`mutation`} operation type:
+
+```graphql example
+"""
+Example schema
+"""
+schema
+
+type Query {
+  someField: String
+}
+
+type Mutation {
+  someMutation: String
 }
 ```
 


### PR DESCRIPTION
This PR is rebased on #1163. It comprises of two commits. The first is from:

- #1166

The second includes the adjustments necessary to relate to:

- #1163 

Please see #1166 for details.