### PR TITLE
Update description of Fragments to emphasize evolving data needs

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -587,13 +587,9 @@ FragmentName : Name but not `on`
 
 Fragments are the primary unit of composition in GraphQL.
 
-Fragments allow for the reuse of common repeated selections of fields, reducing
-duplicated text in the document. Inline Fragments can be used directly within a
-selection to condition upon a type condition when querying against an interface
-or union.
+Fragments allow for the definition of selection sets that are colocated with the logic that requires those selections, making it easier to add and remove selections as needed.
 
-For example, if we wanted to fetch some common information about mutual friends
-as well as friends of some user:
+For example, if we have some `friendProfile` logic that requires `id`, `name`, and `profilePic`, and we want to apply that logic to the mutual friends as well as friends of some user:
 
 ```graphql example
 query noFragments {
@@ -612,28 +608,32 @@ query noFragments {
 }
 ```
 
-The repeated fields could be extracted into a fragment and composed by a parent
-fragment or operation.
+The fields required of `friendProfile` can be extracted into a fragment and composed 
+by a parent fragment or operation.
 
 ```graphql example
 query withFragments {
   user(id: 4) {
     friends(first: 10) {
-      ...friendFields
+      ...friendProfileFragment
     }
     mutualFriends(first: 10) {
-      ...friendFields
+      ...friendProfileFragment
     }
   }
 }
-
-"Common fields for a user's friends."
-fragment friendFields on User {
+```
+```graphql example
+"Fields required to display a friend's profile"
+fragment friendProfileFragment on User {
   id
   name
   profilePic(size: 50)
 }
 ```
+If `friendProfile` no longer needs `name`, the `name` field can be removed from 
+`friendProfileFragment` and it will no longer be fetched in both locations the 
+fragment is consumed.
 
 Fragments are consumed by using the spread operator (`...`). All fields selected
 by the fragment will be added to the field selection at the same level as the

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -587,12 +587,11 @@ FragmentName : Name but not `on`
 
 Fragments are the primary unit of composition in GraphQL.
 
-Fragments allow for the definition of selection sets that are colocated with the 
-logic that requires those selections, making it easier to add and remove selections 
-as needed.
+Fragments allow for the definition of modular selection sets that make it easier
+to add and remove selections as needed.
 
-For example, if we have some `friendProfile` logic that requires `id`, `name`, 
-and `profilePic`, and we want to apply that logic to the mutual friends as well 
+For example, if we have some `friendProfile` logic that requires `id`, `name`,
+and `profilePic`, and we want to apply that logic to the mutual friends as well
 as friends of some user:
 
 ```graphql example
@@ -612,31 +611,31 @@ query noFragments {
 }
 ```
 
-The fields required by `friendProfile` can be extracted into a fragment and 
+The fields required by `friendProfile` can be extracted into a fragment and
 composed by a parent fragment or operation.
 
 ```graphql example
 query withFragments {
   user(id: 4) {
     friends(first: 10) {
-      ...friendProfileFragment
+      ...friendProfile
     }
     mutualFriends(first: 10) {
-      ...friendProfileFragment
+      ...friendProfile
     }
   }
 }
 ```
 ```graphql example
 "Fields required to display a friend's profile"
-fragment friendProfileFragment on User {
+fragment friendProfile on User {
   id
   name
   profilePic(size: 50)
 }
 ```
-If `friendProfile` no longer needs `name`, the `name` field can be removed from 
-`friendProfileFragment` and it will no longer be fetched in both locations the 
+If `friendProfile` no longer needs `name`, the `name` field can be removed from
+the `friendProfile` fragment and it will no longer be fetched in both locations the
 fragment is consumed.
 
 Fragments are consumed by using the spread operator (`...`). All fields selected

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -587,9 +587,13 @@ FragmentName : Name but not `on`
 
 Fragments are the primary unit of composition in GraphQL.
 
-Fragments allow for the definition of selection sets that are colocated with the logic that requires those selections, making it easier to add and remove selections as needed.
+Fragments allow for the definition of selection sets that are colocated with the 
+logic that requires those selections, making it easier to add and remove selections 
+as needed.
 
-For example, if we have some `friendProfile` logic that requires `id`, `name`, and `profilePic`, and we want to apply that logic to the mutual friends as well as friends of some user:
+For example, if we have some `friendProfile` logic that requires `id`, `name`, 
+and `profilePic`, and we want to apply that logic to the mutual friends as well 
+as friends of some user:
 
 ```graphql example
 query noFragments {
@@ -608,8 +612,8 @@ query noFragments {
 }
 ```
 
-The fields required of `friendProfile` can be extracted into a fragment and composed 
-by a parent fragment or operation.
+The fields required by `friendProfile` can be extracted into a fragment and 
+composed by a parent fragment or operation.
 
 ```graphql example
 query withFragments {

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -626,6 +626,7 @@ query withFragments {
   }
 }
 ```
+
 ```graphql example
 "Fields required to display a friend's profile"
 fragment friendProfile on User {
@@ -634,9 +635,10 @@ fragment friendProfile on User {
   profilePic(size: 50)
 }
 ```
+
 If `friendProfile` no longer needs `name`, the `name` field can be removed from
