### PR TITLE
Incorporate meta-fields into ExecuteCollectedFields

### DIFF
--- a/spec/Section 6 -- Execution.md
+++ b/spec/Section 6 -- Execution.md
@@ -840,7 +840,9 @@ ResolveMetaFieldValue(objectType, fieldName, argumentValues):
     operations.
   - Let {typeName} be the value provided in {argumentValues} for the name
     {"name"}.
-  - Let {type} be the type with name {typeName} in {schema}.
+  - If {typeName} begins with {"\_\_"}, let {type} be the type with name
+    {typeName} in the introspection schema.
+  - Otherwise, let {type} be the type with name {typeName} in {schema}.
   - Return {type} if it exists; otherwise {null}.
 - Otherwise:
   - Assert: {fieldName} is {"\_\_typename"}.


### PR DESCRIPTION
GraphQL.js uses a `getFieldDef()` helper:

https://github.com/graphql/graphql-js/blob/9032db1e4e55052bead6936359ecc5592c817f64/src/execution/execute.ts#L1047-L1079

called from `executeField()` to get the field definition to execute; returning meta-field definitions as appropriate.

This spec change reflects this existing behavior as best we can.

(Technically GraphQL.js' `executeField()` function overlaps responsibilities between the `ExecuteField()` and `ExecuteCollectedFields()` algorithms in the spec - specifically, `executeField()` may return `undefined`, resulting in `executeFields()` not adding the entry to the result object, whereas this conditional addition is handled in `ExecuteCollectedFields()` in the spec and we cannot/should not differentiate between `null` and `undefined` in this way.)