### PR TITLE
Editorial: Fix cases in validation where technically a crash could occur due to non-existent definitions

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -1144,6 +1144,7 @@ DetectFragmentCycles(fragmentDefinition, visited):
   - {visited} must not contain {spread}.
   - Let {nextVisited} be the set including {spread} and members of {visited}.
   - Let {nextFragmentDefinition} be the target of {spread}.
+  - If {nextFragmentDefinition} can't be found, return.
   - {DetectFragmentCycles(nextFragmentDefinition, nextVisited)}.
 
 **Explanatory Text**
@@ -1995,6 +1996,7 @@ variable.
     - Let {variableName} be the name of {variableUsage}.
     - Let {variableDefinition} be the {VariableDefinition} named {variableName}
       defined within {operation}.
+    - If no {variableDefinition} can be found, return.
     - {IsVariableUsageAllowed(variableDefinition, variableUsage)} must be
       {true}.
 


### PR DESCRIPTION
We have a few cases where in validation rules we rely on a different rule ensuring that the definition for usage exists.

- Overlapping Fields, we use a Fragment Definition looked up by a SpreadName that potentially does not exist
- VariablesOfCorrectType, we look up a VariableDefinition from a VariableName which could potentially not exist.