### PR TITLE
RFC: Add Schema Coordinate to GraphQL Errors

### DIFF
--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -193,6 +193,11 @@ describes the _response position_ which raised the error. This allows clients to
 identify whether a {null} resolved result is a true value or the result of an
 _execution error_.
 
+If an error can be associated to a particular object field or field argument, it should contain an
+entry with the key {"coordinate"} with a string value that is the _schema coordinate_ of that object
+field or field argument. This allows clients to identify the precise location in the schema where
+the error originated.
+
 For example, if fetching one of the friends' names fails in the following
 operation:
 
@@ -216,7 +221,8 @@ The response might look like:
     {
       "message": "Name for character with ID 1002 could not be fetched.",
       "locations": [{ "line": 6, "column": 7 }],
-      "path": ["hero", "heroFriends", 1, "name"]
+      "path": ["hero", "heroFriends", 1, "name"],
+      "coordinate": "Human.name"
     }
   ],
   "data": {
@@ -256,7 +262,8 @@ be the same:
     {
       "message": "Name for character with ID 1002 could not be fetched.",
       "locations": [{ "line": 6, "column": 7 }],
-      "path": ["hero", "heroFriends", 1, "name"]
+      "path": ["hero", "heroFriends", 1, "name"],
+      "coordinate": "Human.name"
     }
   ],
   "data": {
@@ -290,6 +297,7 @@ see fit, and there are no additional restrictions on its contents.
       "message": "Name for character with ID 1002 could not be fetched.",
       "locations": [{ "line": 6, "column": 7 }],
       "path": ["hero", "heroFriends", 1, "name"],
+      "coordinate": "Human.name",
       "extensions": {
         "code": "CAN_NOT_FETCH_BY_ID",
         "timestamp": "Fri Feb 9 14:33:09 UTC 2018"
@@ -314,6 +322,7 @@ discouraged.
       "message": "Name for character with ID 1002 could not be fetched.",
       "locations": [{ "line": 6, "column": 7 }],
       "path": ["hero", "heroFriends", 1, "name"],
+      "coordinate": "Human.name",
       "code": "CAN_NOT_FETCH_BY_ID",
       "timestamp": "Fri Feb 9 14:33:09 UTC 2018"
     }


### PR DESCRIPTION
Add an optional `coordinate` field to GraphQL errors that contains the schema coordinate of the object field or field argument associated with the error, enabling direct identification of schema elements that caused runtime errors.

## 📜 Problem Statement

When a GraphQL error occurs, developers must perform multiple steps to identify which type system member caused the error:

1. Parse the schema
2. Parse the operation
3. Traverse the operation based on the `path` field in the error

This process is cumbersome and requires tooling to correlate runtime errors back to their schema definitions. While the `path` field identifies where in the response the error occurred, it doesn't directly indicate which schema element is responsible for the error.

**Example**

Consider this error response:

```json
{
  "errors": [
    {
      "message": "Name for character with ID 1002 could not be fetched.",
      "locations": [{ "line": 6, "column": 7 }],
      "path": ["hero", "heroFriends", 1, "name"]
    }
  ]
}
```

To determine that this error originated from the `Human.name` field in the schema, developers must:

- Load and parse the schema
- Parse the GraphQL operation
- Walk through the operation following the path `["hero", "heroFriends", 1, "name"]`
- Determine the types at each step to identify that `heroFriends` returns `[Friend]`
- Conclude that the error is associated with `Human.name`

## 💡 Proposed Solution

Add an optional `coordinate` field to GraphQL errors that directly references the object fiel or field argument where the error originated.

### Example

```json
{
  "errors": [
    {
      "message": "Name for character with ID 1002 could not be fetched.",
      "locations": [{ "line": 6, "column": 7 }],
      "path": ["hero", "heroFriends", 1, "name"],
      "coordinate": "Human.name"
    }
  ]
}
```

In this example `coordinate` directly identifies `Human.name` in the schema as the source, without requiring any parsing or traversal


1. **Simplified Error Tracking**: Developers can immediately identify which schema element caused an error without complex analysis.

2. **Better Tooling Support**: IDEs, monitoring systems, and debugging tools can directly link errors to schema definitions.


The `coordinate` field should be included when:

- An error originates from resolving a specific object field -> object field coordinate
- An error originates from resolving a specific field argument -> field argument coordinate
- An error originates from coercing a value of a input object -> field argument of the field that the input object is passed to

The `coordinate` field may be omitted when:

- The error is not associated with a specific schema element
- The server implementation cannot determine the appropriate coordinate