### PR TITLE
Add descriptions to executable documents | 2025 Update

### DIFF
--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -133,6 +133,8 @@ lines and uniform indentation with {BlockStringValue()}.
 
 ## Document Syntax
 
+Description : StringValue
+
 Document : Definition+
 
 Definition :
@@ -146,8 +148,6 @@ ExecutableDefinition :
 
 - OperationDefinition
 - FragmentDefinition
-
-Description : StringValue
 
 OperationDefinition :
 

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -147,9 +147,11 @@ ExecutableDefinition :
 - OperationDefinition
 - FragmentDefinition
 
+Description : StringValue
+
 OperationDefinition :
 
-- OperationType Name? VariablesDefinition? Directives? SelectionSet
+- Description? OperationType Name? VariablesDefinition? Directives? SelectionSet
 - SelectionSet
 
 OperationType : one of `query` `mutation` `subscription`
@@ -174,7 +176,7 @@ FragmentSpread : ... FragmentName Directives?
 
 InlineFragment : ... TypeCondition? Directives? SelectionSet
 
-FragmentDefinition : fragment FragmentName TypeCondition Directives?
+FragmentDefinition : Description? fragment FragmentName TypeCondition Directives?
 SelectionSet
 
 FragmentName : Name but not `on`
@@ -213,7 +215,7 @@ ObjectField[Const] : Name : Value[?Const]
 
 VariablesDefinition : ( VariableDefinition+ )
 
-VariableDefinition : Variable : Type DefaultValue? Directives[Const]?
+VariableDefinition : Description? Variable : Type DefaultValue? Directives[Const]?
 
 Variable : $ Name
 
@@ -267,8 +269,6 @@ SchemaExtension :
 - extend schema Directives[Const] [lookahead != `{`]
 
 RootOperationTypeDefinition : OperationType : NamedType
-
-Description : StringValue
 
 TypeDefinition :
 

--- a/spec/Appendix B -- Grammar Summary.md
+++ b/spec/Appendix B -- Grammar Summary.md
@@ -176,8 +176,8 @@ FragmentSpread : ... FragmentName Directives?
 
 InlineFragment : ... TypeCondition? Directives? SelectionSet
 
-FragmentDefinition : Description? fragment FragmentName TypeCondition Directives?
-SelectionSet
+FragmentDefinition : Description? fragment FragmentName TypeCondition
+Directives? SelectionSet
 
 FragmentName : Name but not `on`
 
@@ -215,7 +215,8 @@ ObjectField[Const] : Name : Value[?Const]
 
 VariablesDefinition : ( VariableDefinition+ )
 
-VariableDefinition : Description? Variable : Type DefaultValue? Directives[Const]?
+VariableDefinition : Description? Variable : Type DefaultValue?
+Directives[Const]?
 
 Variable : $ Name
 

--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -63,7 +63,7 @@ GraphQL has a number of design principles:
   endpoints. A GraphQL response, on the other hand, contains exactly what a
   client asks for and no more.
 
-- **Introspective**: GraphQL is introspective and self-describing. A GraphQL
+- **Self-describing**: GraphQL is self-describing and introspective. A GraphQL
   service's type system can be queryable by the GraphQL language itself, which
   includes readable documentation. GraphQL introspection serves as a powerful
   platform for building common developer tools and client software libraries.

--- a/spec/Section 1 -- Overview.md
+++ b/spec/Section 1 -- Overview.md
@@ -63,10 +63,10 @@ GraphQL has a number of design principles:
   endpoints. A GraphQL response, on the other hand, contains exactly what a
   client asks for and no more.
 
-- **Introspective**: GraphQL is introspective. A GraphQL service's type system
-  can be queryable by the GraphQL language itself, as will be described in this
-  specification. GraphQL introspection serves as a powerful platform for
-  building common tools and client software libraries.
+- **Introspective**: GraphQL is introspective and self-describing. A GraphQL
+  service's type system can be queryable by the GraphQL language itself, which
+  includes readable documentation. GraphQL introspection serves as a powerful
+  platform for building common developer tools and client software libraries.
 
 Because of these principles, GraphQL is a powerful and productive environment
 for building client applications. Product developers and designers building

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -238,80 +238,16 @@ defined by this specification.
 Description : StringValue
 
 Documentation is a first-class feature of GraphQL by encouraging written