-the `friendProfile` fragment and it will no longer be fetched in both locations the
-fragment is consumed.
+the `friendProfile` fragment and it will no longer be fetched in both locations
+the fragment is consumed.
 
 Fragments are consumed by using the spread operator (`...`). All fields selected
 by the fragment will be added to the field selection at the same level as the

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -587,9 +587,10 @@ FragmentName : Name but not `on`
 
 Fragments are the primary unit of composition in GraphQL.
 
-Each client component should declare its data needs in a dedicated fragment.
-These fragments may then be composed in the same fashion as the components
-themselves to form a GraphQL operation to issue to the server.
+Each data-consuming component (function, class, UI element, and so on) of
+a client application should declare its data needs in a dedicated fragment.
+These fragments may then be composed, following the usage of the components
+themselves, to form a GraphQL operation to issue to the server.
 
 For example, if we have some logic that requires `id`, `name`, and `profilePic`
 to render a profile, and we want to apply that logic to the friends and mutual

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -587,12 +587,13 @@ FragmentName : Name but not `on`
 
 Fragments are the primary unit of composition in GraphQL.
 
-Fragments allow for the definition of modular selection sets that make it easier
-to add and remove selections as needed.
+Each client component should declare its data needs in a dedicated fragment.
+These fragments may then be composed in the same fashion as the components
+themselves to form a GraphQL operation to issue to the server.
 
-For example, if we have some `friendProfile` logic that requires `id`, `name`,
-and `profilePic`, and we want to apply that logic to the mutual friends as well
-as friends of some user:
+For example, if we have some logic that requires `id`, `name`, and `profilePic`
+to render a profile, and we want to apply that logic to the friends and mutual
+friends of a user:
 
 ```graphql example
 query noFragments {
@@ -611,7 +612,7 @@ query noFragments {
 }
 ```
 
-The fields required by `friendProfile` can be extracted into a fragment and
+The fields required to render a profile can be extracted into a fragment and
 composed by a parent fragment or operation.
 
 ```graphql example
@@ -628,7 +629,7 @@ query withFragments {
 ```
 
 ```graphql example
-"Fields required to display a friend's profile"
+"Fields required to render a friend's profile"
 fragment friendProfile on User {
   id
   name
@@ -636,9 +637,9 @@ fragment friendProfile on User {
 }
 ```
 
-If `friendProfile` no longer needs `name`, the `name` field can be removed from
-the `friendProfile` fragment and it will no longer be fetched in both locations
-the fragment is consumed.
+If the profile rendering logic no longer needs `name`, the `name` field can be
+removed from the `friendProfile` fragment and it will no longer be fetched in
+both locations the fragment is consumed.
 
 Fragments are consumed by using the spread operator (`...`). All fields selected
 by the fragment will be added to the field selection at the same level as the


### PR DESCRIPTION
## Why these changes?

**Fragments are not for reuse.**

The current language in [section 2.8 on Fragments](https://spec.graphql.org/October2021/#sec-Language.Fragments), namely the sentence...

> Fragments allow for the reuse of common repeated selections of fields, reducing duplicated text in the document.

...encourages using fragments to deduplicate common selections, even if those selections represent independent data needs. 

For example, let's consider these two functions

```swift
// This function formats a post for display in a feed
func formatPostForFeed(post: PostDisplayFragment) -> String {
 let authorName = post.author.name
 let contentText = post.content.text

 return "\(authorName) posted: \(contentText)"
}

// This function formats a post for notification purposes
func formatPostForNotification(post: PostDisplayFragment) -> String {
 let authorName = post.author.name
 let contentText = post.content.text

 return "New post from \(authorName): \(contentText)"
}
```

Given these two functions currently both use `authorName` and `contentText`, the current language in the spec encourages one to write a fragment

```graphql 
fragment PostDisplayFragment on Post {
 author
 content
}
```

If `formatPostForFeed` now needs `timestamp`, we will add naturally add `timestamp` to `PostDisplayFragment` 
```swift
// This function formats a post for display in a feed
func formatPostForFeed(post: PostDisplayFragment) -> String {
 let authorName = post.author.name
 let contentText = post.content.text
 let timestamp = post.createdAt.formatted // Added

 return "\(authorName) posted: \(contentText)\nPosted \(timestamp)"
}
```

```graphql 
fragment PostDisplayFragment on Post {
 author
 content
 timestamp # Added
}
```
If we have the following queries

```graphql
query NotificationQuery {
 ...PostDisplayFragment # Over-fetching timestamp
}

query FeedQuery {
 ...PostDisplayFragment
}
```
notice how `NotificationQuery` is now over-fetching timestamp! 

The key observation is that `formatPostForFeed` and `formatPostForNotification` are two independent functions, so by having them both rely on a single fragment to express their data needs, we are creating a dependency where one should not exist (because that dependency does not exist in the product logic itself).

## What are the proposed changes?

Updated:
1. The description for why one might use fragments
2. The first GraphQL example in section 2.8

The goal is to emphasize that fragments support evolving data needs (as opposed to recommending people identify common selections that are currently in an executable document).

Open to any and all feedback on the motivation for the change and how it's communicated via changes in the spec language!
