### PR TITLE
Add Transitional Non-Null appendix (`@noPropagate` directive)

### DIFF
--- a/spec/Appendix C -- Transitional Non-Null.md
+++ b/spec/Appendix C -- Transitional Non-Null.md
@@ -8,28 +8,23 @@ gradual migration toward semantic nullability while preserving compatibility.
 
 ## Overview
 
+With the introduction of _error behavior_, clients can take responsibility for
+handling of _execution error_: correlating {"errors"} in the result with `null`
+values inside {"data"} and thereby removing the ambiguity that error propagation
+originally set out to solve. If all clients adopt this approach then schema
+designers can, and should, reflect true nullability in the schema, marking
+fields as `Non-Null` based on their data semantics without regard to whether or
+not they might error.
 
-The introduction of _error behavior_ to this specification allows clients to
-take responsibility for error handling, no longer having the schema perform
-error propagation and destroying potentially useful response data in the
-process. With this move towards clients handling errors, designers of new
-schemas (or new fields in existing schemas) no longer need to factor whether or
-not a field is likely to error into its nullability; designers can mark a
-_semantically_ non-nullable _response position_ (a place where {null} is not a
-semantically valid value for the data) as `Non-Null`, writing a {null} there on
-error in the knowledge that the client now takes responsibility for handling
-errors and preventing these placeholder {null} values from being read.
+However, legacy clients may not perform this correlation. Introducing `Non-Null`
+in such cases could cause errors to propagate further, potentially turning a
+previously handled error in a single field into a full-screen error in the
+application.
 
-However, for schema designers that need to support legacy clients that do not
-exhibit these error handling properties, marking semantically non-nullable
-response positions as `Non-Null` would mean that more of the response would be
-destroyed for these clients on error, potentially turning local widget errors
-into full screen errors.
-
-To allow you to add `Non-Null` to existing fields during this transitional time,
-whilst the fields are still in use by legacy clients, without changing their
-error propagation boundaries, this appendix introduces the optional
-`@noPropagate` directive.
+To support a smooth transition, this appendix introduces the `@noPropagate`
+directive and the concept of _transitional_ Non-Null types. These wrappers raise
+errors like regular `Non-Null` types, but suppress propagation and appear
+nullable in introspection when using the legacy {"PROPAGATE"} _error behavior_.
 
 ## The @noPropagate Directive
 

--- a/spec/Appendix C -- Transitional Non-Null.md
+++ b/spec/Appendix C -- Transitional Non-Null.md
@@ -1,5 +1,7 @@
 # C. Appendix: Transitional Non-Null
 
+## Overview
+
 _This appendix defines an optional mechanism for marking fields as
 "transitionally non-null" to allow schema evolution without breaking error
 behavior for legacy clients. Implementations are not required to support this
@@ -28,7 +30,7 @@ whilst the fields are still in use by legacy clients, without changing their
 error propagation boundaries, this appendix introduces the optional
 `@noPropagate` directive.
 