-descriptions on all named definitions in both a GraphQL schema
-{TypeSystemDocument} and an executable {Document}. GraphQL descriptions are
-expected to provided as Markdown (as specified by
+descriptions on all named definitions in executable {Document} and GraphQL type
+systems, which is also made available via introspection ensuring the
+documentation of a GraphQL service remains consistent with its capabilities (see
+[Type System Descriptions](#sec-Type-System-Descriptions)).
+
+GraphQL descriptions are expected to provided as Markdown (as specified by
 [CommonMark](https://commonmark.org/)). Description strings (often
-{BlockString}) occur immediately before the named definition they describe.
+{BlockString}) occur immediately before the definition they describe.
 
-Descriptions in type system definitions are made available via introspection,
-ensuring the documentation of a GraphQL service remains consistent with its
-capabilities.
-
-Descriptions may appear before:
-
-**In type system definitions:**
-
-- Schema definitions.
-- Type definitions (scalars, objects, interfaces, unions, enums, input objects).
-- Field definitions.
-- Argument definitions.
-- Enum value definitions.
-- Input field definitions.
-- Directive definitions.
-
-**In executable documents:**
-
-- Operation definitions (queries, mutations, subscriptions) in their full form
-  (not the shorthand form).
-- Fragment definitions.
-- Variable definitions within operation definitions.
-
-As an example, this simple GraphQL schema is well described:
-
-```raw graphql example
-"""
-A simple GraphQL schema which is well described.
-"""
-schema {
-  query: Query
-}
-
-"""
-Root type for all your query operations
-"""
-type Query {
-  """
-  Translates a string from a given language into a different language.
-  """
-  translate(
-    "The original language that `text` is provided in."
-    fromLanguage: Language
-
-    "The translated language to be returned."
-    toLanguage: Language
-
-    "The text to be translated."
-    text: String
-  ): String
-}
-
-"""
-The set of languages supported by `translate`.
-"""
-enum Language {
-  "English"
-  EN
-
-  "French"
-  FR
-
-  "Chinese"
-  CH
-}
-```
-
-This is an example of a well-described executable document:
+This is an example of a well-described operation:
 
 ```graphql example
 """
@@ -343,26 +279,11 @@ fragment TimeMachineDetails on TimeMachine {
 }
 ```
 
-Descriptions are not permitted on the shorthand form of operations:
-
-```graphql counter-example
-"This description is invalid, because this is a shorthand operation definition"
-{
-  timeMachine(id: "TM-1985") {
-    status
-    destination {
-      year
-      location
-    }
-  }
-}
-```
-
-Note: Descriptions and comments in executable GraphQL documents are purely for
+Descriptions and comments in executable GraphQL documents are purely for
 documentation purposes. They MUST NOT affect the execution, validation, or
-response of a GraphQL document except for type and schema introspection. It is
-otherwise safe to remove all descriptions and comments from executable documents
-without changing their behavior or results.
+response of a GraphQL document except for type introspection. It is otherwise
+safe to remove all descriptions and comments from executable documents without
+changing their behavior or results.
 
 ## Document
 
@@ -456,6 +377,8 @@ For example, this unnamed query operation is written via query shorthand.
   field
 }
 ```
+
+Descriptions are not permitted on query shorthand.
 
 Note: many examples below will use the query short-hand syntax.
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -360,7 +360,6 @@ documentation purposes. They MUST NOT affect the execution, validation, or
 response of a GraphQL document. It is safe to remove all descriptions and
 comments from executable documents without changing their behavior or results.
 
-
 ## Operations
 
 OperationDefinition :

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -300,43 +300,33 @@ Request the current status of a time machine and its operator.
 This operation retrieves the latest information about a specific time machine,
 including its model, last maintenance date, and the operator currently assigned.
 
-You can also check the status for a particular year, to see if the time machine
-was scheduled for travel or maintenance at that time.
+You can also check the status for a particular year.
+
+**Warning:** certain years may trigger an anomaly in the space-time continuum. Use with caution!
 """
 query GetTimeMachineStatus(
   "The unique serial number of the time machine to inspect."
   $machineId: ID!
-
-  """
-  The year to check the status for.
-  **Warning:** Requesting status information for certain years may trigger an anomaly in the space-time continuum.
-  """
+  "The year to check the status for."
   $year: Int
 ) {
   timeMachine(id: $machineId) {
     ...TimeMachineDetails
-    operator {
-      ...OperatorDetails
-    }
     status(year: $year)
   }
 }
 
 """
-Time machine details.
+Details about a time machine and its operator.
 """
 fragment TimeMachineDetails on TimeMachine {
   id
   model
   lastMaintenance
-}
-
-"""
-Basic information about a time machine operator.
-"""
-fragment OperatorDetails on Operator {
-  name
-  licenseLevel
+  operator {
+    name
+    licenseLevel
+  }
 }
 ```
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -291,18 +291,11 @@ Descriptions may appear before:
 - Fragment definitions.
 - Variable definitions within operation definitions.
 
-Example:
-
 ```graphql example
 """
 Request the current status of a time machine and its operator.
-
-This operation retrieves the latest information about a specific time machine,
-including its model, last maintenance date, and the operator currently assigned.
-
 You can also check the status for a particular year.
-
-**Warning:** certain years may trigger an anomaly in the space-time continuum. Use with caution!
+**Warning:** certain years may trigger an anomaly in the space-time continuum.
 """
 query GetTimeMachineStatus(
   "The unique serial number of the time machine to inspect."
@@ -316,9 +309,7 @@ query GetTimeMachineStatus(
   }
 }
 
-"""
-Details about a time machine and its operator.
-"""
+"Details about a time machine and its operator."
 fragment TimeMachineDetails on TimeMachine {
   id
   model

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -287,6 +287,7 @@ defined using the Markdown syntax (as specified by
 Descriptions may appear before:
 
 **In type system definitions:**
+
 - Schema definitions.
 - Type definitions (scalars, objects, interfaces, unions, enums, input objects).
 - Field definitions.
@@ -296,6 +297,7 @@ Descriptions may appear before:
 - Directive definitions.
 
 **In executable documents:**
+
 - Operation definitions (queries, mutations, subscriptions) in their full form
   (not the shorthand form).
 - Fragment definitions.

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -301,7 +301,7 @@ comments from executable documents without changing their behavior or results.
 
 Example:
 
-```graphql
+```graphql example
 "Some description"
 query SomeOperation(
   "ID you should provide"

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -640,7 +640,7 @@ query withFragments {
   }
 }
 
-"""Common fields for a user's friends."""
+"Common fields for a user's friends."
 fragment friendFields on User {
   id
   name
@@ -1273,7 +1273,7 @@ particular device:
 
 ```graphql example
 query getZuckProfile(
-  """The size of the profile picture to fetch."""
+  "The size of the profile picture to fetch."
   $devicePicSize: Int
 ) {
   user(id: 4) {

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -291,52 +291,75 @@ Descriptions may appear before:
 - Fragment definitions.
 - Variable definitions within operation definitions.
 
-Descriptions are not permitted on the shorthand form of operations (e.g.,
-`{ ... }`).
+Example:
+
+```graphql example
+"""
+Request the current status of a time machine and its operator.
+
+This operation retrieves the latest information about a specific time machine,
+including its model, last maintenance date, and the operator currently assigned.
+
+You can also check the status for a particular year, to see if the time machine
+was scheduled for travel or maintenance at that time.
+"""
+query GetTimeMachineStatus(
+  "The unique serial number of the time machine to inspect."
+  $machineId: ID!
+
+  """
+  The year to check the status for.
+  **Warning:** Requesting status information for certain years may trigger an anomaly in the space-time continuum.
+  """
+  $year: Int
+) {
+  timeMachine(id: $machineId) {
+    ...TimeMachineDetails
+    operator {
+      ...OperatorDetails
+    }
+    status(year: $year)
+  }
+}
+
+"""
+Time machine details.
+"""
+fragment TimeMachineDetails on TimeMachine {
+  id
+  model
+  lastMaintenance
+}
+
+"""
+Basic information about a time machine operator.
+"""
+fragment OperatorDetails on Operator {
+  name
+  licenseLevel
+}
+```
+
+Descriptions are not permitted on the shorthand form of operations:
+
+```graphql counter-example
+"This description is invalid, because this is a shorthand operation definition"
+{
+  timeMachine(id: "TM-1985") {
+    status
+    destination {
+      year
+      location
+    }
+  }
+}
+```
 
 Note: Descriptions and comments in executable GraphQL documents are purely for
 documentation purposes. They MUST NOT affect the execution, validation, or
 response of a GraphQL document. It is safe to remove all descriptions and
 comments from executable documents without changing their behavior or results.
 
-Example:
-
-```graphql example
-"Some description"
-query SomeOperation(
-  "ID you should provide"
-  $id: String
-
-  "Switch for experiment ...."
-  $enableBaz: Boolean = false,
-) {
-  foo(id: $id) {
-    bar
-    baz @include(if: $enableBaz) {
-      ...BazInfo
-    }
-  }
-}
-
-"Some description here"
-fragment BazInfo on Baz {
-  # ...
-}
-```
-
-Counterexample:
-
-```graphql counter-example
-"Descriptions are not permitted on the shorthand form of operations"
-{
-  foo {
-    bar
-    baz {
-      ...BazInfo
-    }
-  }
-}
-```
 
 ## Operations
 
@@ -361,6 +384,10 @@ For example, this mutation operation might "like" a story and then retrieve the
 new number of likes:
 
 ```graphql example
+"""
+Mark story 12345 as "liked"
+and return the updated number of likes on the story
+"""
 mutation {
   likeStory(storyID: 12345) {
     story {
@@ -633,6 +660,7 @@ query withFragments {
   }
 }
 
+"""Common fields for a user's friends."""
 fragment friendFields on User {
   id
   name
@@ -1263,7 +1291,10 @@ In this example, we want to fetch a profile picture size based on the size of a
 particular device:
 
 ```graphql example
-query getZuckProfile($devicePicSize: Int) {
+query getZuckProfile(
+  """The size of the profile picture to fetch."""
+  $devicePicSize: Int
+) {
   user(id: 4) {
     id
     name

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -286,10 +286,66 @@ defined using the Markdown syntax (as specified by
 
 Descriptions may appear before:
 
+**In type system definitions:**
+- Schema definitions.
+- Type definitions (scalars, objects, interfaces, unions, enums, input objects).
+- Field definitions.
+- Argument definitions.
+- Enum value definitions.
+- Input field definitions.
+- Directive definitions.
+
+**In executable documents:**
 - Operation definitions (queries, mutations, subscriptions) in their full form
   (not the shorthand form).
 - Fragment definitions.
 - Variable definitions within operation definitions.
+
+As an example, this simple GraphQL schema is well described:
+
+```raw graphql example
+"""
+A simple GraphQL schema which is well described.
+"""
+schema {
+  query: Query
+}
+
+"""
+Root type for all your query operations
+"""
+type Query {
+  """
+  Translates a string from a given language into a different language.
+  """
+  translate(
+    "The original language that `text` is provided in."
+    fromLanguage: Language
+
+    "The translated language to be returned."
+    toLanguage: Language
+
+    "The text to be translated."
+    text: String
+  ): String
+}
+
+"""
+The set of languages supported by `translate`.
+"""
+enum Language {
+  "English"
+  EN
+
+  "French"
+  FR
+
+  "Chinese"
+  CH
+}
+```
+
+This is an example of a well-described executable document:
 
 ```graphql example
 """
@@ -340,6 +396,10 @@ Note: Descriptions and comments in executable GraphQL documents are purely for
 documentation purposes. They MUST NOT affect the execution, validation, or
 response of a GraphQL document. It is safe to remove all descriptions and
 comments from executable documents without changing their behavior or results.
+
+Descriptions in type system definitions are made available via introspection,
+ensuring the documentation of a GraphQL service remains consistent with its
+capabilities.
 
 ## Operations
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -279,20 +279,70 @@ be executed must also be provided.
 
 Description : StringValue
 
-Documentation is a first-class feature of GraphQL.
-GraphQL descriptions are defined using the Markdown syntax (as specified by
-[CommonMark](https://commonmark.org/)). Description strings (often {BlockString})
-occur immediately before the definition they describe.
+Documentation is a first-class feature of GraphQL. GraphQL descriptions are
+defined using the Markdown syntax (as specified by
+[CommonMark](https://commonmark.org/)). Description strings (often
+{BlockString}) occur immediately before the definition they describe.
 
-GraphQL definitions (e.g. queries, fragments, types, fields, arguments, etc.)
-which can be described should provide a {Description} unless they are considered
-self descriptive.
+Descriptions may appear before:
+
+- Operation definitions (queries, mutations, subscriptions) in their full form
+  (not the shorthand form).
+- Fragment definitions.
+- Variable definitions within operation definitions.
+
+Descriptions are not permitted on the shorthand form of operations (e.g.,
+`{ ... }`).
+
+Note: Descriptions and comments in executable GraphQL documents are purely for
+documentation purposes. They MUST NOT affect the execution, validation, or
+response of a GraphQL document. It is safe to remove all descriptions and
+comments from executable documents without changing their behavior or results.
+
+Example:
+
+```graphql
+"Some description"
+query SomeOperation(
+  "ID you should provide"
+  $id: String
+
+  "Switch for experiment ...."
+  $enableBaz: Boolean = false,
+) {
+  foo(id: $id) {
+    bar
+    baz @include(if: $enableBaz) {
+      ...BazInfo
+    }
+  }
+}
+
+"Some description here"
+fragment BazInfo on Baz {
+  # ...
+}
+```
+
+Counterexample:
+
+```graphql counter-example
+"Descriptions are not permitted on the shorthand form of operations"
+{
+  foo {
+    bar
+    baz {
+      ...BazInfo
+    }
+  }
+}
+```
 
 ## Operations
 
 OperationDefinition :
 
-- OperationType Name? VariablesDefinition? Directives? SelectionSet
+- Description? OperationType Name? VariablesDefinition? Directives? SelectionSet
 - SelectionSet
 
 OperationType : one of `query` `mutation` `subscription`

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -613,8 +613,8 @@ which returns the result:
 
 FragmentSpread : ... FragmentName Directives?
 
-FragmentDefinition : fragment FragmentName TypeCondition Directives?
-SelectionSet
+FragmentDefinition : Description? fragment FragmentName TypeCondition
+Directives? SelectionSet
 
 FragmentName : Name but not `on`
 
@@ -1272,7 +1272,8 @@ Variable : $ Name
 
 VariablesDefinition : ( VariableDefinition+ )
 
-VariableDefinition : Variable : Type DefaultValue? Directives[Const]?
+VariableDefinition : Description? Variable : Type DefaultValue?
+Directives[Const]?
 
 DefaultValue : = Value[Const]
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -275,6 +275,19 @@ operations, each operation must be named. When submitting a Document with
 multiple operations to a GraphQL service, the name of the desired operation to
 be executed must also be provided.
 
+## Descriptions
+
+Description : StringValue
+
+Documentation is a first-class feature of GraphQL.
+GraphQL descriptions are defined using the Markdown syntax (as specified by
+[CommonMark](https://commonmark.org/)). Description strings (often {BlockString})
+occur immediately before the definition they describe.
+
+GraphQL definitions (e.g. queries, fragments, types, fields, arguments, etc.)
+which can be described should provide a {Description} unless they are considered
+self descriptive.
+
 ## Operations
 
 OperationDefinition :

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -237,13 +237,13 @@ defined by this specification.
 
 Description : StringValue
 
-Documentation is a first-class feature of GraphQL by encouraging written
+Documentation is a first-class feature of GraphQL by including written
 descriptions on all named definitions in executable {Document} and GraphQL type
 systems, which is also made available via introspection ensuring the
 documentation of a GraphQL service remains consistent with its capabilities (see
 [Type System Descriptions](#sec-Type-System-Descriptions)).
 
-GraphQL descriptions are expected to provided as Markdown (as specified by
+GraphQL descriptions are provided as Markdown (as specified by
 [CommonMark](https://commonmark.org/)). Description strings (often
 {BlockString}) occur immediately before the definition they describe.
 
@@ -279,11 +279,10 @@ fragment TimeMachineDetails on TimeMachine {
 }
 ```
 
-Descriptions and comments in executable GraphQL documents are purely for
-documentation purposes. They MUST NOT affect the execution, validation, or
-response of a GraphQL document except for type introspection. It is otherwise
-safe to remove all descriptions and comments from executable documents without
-changing their behavior or results.
+Descriptions in GraphQL executable documents are purely for documentation
+purposes. They MUST NOT affect the execution, validation, or response of a
+GraphQL document. It is safe to remove all descriptions and comments from
+executable documents without changing their behavior or results.
 
 ## Document
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -233,56 +233,20 @@ Any {Name} within a GraphQL type system must not start with two underscores
 {"\_\_"} unless it is part of the [introspection system](#sec-Introspection) as
 defined by this specification.
 
-## Document
-
-Document : Definition+
-
-Definition :
-
-- ExecutableDefinition
-- TypeSystemDefinitionOrExtension
-
-ExecutableDocument : ExecutableDefinition+
-
-ExecutableDefinition :
-
-- OperationDefinition
-- FragmentDefinition
-
-A GraphQL Document describes a complete file or request string operated on by a
-GraphQL service or client. A document contains multiple definitions, either
-executable or representative of a GraphQL type system.
-
-Documents are only executable by a GraphQL service if they are
-{ExecutableDocument} and contain at least one {OperationDefinition}. A Document
-which contains {TypeSystemDefinitionOrExtension} must not be executed; GraphQL
-execution services which receive a Document containing these should return a
-descriptive error.
-
-GraphQL services which only seek to execute GraphQL requests and not construct a
-new GraphQL schema may choose to only permit {ExecutableDocument}.
-
-Documents which do not contain {OperationDefinition} or do contain
-{TypeSystemDefinitionOrExtension} may still be parsed and validated to allow
-client tools to represent many GraphQL uses which may appear across many
-individual files.
-
-If a Document contains only one operation, that operation may be unnamed. If
-that operation is a query without variables or directives then it may also be
-represented in the shorthand form, omitting both the {`query`} keyword as well
-as the operation name. Otherwise, if a GraphQL Document contains multiple
-operations, each operation must be named. When submitting a Document with
-multiple operations to a GraphQL service, the name of the desired operation to
-be executed must also be provided.
-
 ## Descriptions
 
 Description : StringValue
 
-Documentation is a first-class feature of GraphQL. GraphQL descriptions are
-defined using the Markdown syntax (as specified by
+Documentation is a first-class feature of GraphQL by encouraging written
+descriptions on all named definitions in both a GraphQL schema
+{TypeSystemDocument} and an executable {Document}. GraphQL descriptions are
+expected to provided as Markdown (as specified by
 [CommonMark](https://commonmark.org/)). Description strings (often
-{BlockString}) occur immediately before the definition they describe.
+{BlockString}) occur immediately before the named definition they describe.
+
+Descriptions in type system definitions are made available via introspection,
+ensuring the documentation of a GraphQL service remains consistent with its
+capabilities.
 
 Descriptions may appear before:
 
@@ -396,12 +360,51 @@ Descriptions are not permitted on the shorthand form of operations:
 
 Note: Descriptions and comments in executable GraphQL documents are purely for
 documentation purposes. They MUST NOT affect the execution, validation, or
-response of a GraphQL document. It is safe to remove all descriptions and
-comments from executable documents without changing their behavior or results.
+response of a GraphQL document except for type and schema introspection. It is
+otherwise safe to remove all descriptions and comments from executable documents
+without changing their behavior or results.
 
-Descriptions in type system definitions are made available via introspection,
-ensuring the documentation of a GraphQL service remains consistent with its
-capabilities.
+## Document
+
+Document : Definition+
+
+Definition :
+
+- ExecutableDefinition
+- TypeSystemDefinitionOrExtension
+
+ExecutableDocument : ExecutableDefinition+
+
+ExecutableDefinition :
+
+- OperationDefinition
+- FragmentDefinition
+
+A GraphQL Document describes a complete file or request string operated on by a
+GraphQL service or client. A document contains multiple definitions, either
+executable or representative of a GraphQL type system.
+
+Documents are only executable by a GraphQL service if they are
+{ExecutableDocument} and contain at least one {OperationDefinition}. A Document
+which contains {TypeSystemDefinitionOrExtension} must not be executed; GraphQL
+execution services which receive a Document containing these should return a
+descriptive error.
+
+GraphQL services which only seek to execute GraphQL requests and not construct a
+new GraphQL schema may choose to only permit {ExecutableDocument}.
+
+Documents which do not contain {OperationDefinition} or do contain
+{TypeSystemDefinitionOrExtension} may still be parsed and validated to allow
+client tools to represent many GraphQL uses which may appear across many
+individual files.
+
+If a Document contains only one operation, that operation may be unnamed. If
+that operation is a query without variables or directives then it may also be
+represented in the shorthand form, omitting both the {`query`} keyword as well
+as the operation name. Otherwise, if a GraphQL Document contains multiple
+operations, each operation must be named. When submitting a Document with
+multiple operations to a GraphQL service, the name of the desired operation to
+be executed must also be provided.
 
 ## Operations
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -52,11 +52,18 @@ choose to only allow {TypeSystemExtensionDocument} and not allow
 
 ## Type System Descriptions
 
-Documentation is a first-class feature of GraphQL type systems. GraphQL schema and all other definitions (e.g. types, fields, arguments, etc.) which can be described should provide a {Description} unless they are considered self descriptive.
+Documentation is a first-class feature of GraphQL type systems. GraphQL schema
+and all other definitions (e.g. types, fields, arguments, etc.) which can be
+described should provide a {Description} unless they are considered self
+descriptive.
 
-Descriptions in the type system definition language occur immediately before the definition they describe and are made available via introspection, ensuring the documentation of a GraphQL service remains consistent with its capabilities.
+Descriptions in the type system definition language occur immediately before the
+definition they describe and are made available via introspection, ensuring the
+documentation of a GraphQL service remains consistent with its capabilities.
 
-Note: See Section 2, "Descriptions", for normative rules and syntax details. Type system descriptions follow the same Markdown format and rules as executable document descriptions.
+Note: See Section 2, "Descriptions", for normative rules and syntax details.
+Type system descriptions follow the same Markdown format and rules as executable
+document descriptions.
 
 ## Schema
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -52,18 +52,62 @@ choose to only allow {TypeSystemExtensionDocument} and not allow
 
 ## Type System Descriptions
 
-Documentation is a first-class feature of GraphQL type systems. GraphQL schema
-and all other definitions (e.g. types, fields, arguments, etc.) which can be
-described should provide a {Description} unless they are considered self
-descriptive.
+Documentation is a first-class feature of GraphQL type systems, written
+immediately alongside definitions in a {TypeSystemDocument} and made available
+via introspection.
 
-Descriptions in the type system definition language occur immediately before the
-definition they describe and are made available via introspection, ensuring the
-documentation of a GraphQL service remains consistent with its capabilities.
+[Descriptions](#sec-Descriptions) allow GraphQL service designers to easily
+provide documentation which remains consistent with the capabilities of a
+GraphQL service. Descriptions provided as Markdown (as specified by
+[CommonMark](https://commonmark.org/)) for every definition in a type system.
 
-Note: See Section 2, "Descriptions", for normative rules and syntax details.
-Type system descriptions follow the same Markdown format and rules as executable
-document descriptions.
+GraphQL schema and all other definitions (e.g. types, fields, arguments, etc.)
+which can be described should provide a {Description} unless they are considered
+self descriptive.
+
+As an example, this simple GraphQL schema is well described:
+
+```raw graphql example
+"""
+A simple GraphQL schema which is well described.
+"""
+schema {
+  query: Query
+}
+
+"""
+Root type for all your query operations
+"""
+type Query {
+  """
+  Translates a string from a given language into a different language.
+  """
+  translate(
+    "The original language that `text` is provided in."
+    fromLanguage: Language
+
+    "The translated language to be returned."
+    toLanguage: Language
+
+    "The text to be translated."
+    text: String
+  ): String
+}
+
+"""
+The set of languages supported by `translate`.
+"""
+enum Language {
+  "English"
+  EN
+
+  "French"
+  FR
+
+  "Chinese"
+  CH
+}
+```
 
 ## Schema
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -59,6 +59,9 @@ documentation of a GraphQL service remains consistent with its capabilities,
 descriptions of GraphQL definitions are provided alongside their definitions and
 made available via introspection.
 
+Note: See Section 2, "Descriptions", for normative rules and additional details
+on descriptions in executable documents.
+
 To allow GraphQL service designers to easily publish documentation alongside the
 capabilities of a GraphQL service, GraphQL descriptions are defined using the
 Markdown syntax (as specified by [CommonMark](https://commonmark.org/)). In the

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -50,71 +50,13 @@ Tools which only seek to produce and extend schema and not execute requests may
 choose to only allow {TypeSystemExtensionDocument} and not allow
 {ExecutableDefinition} but should provide a descriptive error if present.
 
-## Descriptions
+## Type System Descriptions
 
-Description : StringValue
+Documentation is a first-class feature of GraphQL type systems. GraphQL schema and all other definitions (e.g. types, fields, arguments, etc.) which can be described should provide a {Description} unless they are considered self descriptive.
 
-Documentation is a first-class feature of GraphQL type systems. To ensure the
-documentation of a GraphQL service remains consistent with its capabilities,
-descriptions of GraphQL definitions are provided alongside their definitions and
-made available via introspection.
+Descriptions in the type system definition language occur immediately before the definition they describe and are made available via introspection, ensuring the documentation of a GraphQL service remains consistent with its capabilities.
 
-Note: See Section 2, "Descriptions", for normative rules and additional details
-on descriptions in executable documents.
-
-To allow GraphQL service designers to easily publish documentation alongside the
-capabilities of a GraphQL service, GraphQL descriptions are defined using the
-Markdown syntax (as specified by [CommonMark](https://commonmark.org/)). In the
-type system definition language, these description strings (often {BlockString})
-occur immediately before the definition they describe.
-
-GraphQL schema and all other definitions (e.g. types, fields, arguments, etc.)
-which can be described should provide a {Description} unless they are considered
-self descriptive.
-
-As an example, this simple GraphQL schema is well described:
-
-```raw graphql example
-"""
-A simple GraphQL schema which is well described.
-"""
-schema {
-  query: Query
-}
-
-"""
-Root type for all your query operations
-"""
-type Query {
-  """
-  Translates a string from a given language into a different language.
-  """
-  translate(
-    "The original language that `text` is provided in."
-    fromLanguage: Language
-
-    "The translated language to be returned."
-    toLanguage: Language
-
-    "The text to be translated."
-    text: String
-  ): String
-}
-
-"""
-The set of languages supported by `translate`.
-"""
-enum Language {
-  "English"
-  EN
-
-  "French"
-  FR
-
-  "Chinese"
-  CH
-}
-```
+Note: See Section 2, "Descriptions", for normative rules and syntax details. Type system descriptions follow the same Markdown format and rules as executable document descriptions.
 
 ## Schema
 

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -33,6 +33,12 @@ Note: GraphQL requests do not require any specific serialization format or
 transport mechanism. Message serialization and transport mechanisms should be
 chosen by the implementing service.
 
+Note: Descriptions and comments in executable documents (operation definitions,
+fragment definitions, and variable definitions) MUST be ignored during execution
+and have no effect on the execution, validation, or response of a GraphQL
+document. Descriptions and comments on executable documents MAY be used for
+observability and logging purposes.
+
 ## Executing Requests
 
 To execute a request, the executor must have a parsed {Document} and a selected

--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -35,9 +35,9 @@ chosen by the implementing service.
 
 Note: Descriptions and comments in executable documents (operation definitions,
 fragment definitions, and variable definitions) MUST be ignored during execution
-and have no effect on the execution, validation, or response of a GraphQL
-document. Descriptions and comments on executable documents MAY be used for
-observability and logging purposes.
+and have no effect on the observable execution, validation, or response of a
+GraphQL document. Descriptions and comments on executable documents MAY be used
+for non-observable purposes, such as logging and other developer tools.
 
 ## Executing Requests
 


### PR DESCRIPTION
This PR builds upon @IvanGoncharov's [2021 RFC](https://github.com/graphql/graphql-spec/pull/892), with changes rebased onto the current spec and updated to incorporate feedback from previous discussion as well as an additional editorial pass.

Descriptions are a core feature of GraphQL, enabling schema and document authors to provide human-readable documentation directly alongside type system elements and executable definitions. This proposal extends the utility of descriptions by allowing them to appear not only on type system definitions, but also on operations, fragments, and variable definitions within executable documents.

Enabling descriptions in these locations improves the expressiveness and maintainability of GraphQL documents, supports better tooling and code generation, and enhances the developer experience by making intent and usage clearer at the point of definition. Importantly, descriptions remain non-semantic—they do not affect execution, validation, or response—ensuring that they serve purely as documentation and can be safely removed without impacting behavior. This change aligns with GraphQL’s commitment to self-documenting APIs and empowers teams to deliver more understandable and maintainable GraphQL applications.

Key points:

  - You can add descriptions on operations, fragments, and query variables
  - You can't add description on the the shorthand form of operations, only the full form
  - Descriptions on operations do not affect query execution, validation, or response

Example:

```graphql
"""
Request the current status of a time machine and its operator.
"""
query GetTimeMachineStatus(
  "The unique serial number of the time machine to inspect."
  $machineId: ID!

  """
  The year to check the status for.
  **Warning:** certain years may trigger an anomaly in the space-time continuum.
  """
  $year: Int
) {
  timeMachine(id: $machineId) {
    ...TimeMachineDetails
    operator {
        name
        licenseLevel
    }
    status(year: $year)
  }
}

"Time machine details."
fragment TimeMachineDetails on TimeMachine {
  id
  model
  lastMaintenance
}
```

Implemented in Graphql.js by https://github.com/graphql/graphql-js/pull/4430