### PR TITLE
Enable 'schema' keyword to be provided without root operations

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -258,8 +258,11 @@ TypeSystemExtension :
 - SchemaExtension
 - TypeExtension
 
-SchemaDefinition : Description? schema Directives[Const]? {
-RootOperationTypeDefinition+ }
+SchemaDefinition :
+
+- Description? schema Directives[Const]? { RootOperationTypeDefinition+ }
+- Description? schema Directives[Const] [lookahead != `{`]
+- Description schema [lookahead != {`{`, `@`}]
 
 SchemaExtension :
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -115,8 +115,11 @@ enum Language {
 
 ## Schema
 
-SchemaDefinition : Description? schema Directives[Const]? {
-RootOperationTypeDefinition+ }
+SchemaDefinition :
+
+- Description? schema Directives[Const]? { RootOperationTypeDefinition+ }
+- Description? schema Directives[Const] [lookahead != `{`]
+- Description schema [lookahead != {`{`, `@`}]
 
 RootOperationTypeDefinition : OperationType : NamedType
 
@@ -216,14 +219,22 @@ type MyMutationRootType {
 {`subscription`} _root operation type_ are {"Query"}, {"Mutation"}, and
 {"Subscription"} respectively.
 
-The type system definition language can omit the schema definition when each
-_root operation type_ uses its respective _default root type name_ and no other
-type uses any _default root type name_.
+The type system definition language can omit the schema definition's root
+operation type definitions when each _root operation type_ uses its respective
+_default root type name_ and no other type uses any _default root type name_.
+
+The type system definition language can omit the schema definition entirely when
+all of the following hold:
+
+- each _root operation type_ uses its respective _default root type name_,
+- no other type uses any _default root type name_, and
+- the schema does not have a description.
 
 Likewise, when representing a GraphQL schema using the type system definition
-language, a schema definition should be omitted if each _root operation type_
-uses its respective _default root type name_ and no other type uses any _default
-root type name_.
+language, a schema definition should be omitted if all of the above conditions
+hold; otherwise the schema definition's root operation type definitions should
+be omitted if each _root operation type_ uses its respective _default root type
+name_ and no other type uses any _default root type name_.
 
 This example describes a valid complete GraphQL schema, despite not explicitly
 including a {`schema`} definition. The {"Query"} type is presumed to be the
@@ -256,6 +267,24 @@ type Virus {
 
 type Mutation {
   name: String
+}
+```
+
+This example describes a valid GraphQL schema with a description and both a
+{`query`} and {`mutation`} operation type:
+
+```graphql example
+"""
+Example schema
+"""
+schema
+
+type Query {
+  someField: String
+}
+
+type Mutation {
+  someMutation: String
 }
 ```
 


### PR DESCRIPTION
This PR is motivated by:

- #1163 

In the above PR we want to be able to indicate the error propagation behavior of a schema. However, I find it displeasing that to do so we would need to also explicitly detail the operations supported by the schema when they would normally be auto-detected based on their names:

```diff
+schema @behavior(onError: NO_PROPAGATE) {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
 type Query {
   q: Int
 }

 type Mutation {
   m: Int
 }

 type Subscription {
   s: Int
 }
```

This PR makes it so that you can use a schema keyword to add directives and/or description to the schema without needing to also specify the root operation types if they can be inferred by the default naming. The above diff would thus become:

```diff
+schema @behavior(onError: NO_PROPAGATE)
+
 type Query {
   q: Int
 }

 type Mutation {
   m: Int
 }

 type Subscription {
   s: Int
 }
```

Much nicer! :sparkles: 

This is also useful without the `onError` feature, since it allows you to apply a description to a schema without having to detail the operations:

```diff
+"""Just an example"""
+schema
+
 type Query {
   q: Int
 }

 type Mutation {
   m: Int
 }

 type Subscription {
   s: Int
 }
```

PR #1164 applies these changes onto #1163; but this PR is mergeable into the spec as-is.