-## @noPropagate
+## The @noPropagate Directive
 
 ```graphql
 directive @noPropagate(levels: [Int!]! = [0]) on FIELD_DEFINITION
@@ -50,7 +52,22 @@ For a field that does not return a list type you do not need to specify levels.
 If a field returns a list type and you wish to mark the inner type as
 `@noPropagate` only then you would provide `@noPropagate(levels: [1])`.
 
-Example:
+This example outlines how you might introduce semantic nullability into existing
+fields in your schema, to reduce the number of null checks your error-handling
+clients need to perform. Remember: new fields should reflect the semantic
+nullability immediately, they do not need the `@noPropagate` directive since
+there is no legacy to support.
+
+```diff example
+ type Query {
+-  myString: String
++  myString: String! @noPropagate
+-  myString2: String
++  myString2: String! @noPropagate(levels: [0])
+-  myList: [Int]!
++  myList: [Int!]! @noPropagate(levels: [1])
+ }
+```
 
 ```graphql example
 type Query {

--- a/spec/Appendix C -- Transitional Non-Null.md
+++ b/spec/Appendix C -- Transitional Non-Null.md
@@ -85,7 +85,7 @@ that behaves identically to Non-Null with two exceptions:
 2. When the _error behavior_ of the request is {"PROPAGATE"}, this _response
    position_ must be exposed as nullable in introspection.
 
-### Changes: Handling Execution Errors
+### Changes to Handling Execution Errors
 
 When interpreting the
 [Handling Execution Errors](#sec-Handling-Execution-Errors) and
@@ -95,7 +95,7 @@ if they were nullable types. This does not apply to {CompleteValue()} which
 should still raise an _execution error_ if {null} is returned for a Transitional
 Non-Null type.
 
-### Changes: Introspection
+### Changes to Introspection
 
 Note: Transitional Non-Null types do not appear in the type system as a distinct
 \_\_TypeKind. They are unwrapped to nullable types in introspection when the
@@ -122,7 +122,7 @@ The list must match the `levels` that would be passed to `@noPropagate` to
 describe the field’s transitional Non-Null wrappers, or `null` if no
 `@noPropagate` would be needed. It must not be an empty list.
 
-### Changes: Type System
+### Changes to the Type System
 
 When representing a GraphQL schema using the type system definition language,
 any field whose return type involves Transitional Non-Null types must indicate

--- a/spec/Appendix C -- Transitional Non-Null.md
+++ b/spec/Appendix C -- Transitional Non-Null.md
@@ -1,12 +1,13 @@
 # C. Appendix: Transitional Non-Null
 
+Note: This appendix defines an optional mechanism enabling existing fields to be
+marked as `Non-Null` for clients that opt out of error propagation without
+changing the error propagation boundaries for deployed legacy clients.
+Implementations are not required to support this feature, but doing so enables
+gradual migration toward semantic nullability while preserving compatibility.
+
 ## Overview
 
-_This appendix defines an optional mechanism for marking fields as
-"transitionally non-null" to allow schema evolution without breaking error
-behavior for legacy clients. Implementations are not required to support this
-feature, but doing so enables gradual migration toward semantic nullability
-while preserving compatibility._
 
 The introduction of _error behavior_ to this specification allows clients to
 take responsibility for error handling, no longer having the schema perform

--- a/spec/Appendix C -- Transitional Non-Null.md
+++ b/spec/Appendix C -- Transitional Non-Null.md
@@ -1,0 +1,116 @@
+# C. Appendix: Transitional Non-Null
+
+_This appendix defines an optional mechanism for marking fields as
+"transitionally non-null" to allow schema evolution without breaking error
+behavior for legacy clients. Implementations are not required to support this
+feature, but doing so enables gradual migration toward semantic nullability
+while preserving compatibility._
+
+The introduction of _error behavior_ to this specification allows clients to
+take responsibility for error handling, no longer having the schema perform
+error propagation and destroying potentially useful response data in the
+process. With this move towards clients handling errors, designers of new
+schemas (or new fields in existing schemas) no longer need to factor whether or
+not a field is likely to error into its nullability; designers can mark a
+_semantically_ non-nullable _response position_ (a place where {null} is not a
+semantically valid value for the data) as `Non-Null`, writing a {null} there on
+error in the knowledge that the client now takes responsibility for handling
+errors and preventing these placeholder {null} values from being read.
+
+However, for schema designers that need to support legacy clients that do not
+exhibit these error handling properties, marking semantically non-nullable
+response positions as `Non-Null` would mean that more of the response would be
+destroyed for these clients on error, potentially turning local widget errors
+into full screen errors.
+
+To allow you to add `Non-Null` to existing fields during this transitional time,
+whilst the fields are still in use by legacy clients, without changing their
+error propagation boundaries, this appendix introduces the optional
+`@noPropagate` directive.
+
+## @noPropagate
+
+```graphql
+directive @noPropagate(levels: [Int!]! = [0]) on FIELD_DEFINITION
+```
+
+The `@noPropagate` directive instructs the system to mark the non-null types at
+the given levels in the field's return type as "transitional" non-null types
+(see [Transitional Non-Null Type](#sec-Transitional-Non-Null-Type)).
+
+The `levels` argument identifies levels within the return type by counting each
+list wrapper. Level 0 refers to the base type; each nested list increases the
+level by 1 for its inner type. For the avoidance of doubt: `Non-Null` wrappers
+do not increase the count.
+
+If a listed level corresponds to a nullable type in the return type, it has no
+effect.
+
+For a field that does not return a list type you do not need to specify levels.
+If a field returns a list type and you wish to mark the inner type as
+`@noPropagate` only then you would provide `@noPropagate(levels: [1])`.
+
+Example:
+
+```graphql example
+type Query {
+  myString: String! @noPropagate
+  # Equivalent to the above
+  myString2: String! @noPropagate(levels: [0])
+  myList: [Int!]! @noPropagate(levels: [1])
+}
+```
+
+## Transitional Non-Null
+
+A "transitional" Non-Null type is a variant of a [Non-Null](#sec-Non-Null) type
+that behaves identically to Non-Null with two exceptions:
+
+1. If an _execution error_ occurs in this response position, the error does not
+   propagate to the parent _response position_, instead the response position is
+   set to {null}.
+2. When the _error behavior_ of the request is {"PROPAGATE"}, this _response
+   position_ must be exposed as nullable in introspection.
+
+### Changes: Handling Execution Errors
+
+When interpreting the
+[Handling Execution Errors](#sec-Handling-Execution-Errors) and
+[Errors and Non-Null Types](#sec-Executing-Selection-Sets.Errors-and-Non-Null-Types)
+sections of the specification, Transitional Non-Null types should be treated as
+if they were nullable types. This does not apply to {CompleteValue()} which
+should still raise an _execution error_ if {null} is returned for a Transitional
+Non-Null type.
+
+### Changes: Introspection
+
+Note: Transitional Non-Null types do not appear in the type system as a distinct
+\_\_TypeKind. They are unwrapped to nullable types in introspection when the
+error behavior is {"PROPAGATE"}, and appear as {"NON_NULL"} otherwise.
+
+**\_\_Field.type**
+
+When the request _error behavior_ is {"PROPAGATE"}, the `type` field on the
+`__Field` introspection type must return a `__Type` that represents the type of
+value returned by this field with the transitional Non-Null wrapper types
+unwrapped at every level.
+
+**\_\_Field.noPropagateLevels**
+
+This additional field should be added to introspection:
+
+```graphql
+extend type __Field {
+  noPropagateLevels: [Int!]
+}
+```
+
+The list must match the `levels` that would be passed to `@noPropagate` to
+describe the field’s transitional Non-Null wrappers, or `null` if no
+`@noPropagate` would be needed. It must not be an empty list.
+
+### Changes: Type System
+
+When representing a GraphQL schema using the type system definition language,
+any field whose return type involves Transitional Non-Null types must indicate
+this via the `@noPropagate` directive.

--- a/spec/GraphQL.md
+++ b/spec/GraphQL.md
@@ -139,3 +139,5 @@ Note: This is an example of a non-normative note.
 # [Appendix: Notation Conventions](Appendix%20A%20--%20Notation%20Conventions.md)
 
 # [Appendix: Grammar Summary](Appendix%20B%20--%20Grammar%20Summary.md)
+
+# [Appendix: Transitional Non-Null](Appendix%20C%20--%20Transitional%20Non-Null.md)


### PR DESCRIPTION
This is essentially solution 8 to the [Semantic Nullability RFC](https://github.com/graphql/graphql-wg/blob/main/rfcs/SemanticNullability.md):

- Enables **semantic nullability** to be reflected in schemas without breaking legacy behavior.
- Facilitates **incremental adoption** of modern error handling without requiring disruptive changes.
- Requires **minimal spec impact** and is fully optional for implementations.
- Reflects **transitional nature** of this change in behavior

I've based it on:

- #1163 

since, like all solutions to the semantic nullability problem[^1], it is designed to enable clients with error propagation disabled to leverage the true nullability of the underlying data without breaking legacy clients. The approach could be rebuilt atop an alternative method of toggling error propagation, for example a directive-based approach.

[^1]: Except solution 5

---

This PR introduces an appendix to the GraphQL specification defining an optional solution to the semantic nullability problem using the following key mechanisms:

- **`@noPropagate`[^2] directive** — allows schema authors to annotate `Non-Null` return types as *transitional*, suppressing propagation but preserving runtime error generation.
- **Transitional Non-Null semantics** — errors at these positions behave like nullable fields in terms of (no!) propagation but like non-nullable fields in value completion (error on null).
- **New `__Field.noPropagateLevels: [Int!]` field** — exposes transitional status to modern clients.
- **Transitional non-null hidden from legacy clients** — tooling using the legacy `PROPAGATE` _error behavior_ will get results from `__Field.type` that unwrap transitional non-null types.[^3]

[^2]: This is essentially the same as the `@semanticNonNull` directive, but more strictly defined and reflected through introspection.

This solution attempts to address all of the feedback on previous solutions to this problem, whilst being explicitly transitional. It:

- Is optional: explicitly only for schemas supporting legacy clients
- Requires no changes to the main spec text
- Introduces no new syntax
- True to its name: an error here will not propagate (`@noPropagate`), regardless of whether error propagation is enabled or disabled.
- Maintains introspection results for existing (deployed) clients and tooling
- Maintains error boundaries for existing (deployed) clients
- Allows all new schemas and new fields to use `!` (non-null) directly for semantically non-null positions
- Allows existing fields to use `!` (non-null) for error handling clients without breaking legacy clients by adding the `@noPropagate` directive[^4]
- Can be adopted gradually, field-by-field, or en masse by applying `@noPropagate` to all nullable positions.
- Can be removed from each field the moment no legacy clients query it


[^3]: This may be controversial, but I truly think it's the right decision. All new tooling (and all new clients!) should use `onError: ABORT` or `onError: NO_PROPAGATE`, and thus will see the true introspection. Existing tooling doesn't know about `onError` and so should not see these "transitional" non-null types.
[^4]: And if you forget to add it, adding it later is only a potentially breaking change for any new versions of legacy clients deployed since the change; error-handling clients (`NO_PROPAGATE` or `ABORT`) are unimpacted.