### PR TITLE
Add 'Assert' consistency to algorithm format check

### DIFF
--- a/.github/algorithm-format-check.mjs
+++ b/.github/algorithm-format-check.mjs
@@ -28,7 +28,7 @@ for (const filename of filenames) {
       const matches = line.match(/^([a-z0-9A-Z]+)(\s*)\(([^)]*)\)(\s*):(\s*)$/);
       const grammarMatches =
         filename === "Section 2 -- Language.md" &&
-        line.match(/^([A-Za-z0-9]+) :\s+((\S).*)$/);
+        line.match(/^([A-Za-z0-9]+) ::?\s+((\S).*)$/);
       if (matches) {
         const [, algorithmName, ns1, _args, ns2, ns3] = matches;
         if (ns1 || ns2 || ns3) {
@@ -139,6 +139,10 @@ for (const filename of filenames) {
           );
           console.log();
           process.exitCode = 1;
+        }
+        while (lines[i + 1].trim() !== "") {
+          // Continuation of definition
+          i++;
         }
         if (!lines[i + 2].startsWith("- ")) {
           // Not an algorithm; probably more grammar

--- a/.github/algorithm-format-check.mjs
+++ b/.github/algorithm-format-check.mjs
@@ -189,6 +189,15 @@ for (const filename of filenames) {
             console.log();
             process.exitCode = 1;
           }
+          const assertMatch = step.match(/^\s*(-|[0-9]+\.)\s*Assert([^:])/);
+          if (assertMatch) {
+            console.log(
+              `Bad formatting of '${grammarName}' step (Assert should be immediately followed by ':'; found '${assertMatch[2]}') in '${filename}':`
+            );
+            console.dir(step);
+            console.log();
+            process.exitCode = 1;
+          }
         }
       }
     }

--- a/.github/algorithm-format-check.mjs
+++ b/.github/algorithm-format-check.mjs
@@ -67,9 +67,18 @@ for (const filename of filenames) {
             console.log();
             process.exitCode = 1;
           }
-          if (step.match(/^\s*(-|[0-9]\.)\s+[a-z]/)) {
+          if (step.match(/^\s*(-|[0-9]+\.)\s+[a-z]/)) {
             console.log(
               `Bad formatting of '${algorithmName}' step (should start with a capital) in '${filename}':`
+            );
+            console.dir(step);
+            console.log();
+            process.exitCode = 1;
+          }
+          const assertMatch = step.match(/^\s*(-|[0-9]+\.)\s*Assert([^:])/);
+          if (assertMatch) {
+            console.log(
+              `Bad formatting of '${algorithmName}' step (Assert should be immediately followed by ':'; found '${assertMatch[2]}') in '${filename}':`
             );
             console.dir(step);
             console.log();

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -972,7 +972,7 @@ StringCharacter :: `\u` EscapedUnicode
 
 - Let {value} be the hexadecimal value represented by the sequence of {HexDigit}
   within {EscapedUnicode}.
-- Assert {value} is a within the _Unicode scalar value_ range (>= 0x0000 and <=
+- Assert: {value} is a within the _Unicode scalar value_ range (>= 0x0000 and <=
   0xD7FF or >= 0xE000 and <= 0x10FFFF).
 - Return the _Unicode scalar value_ {value}.
 
@@ -984,12 +984,12 @@ HexDigit HexDigit HexDigit
 - Let {trailingValue} be the hexadecimal value represented by the second
   sequence of {HexDigit}.
 - If {leadingValue} is >= 0xD800 and <= 0xDBFF (a _Leading Surrogate_):
-  - Assert {trailingValue} is >= 0xDC00 and <= 0xDFFF (a _Trailing Surrogate_).
+  - Assert: {trailingValue} is >= 0xDC00 and <= 0xDFFF (a _Trailing Surrogate_).
   - Return ({leadingValue} - 0xD800) × 0x400 + ({trailingValue} - 0xDC00) +
     0x10000.
 - Otherwise:
-  - Assert {leadingValue} is within the _Unicode scalar value_ range.
-  - Assert {trailingValue} is within the _Unicode scalar value_ range.
+  - Assert: {leadingValue} is within the _Unicode scalar value_ range.
+  - Assert: {trailingValue} is within the _Unicode scalar value_ range.
   - Return the sequence of the _Unicode scalar value_ {leadingValue} followed by
     the _Unicode scalar value_ {trailingValue}.
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -757,7 +757,7 @@ coerce result values.
 
 CoerceResult(leafType, value):
 
-- Assert {value} is not {null}.
+- Assert: {value} is not {null}.
 - Return the result of calling the internal method provided by the type system
   for determining the "result coercion" of {leafType} given the value {value}.
   This internal method must return a valid value for the type and not {null}.


### PR DESCRIPTION
We have a mixture of `- Assert: blah` and `- Assert blah`. We should standardize on one pattern; this adds it to the spec format checks. (It also fixes some minor bugs in the script itself.)