### PR TITLE
Service capabilities

### DIFF
--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -265,8 +265,8 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
-- ServiceExtension
 - TypeExtension
+- ServiceExtension
 
 SchemaDefinition : Description? schema Directives[Const]? {
 RootOperationTypeDefinition+ }

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -421,11 +421,11 @@ TypeSystemDirectiveLocation : one of
 - `INPUT_OBJECT`
 - `INPUT_FIELD_DEFINITION`
 
-ServiceDefinition : Description? service Directives? { ServiceCapability* }
+ServiceDefinition : Description? service Directives? { ServiceCapability\* }
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability* }
+- extend service Directives? { ServiceCapability\* }
 - extend service Directives [lookahead != `{`]
 
 ServiceCapability :

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -425,7 +425,7 @@ ServiceDefinition : Description? service Directives? { ServiceCapability* }
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability+ }
+- extend service Directives? { ServiceCapability* }
 - extend service Directives [lookahead != `{`]
 
 ServiceCapability :

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -71,6 +71,11 @@ Digit :: one of
 
 - `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
+QualifiedName ::
+
+- QualifiedName . Name [lookahead != `.`]
+- Name . Name [lookahead != `.`]
+
 IntValue :: IntegerPart [lookahead != {Digit, `.`, NameStart}]
 
 IntegerPart ::
@@ -248,6 +253,7 @@ TypeSystemDefinition :
 - SchemaDefinition
 - TypeDefinition
 - DirectiveDefinition
+- ServiceDefinition
 
 TypeSystemExtensionDocument : TypeSystemDefinitionOrExtension+
 
@@ -413,6 +419,19 @@ TypeSystemDirectiveLocation : one of
 - `ENUM_VALUE`
 - `INPUT_OBJECT`
 - `INPUT_FIELD_DEFINITION`
+
+ServiceDefinition : Description? service { ServiceAttribute\* }
+
+ServiceAttribute :
+
+- ServiceCapabilities
+
+ServiceCapabilities: capabilities { ServiceCapability\* }
+
+ServiceCapability:
+
+- Description? QualifiedName [lookahead != `(`]
+- Description? QualifiedName ( StringValue )
 
 ## Schema Coordinate Syntax
 

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -265,6 +265,7 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
+- ServiceExtension
 - TypeExtension
 
 SchemaDefinition : Description? schema Directives[Const]? {
@@ -421,6 +422,11 @@ TypeSystemDirectiveLocation : one of
 - `INPUT_FIELD_DEFINITION`
 
 ServiceDefinition : Description? service Directives? { ServiceCapability* }
+
+ServiceExtension :
+
+- extend service Directives? { ServiceCapability+ }
+- extend service Directives [lookahead != `{`]
 
 ServiceCapability :
 

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -420,18 +420,13 @@ TypeSystemDirectiveLocation : one of
 - `INPUT_OBJECT`
 - `INPUT_FIELD_DEFINITION`
 
-ServiceDefinition : Description? service { ServiceAttribute\* }
+ServiceDefinition : Description? service Directives? { ServiceCapability* }
 
-ServiceAttribute :
+ServiceCapability :
 
-- ServiceCapabilities
+- Description? capability QualifiedName ServiceCapabilityValue?
 
-ServiceCapabilities: capabilities { ServiceCapability\* }
-
-ServiceCapability:
-
-- Description? QualifiedName [lookahead != `(`]
-- Description? QualifiedName ( StringValue )
+ServiceCapabilityValue : ( StringValue )
 
 ## Schema Coordinate Syntax
 

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -71,6 +71,11 @@ Digit :: one of
 
 - `0` `1` `2` `3` `4` `5` `6` `7` `8` `9`
 
+QualifiedName ::
+
+- QualifiedName . Name [lookahead != `.`]
+- Name . Name [lookahead != `.`]
+
 IntValue :: IntegerPart [lookahead != {Digit, `.`, NameStart}]
 
 IntegerPart ::
@@ -248,6 +253,7 @@ TypeSystemDefinition :
 - SchemaDefinition
 - TypeDefinition
 - DirectiveDefinition
+- ServiceDefinition
 
 TypeSystemExtensionDocument : TypeSystemDefinitionOrExtension+
 
@@ -417,6 +423,19 @@ TypeSystemDirectiveLocation : one of
 - `INPUT_OBJECT`
 - `INPUT_FIELD_DEFINITION`
 - `DIRECTIVE_DEFINITION`
+
+ServiceDefinition : Description? service { ServiceAttribute\* }
+
+ServiceAttribute :
+
+- ServiceCapabilities
+
+ServiceCapabilities: capabilities { ServiceCapability\* }
+
+ServiceCapability:
+
+- Description? QualifiedName [lookahead != `(`]
+- Description? QualifiedName ( StringValue )
 
 ## Schema Coordinate Syntax
 

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -265,6 +265,7 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
+- ServiceExtension
 - TypeExtension
 - DirectiveExtension
 
@@ -425,6 +426,11 @@ TypeSystemDirectiveLocation : one of
 - `DIRECTIVE_DEFINITION`
 
 ServiceDefinition : Description? service Directives? { ServiceCapability* }
+
+ServiceExtension :
+
+- extend service Directives? { ServiceCapability+ }
+- extend service Directives [lookahead != `{`]
 
 ServiceCapability :
 

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -424,18 +424,13 @@ TypeSystemDirectiveLocation : one of
 - `INPUT_FIELD_DEFINITION`
 - `DIRECTIVE_DEFINITION`
 
-ServiceDefinition : Description? service { ServiceAttribute\* }
+ServiceDefinition : Description? service Directives? { ServiceCapability* }
 
-ServiceAttribute :
+ServiceCapability :
 
-- ServiceCapabilities
+- Description? capability QualifiedName ServiceCapabilityValue?
 
-ServiceCapabilities: capabilities { ServiceCapability\* }
-
-ServiceCapability:
-
-- Description? QualifiedName [lookahead != `(`]
-- Description? QualifiedName ( StringValue )
+ServiceCapabilityValue : ( StringValue )
 
 ## Schema Coordinate Syntax
 

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -429,7 +429,7 @@ ServiceDefinition : Description? service Directives? { ServiceCapability* }
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability+ }
+- extend service Directives? { ServiceCapability* }
 - extend service Directives [lookahead != `{`]
 
 ServiceCapability :

--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -265,9 +265,9 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
-- ServiceExtension
 - TypeExtension
 - DirectiveExtension
+- ServiceExtension
 
 SchemaDefinition : Description? schema Directives[Const]? {
 RootOperationTypeDefinition+ }
@@ -425,11 +425,11 @@ TypeSystemDirectiveLocation : one of
 - `INPUT_FIELD_DEFINITION`
 - `DIRECTIVE_DEFINITION`
 
-ServiceDefinition : Description? service Directives? { ServiceCapability* }
+ServiceDefinition : Description? service Directives? { ServiceCapability\* }
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability* }
+- extend service Directives? { ServiceCapability\* }
 - extend service Directives [lookahead != `{`]
 
 ServiceCapability :

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -233,6 +233,18 @@ Any {Name} within a GraphQL type system must not start with two underscores
 {"\_\_"} unless it is part of the [introspection system](#sec-Introspection) as
 defined by this specification.
 
+### Qualified Names
+
+QualifiedName ::
+
+- QualifiedName . Name [lookahead != `.`]
+- Name . Name [lookahead != `.`]
+
+A qualified name is a case-sensitive string composed of two or more names
+separated by a period (`.`). A qualified name allows for a structured chain of
+names which can be useful for scoping or applying namespaces. A _capability
+identifier_ is an example of a {QualifiedName}.
+
 ## Descriptions
 
 Description : StringValue

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2423,7 +2423,7 @@ This version of the specification defines the following capabilities:
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability+ }
+- extend service Directives? { ServiceCapability* }
 - extend service Directives [lookahead != `{`]
 
 Service extensions are used to represent a service which has been extended from

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2380,8 +2380,8 @@ reserved for future usage.
 Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals. Identifiers beginning with the prefix {"example."} are reserved for
-documentation purposes, and should not be used in operations.
+proposals. Identifiers beginning with the prefix {"example."} are reserved and
+should only be used for documentation purposes.
 
 Note: Since IANA RFC 2606 reserves the second-level domain names
 {example.com}, {example.net}, and {example.org} for documentation purposes, the

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2326,14 +2326,15 @@ input UserUniqueCondition @oneOf {
 
 ## Service Definition
 
-ServiceDefinition : Description? service Directives? { ServiceCapability* }
+ServiceDefinition : Description? service Directives? { ServiceCapability\* }
 
 A GraphQL service is defined in terms of the capabilities that it offers which
 are external to the schema.
 
 ### Service Capabilities
 
-ServiceCapability : Description? capability QualifiedName ServiceCapabilityValue?
+ServiceCapability : Description? capability QualifiedName
+ServiceCapabilityValue?
 
 ServiceCapabilityValue : ( StringValue )
 
@@ -2388,9 +2389,10 @@ Identifiers beginning with the prefix {"example."} are reserved for usage in
 documentation and examples only.
 
 Note: Since IANA RFC 2606 reserves the second-level domain names
-{example.com}, {example.net}, and {example.org} for documentation purposes, the
-corresponding reverse-domain prefixes {"com.example."}, {"net.example."}, and
-{"org.example."} are also reserved for documentation purposes.
+{"example.com"}, {"example.net"}, and {"example.org"} for documentation
+purposes, the corresponding reverse-domain prefixes {"com.example."},
+{"net.example."}, and {"org.example."} are also reserved for documentation
+purposes.
 
 Implementers should not change the meaning of capability identifiers; instead, a
 new capability identifier should be used when the meaning changes. Implementers
@@ -2418,13 +2420,14 @@ websockets are supported at the current endpoint).
 
 This version of the specification defines the following capabilities:
 
-- {"graphql.operationDescriptions"} - indicates support for descriptions on operations and fragments
+- {"graphql.operationDescriptions"} - indicates support for descriptions on
+  operations and fragments
 
 ### Service Extension
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability* }
+- extend service Directives? { ServiceCapability\* }
 - extend service Directives [lookahead != `{`]
 
 Service extensions are used to represent a service which has been extended from

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2325,11 +2325,7 @@ input UserUniqueCondition @oneOf {
 
 ## Service Definition
 
-ServiceDefinition : Description? service { ServiceAttribute\* }
-
-ServiceAttribute :
-
-- ServiceCapabilities
+ServiceDefinition : Description? service Directives? { ServiceCapability* }
 
 A GraphQL service is defined in terms of the capabilities that it offers which
 are external to the schema.
@@ -2338,12 +2334,9 @@ All capabilities within a service must have unique identifiers.
 
 ### Service Capabilities
 
-ServiceCapabilities: capabilities { ServiceCapability\* }
+ServiceCapability : Description? capability QualifiedName ServiceCapabilityValue?
 
-ServiceCapability:
-
-- Description? QualifiedName [lookahead != `(`]
-- Description? QualifiedName ( StringValue )
+ServiceCapabilityValue : ( StringValue )
 
 :: A _service capability_ describes a feature supported by the GraphQL service
 but not directly expressible via the type system. This may include support for
@@ -2355,6 +2348,16 @@ both.
 
 A _service capability_ is identified by a _capability identifier_ (a
 {QualifiedName}), and may optionally have a string value.
+
+```graphql example
+service {
+  "Indicates syntax support for descriptions on operation and fragment definitions"
+  capability graphql.operationDescriptions
+
+  "Websocket transport is supported via the given endpoint"
+  capability example.transport.ws("wss://api.example.com/graphql")
+}
+```
 
 **Capability Identifier**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2376,7 +2376,8 @@ reserved for future usage.
 Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals.
+proposals. Identifiers beginning with the prefix {"example."} are reserved for
+documentation purposes.
 
 Any identifiers beginning with case-insensitive variants of {"graphql."},
 {"org.graphql."} and {"gql."} are also reserved.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2331,8 +2331,6 @@ ServiceDefinition : Description? service Directives? { ServiceCapability* }
 A GraphQL service is defined in terms of the capabilities that it offers which
 are external to the schema.
 
-All capabilities within a service must have unique identifiers.
-
 ### Service Capabilities
 
 ServiceCapability : Description? capability QualifiedName ServiceCapabilityValue?
@@ -2348,7 +2346,8 @@ capabilities may be supplied by the GraphQL implementation, the service, or
 both.
 
 A _service capability_ is identified by a _capability identifier_ (a
-{QualifiedName}), and may optionally have a string value.
+{QualifiedName}), and may optionally have a string value. All capabilities
+within a service must have unique identifiers.
 
 ```graphql example
 service {
@@ -2380,16 +2379,18 @@ reserved for future usage.
 Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals. Identifiers beginning with the prefix {"example."} are reserved and
-should only be used for documentation purposes.
+proposals.
+
+Any identifiers beginning with case-insensitive variants of {"graphql."},
+{"org.graphql."} and {"gql."} are also reserved.
+
+Identifiers beginning with the prefix {"example."} are reserved for usage in
+documentation and examples only.
 
 Note: Since IANA RFC 2606 reserves the second-level domain names
 {example.com}, {example.net}, and {example.org} for documentation purposes, the
 corresponding reverse-domain prefixes {"com.example."}, {"net.example."}, and
 {"org.example."} are also reserved for documentation purposes.
-
-Any identifiers beginning with case-insensitive variants of {"graphql."},
-{"org.graphql."} and {"gql."} are also reserved.
 
 Implementers should not change the meaning of capability identifiers; instead, a
 new capability identifier should be used when the meaning changes. Implementers
@@ -2397,7 +2398,7 @@ should ensure that capability identifiers remain stable and version-agnostic
 where possible.
 
 Note: Capability versioning, if needed, can be indicated using dot suffixes
-(e.g. {"org.example.capability.v2"}).
+(e.g. {"example.capability.v2"}).
 
 This system enables incremental feature adoption and richer tooling
 interoperability, while avoiding tight coupling to specific implementations.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -40,8 +40,8 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
-- ServiceExtension
 - TypeExtension
+- ServiceExtension
 
 Type system extensions are used to represent a GraphQL type system which has
 been extended from some previous type system. For example, this might be used by

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2414,7 +2414,7 @@ For example, the capability {"graphql.operationDescriptions"} does not require
 additional information and thus does not specify a value; whereas a capability
 such as {"example.transport.ws"} might use the value to indicate the endpoint to
 use for websocket communications (or might omit a value to indicate that
-websockets are supported at the current endpoint).
+WebSockets are supported at the current endpoint).
 
 **Specified capabilities**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2351,7 +2351,7 @@ A _service capability_ is identified by a _capability identifier_ (a
 
 ```graphql example
 service {
-  "Indicates syntax support for descriptions on operation and fragment definitions"
+  "Descriptions on operations and fragments are supported"
   capability graphql.operationDescriptions
 
   "Websocket transport is supported via the given endpoint"
@@ -2391,7 +2391,7 @@ should ensure that capability identifiers remain stable and version-agnostic
 where possible.
 
 Note: Capability versioning, if needed, can be indicated using dot suffixes
-(e.g.{ "org.example.capability.v2"}).
+(e.g. {"org.example.capability.v2"}).
 
 This system enables incremental feature adoption and richer tooling
 interoperability, while avoiding tight coupling to specific implementations.
@@ -2411,4 +2411,4 @@ websockets are supported at the current endpoint).
 
 This version of the specification defines the following capabilities:
 
-- {"graphql.operationDescriptions"} - indicates syntax support for descriptions on operation and fragments
+- {"graphql.operationDescriptions"} - indicates support for descriptions on operations and fragments

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -40,6 +40,7 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
+- ServiceExtension
 - TypeExtension
 
 Type system extensions are used to represent a GraphQL type system which has
@@ -2412,3 +2413,33 @@ websockets are supported at the current endpoint).
 This version of the specification defines the following capabilities:
 
 - {"graphql.operationDescriptions"} - indicates support for descriptions on operations and fragments
+
+### Service Extension
+
+ServiceExtension :
+
+- extend service Directives? { ServiceCapability+ }
+- extend service Directives [lookahead != `{`]
+
+Service extensions are used to represent a service which has been extended from
+a previous service. For example, this might be used by a GraphQL service which
+adds additional capabilities to an existing service.
+
+Note: Service extensions without additional capability definitions must not be
+followed by a {`{`} (such as a query shorthand) to avoid parsing ambiguity.
+
+```graphql example
+extend service {
+  capability example.newCapability
+}
+```
+
+**Service Validation**
+
+Service extensions have the potential to be invalid if incorrectly defined.
+
+1. The Service must already be defined.
+2. Any non-repeatable directives provided must not already apply to the previous
+   Service.
+3. Any capabilities provided must not already be defined on the previous
+   Service.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -12,6 +12,7 @@ TypeSystemDefinition :
 - SchemaDefinition
 - TypeDefinition
 - DirectiveDefinition
+- ServiceDefinition
 
 The GraphQL language includes an
 [IDL](https://en.wikipedia.org/wiki/Interface_description_language) used to
@@ -2321,3 +2322,93 @@ input UserUniqueCondition @oneOf {
   organizationAndEmail: OrganizationAndEmailInput
 }
 ```
+
+## Service Definition
+
+ServiceDefinition : Description? service { ServiceAttribute\* }
+
+ServiceAttribute :
+
+- ServiceCapabilities
+
+A GraphQL service is defined in terms of the capabilities that it offers which
+are external to the schema.
+
+All capabilities within a service must have unique identifiers.
+
+### Service Capabilities
+
+ServiceCapabilities: capabilities { ServiceCapability\* }
+
+ServiceCapability:
+
+- Description? QualifiedName [lookahead != `(`]
+- Description? QualifiedName ( StringValue )
+
+:: A _service capability_ describes a feature supported by the GraphQL service
+but not directly expressible via the type system. This may include support for
+new or experimental GraphQL syntactic or behavioral features, protocol support
+(such as GraphQL over WebSockets or Server-Sent Events), or additional
+operational information (such as endpoints for related services). Service
+capabilities may be supplied by the GraphQL implementation, the service, or
+both.
+
+A _service capability_ is identified by a _capability identifier_ (a
+{QualifiedName}), and may optionally have a string value.
+
+**Capability Identifier**
+
+:: A _capability identifier_ is a {QualifiedName} (a case-sensitive string value
+composed of two or more {Name} separated by a period (`.`)) that uniquely
+identifies a capability. This structure is inspired by reverse domain notation
+to encourage global uniqueness and collision-resistance; it is recommended that
+identifiers defined by specific projects, vendors, or implementations begin with
+a prefix derived from a DNS name they control (e.g., {"com.example."}).
+
+Clients must compare capability identifiers using exact (case-sensitive) string
+equality.
+
+**Reserved Capability Identifiers**
+
+A _capability identifier_ must not start with an underscore {"\_"}; this is
+reserved for future usage.
+
+Capability identifiers beginning with the prefix {"graphql."} are reserved and
+must not be used outside of official GraphQL Foundation specifications.
+Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
+proposals.
+
+Any identifiers beginning with case-insensitive variants of {"graphql."},
+{"org.graphql."} and {"gql."} are also reserved.
+
+Implementers should not change the meaning of capability identifiers; instead, a
+new capability identifier should be used when the meaning changes. Implementers
+should ensure that capability identifiers remain stable and version-agnostic
+where possible.
+
+Note: Capability versioning, if needed, can be indicated using dot suffixes
+(e.g.{ "org.example.capability.v2"}).
+
+This system enables incremental feature adoption and richer tooling
+interoperability, while avoiding tight coupling to specific implementations.
+
+**Capability value**
+
+For capabilities that require more information than a simple indication of
+support, a string value may be specified.
+
+For example, the capability {"graphql.onError"} does not require additional
+information and thus does not specify a value; whereas
+{"graphql.defaultErrorBehavior"} uses the value to indicate which _error
+behavior_ is the default.
+
+**Specified capabilities**
+
+This version of the specification defines the following capabilities:
+
+- {"graphql.defaultErrorBehavior"} - indicates the _default error behavior_ of
+  the service via the {value}. If not present, assume the _default error
+  behavior_ is {"PROPAGATE"}.
+- {"graphql.onError"} - indicates that the service allows the client to specify
+  {onError} in a request to indicate the _error behavior_ the service should use
+  for the request. No {value} is provided.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2381,7 +2381,12 @@ Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
 proposals. Identifiers beginning with the prefix {"example."} are reserved for
-documentation purposes.
+documentation purposes, and should not be used in operations.
+
+Note: Since IANA RFC 2606 reserves the second-level domain names
+{example.com}, {example.net}, and {example.org} for documentation purposes, the
+corresponding reverse-domain prefixes {"com.example."}, {"net.example."}, and
+{"org.example."} are also reserved for documentation purposes.
 
 Any identifiers beginning with case-insensitive variants of {"graphql."},
 {"org.graphql."} and {"gql."} are also reserved.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2398,18 +2398,14 @@ interoperability, while avoiding tight coupling to specific implementations.
 For capabilities that require more information than a simple indication of
 support, a string value may be specified.
 
-For example, the capability {"graphql.onError"} does not require additional
-information and thus does not specify a value; whereas
-{"graphql.defaultErrorBehavior"} uses the value to indicate which _error
-behavior_ is the default.
+For example, the capability {"graphql.operationDescriptions"} does not require
+additional information and thus does not specify a value; whereas a capability
+such as {"example.transport.ws"} might use the value to indicate the endpoint to
+use for websocket communications (or might omit a value to indicate that
+websockets are supported at the current endpoint).
 
 **Specified capabilities**
 
 This version of the specification defines the following capabilities:
 
-- {"graphql.defaultErrorBehavior"} - indicates the _default error behavior_ of
-  the service via the {value}. If not present, assume the _default error
-  behavior_ is {"PROPAGATE"}.
-- {"graphql.onError"} - indicates that the service allows the client to specify
-  {onError} in a request to indicate the _error behavior_ the service should use
-  for the request. No {value} is provided.
+- {"graphql.operationDescriptions"} - indicates syntax support for descriptions on operation and fragments

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2346,9 +2346,9 @@ operational information (such as endpoints for related services). Service
 capabilities may be supplied by the GraphQL implementation, the service, or
 both.
 
-A _service capability_ is identified by a _capability identifier_ (a
-{QualifiedName}), and may optionally have a string value. All capabilities
-within a service must have unique identifiers.
+A _service capability_ is identified by a _capability name_ (a {QualifiedName}),
+and may optionally have a string value. All capabilities within a service must
+have unique identifiers.
 
 ```graphql example
 service {
@@ -2360,33 +2360,32 @@ service {
 }
 ```
 
-**Capability Identifier**
+**Capability Name**
 
-:: A _capability identifier_ is a {QualifiedName} (a case-sensitive string value
+:: A _capability name_ is a {QualifiedName} (a case-sensitive string value
 composed of two or more {Name} separated by a period (`.`)) that uniquely
 identifies a capability. This structure is inspired by reverse domain notation
 to encourage global uniqueness and collision-resistance; it is recommended that
-identifiers defined by specific projects, vendors, or implementations begin with
-a prefix derived from a DNS name they control (e.g., {"com.example."}).
+capability names defined by specific projects, vendors, or implementations begin
+with a prefix derived from a DNS name they control (e.g., {"com.example."}).
 
-Clients must compare capability identifiers using exact (case-sensitive) string
+Clients must compare capability names using exact (case-sensitive) string
 equality.
 
-**Reserved Capability Identifiers**
+**Reserved Capability Names**
 
-A _capability identifier_ must not start with an underscore {"\_"}; this is
-reserved for future usage.
+A _capability name_ must not start with an underscore {"\_"}; this is reserved
+for future usage.
 
-Capability identifiers beginning with the prefix {"graphql."} are reserved and
-must not be used outside of official GraphQL Foundation specifications.
-Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals.
+Capability names beginning with the prefix {"graphql."} are reserved and must
+not be used outside of official GraphQL Foundation specifications. Capability
+names beginning with the prefix {"graphql.rfc."} are reserved for RFC proposals.
 
-Any identifiers beginning with case-insensitive variants of {"graphql."},
+Any capability names beginning with case-insensitive variants of {"graphql."},
 {"org.graphql."} and {"gql."} are also reserved.
 
-Identifiers beginning with the prefix {"example."} are reserved for usage in
-documentation and examples only.
+Capability names beginning with the prefix {"example."} are reserved for usage
+in documentation and examples only.
 
 Note: Since IANA RFC 2606 reserves the second-level domain names
 {"example.com"}, {"example.net"}, and {"example.org"} for documentation
@@ -2394,10 +2393,9 @@ purposes, the corresponding reverse-domain prefixes {"com.example."},
 {"net.example."}, and {"org.example."} are also reserved for documentation
 purposes.
 
-Implementers should not change the meaning of capability identifiers; instead, a
-new capability identifier should be used when the meaning changes. Implementers
-should ensure that capability identifiers remain stable and version-agnostic
-where possible.
+Implementers should not change the meaning of capability names; instead, a new
+capability name should be used when the meaning changes. Implementers should
+ensure that capability names remain stable and version-agnostic where possible.
 
 Note: Capability versioning, if needed, can be indicated using dot suffixes
 (e.g. {"example.capability.v2"}).

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2348,7 +2348,7 @@ both.
 
 A _service capability_ is identified by a _capability name_ (a {QualifiedName}),
 and may optionally have a string value. All capabilities within a service must
-have unique identifiers.
+have unique names.
 
 ```graphql example
 service {

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2448,5 +2448,23 @@ Service extensions have the potential to be invalid if incorrectly defined.
 1. The Service must already be defined.
 2. Any non-repeatable directives provided must not already apply to the previous
    Service.
-3. Any capabilities provided must not already be defined on the previous
-   Service.
+3. Any capabilities provided must have unique names and must not already be
+   defined on the previous Service.
+
+The following service extension is invalid because the {"example.transport.ws"}
+capability is already defined in the previous Service:
+
+```graphql counter-example
+extend service {
+  capability example.transport.ws("wss://ws.api.example.com/graphql")
+}
+```
+
+This service extension is invalid because the capability names are not unique:
+
+```graphql counter-example
+extend service {
+  capability example.someCapability
+  capability example.someCapability
+}
+```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2399,7 +2399,8 @@ reserved for future usage.
 Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals.
+proposals. Identifiers beginning with the prefix {"example."} are reserved for
+documentation purposes.
 
 Any identifiers beginning with case-insensitive variants of {"graphql."},
 {"org.graphql."} and {"gql."} are also reserved.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2411,10 +2411,11 @@ Any identifiers beginning with case-insensitive variants of {"graphql."},
 Identifiers beginning with the prefix {"example."} are reserved for usage in
 documentation and examples only.
 
-Note: Since IANA RFC 2606 reserves the second-level domain names {example.com},
-{example.net}, and {example.org} for documentation purposes, the corresponding
-reverse-domain prefixes {"com.example."}, {"net.example."}, and {"org.example."}
-are also reserved for documentation purposes.
+Note: Since IANA RFC 2606 reserves the second-level domain names
+{"example.com"}, {"example.net"}, and {"example.org"} for documentation
+purposes, the corresponding reverse-domain prefixes {"com.example."},
+{"net.example."}, and {"org.example."} are also reserved for documentation
+purposes.
 
 Implementers should not change the meaning of capability identifiers; instead, a
 new capability identifier should be used when the meaning changes. Implementers

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -40,9 +40,9 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
-- ServiceExtension
 - TypeExtension
 - DirectiveExtension
+- ServiceExtension
 
 Type system extensions are used to represent a GraphQL type system which has
 been extended from some previous type system. For example, this might be used by
@@ -2349,7 +2349,7 @@ Directive extensions have the potential to be invalid if incorrectly defined.
 
 ## Service Definition
 
-ServiceDefinition : Description? service Directives? { ServiceCapability* }
+ServiceDefinition : Description? service Directives? { ServiceCapability\* }
 
 A GraphQL service is defined in terms of the capabilities that it offers which
 are external to the schema.
@@ -2358,7 +2358,8 @@ All capabilities within a service must have unique identifiers.
 
 ### Service Capabilities
 
-ServiceCapability : Description? capability QualifiedName ServiceCapabilityValue?
+ServiceCapability : Description? capability QualifiedName
+ServiceCapabilityValue?
 
 ServiceCapabilityValue : ( StringValue )
 
@@ -2406,10 +2407,10 @@ Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
 proposals. Identifiers beginning with the prefix {"example."} are reserved and
 should only be used for documentation purposes.
 
-Note: Since IANA RFC 2606 reserves the second-level domain names
-{example.com}, {example.net}, and {example.org} for documentation purposes, the
-corresponding reverse-domain prefixes {"com.example."}, {"net.example."}, and
-{"org.example."} are also reserved for documentation purposes.
+Note: Since IANA RFC 2606 reserves the second-level domain names {example.com},
+{example.net}, and {example.org} for documentation purposes, the corresponding
+reverse-domain prefixes {"com.example."}, {"net.example."}, and {"org.example."}
+are also reserved for documentation purposes.
 
 Any identifiers beginning with case-insensitive variants of {"graphql."},
 {"org.graphql."} and {"gql."} are also reserved.
@@ -2440,13 +2441,14 @@ websockets are supported at the current endpoint).
 
 This version of the specification defines the following capabilities:
 
-- {"graphql.operationDescriptions"} - indicates support for descriptions on operations and fragments
+- {"graphql.operationDescriptions"} - indicates support for descriptions on
+  operations and fragments
 
 ### Service Extension
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability* }
+- extend service Directives? { ServiceCapability\* }
 - extend service Directives [lookahead != `{`]
 
 Service extensions are used to represent a service which has been extended from

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2403,8 +2403,8 @@ reserved for future usage.
 Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals. Identifiers beginning with the prefix {"example."} are reserved for
-documentation purposes, and should not be used in operations.
+proposals. Identifiers beginning with the prefix {"example."} are reserved and
+should only be used for documentation purposes.
 
 Note: Since IANA RFC 2606 reserves the second-level domain names
 {example.com}, {example.net}, and {example.org} for documentation purposes, the

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2437,7 +2437,7 @@ For example, the capability {"graphql.operationDescriptions"} does not require
 additional information and thus does not specify a value; whereas a capability
 such as {"example.transport.ws"} might use the value to indicate the endpoint to
 use for websocket communications (or might omit a value to indicate that
-websockets are supported at the current endpoint).
+WebSockets are supported at the current endpoint).
 
 **Specified capabilities**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2374,7 +2374,7 @@ A _service capability_ is identified by a _capability identifier_ (a
 
 ```graphql example
 service {
-  "Indicates syntax support for descriptions on operation and fragment definitions"
+  "Descriptions on operations and fragments are supported"
   capability graphql.operationDescriptions
 
   "Websocket transport is supported via the given endpoint"
@@ -2414,7 +2414,7 @@ should ensure that capability identifiers remain stable and version-agnostic
 where possible.
 
 Note: Capability versioning, if needed, can be indicated using dot suffixes
-(e.g.{ "org.example.capability.v2"}).
+(e.g. {"org.example.capability.v2"}).
 
 This system enables incremental feature adoption and richer tooling
 interoperability, while avoiding tight coupling to specific implementations.
@@ -2434,4 +2434,4 @@ websockets are supported at the current endpoint).
 
 This version of the specification defines the following capabilities:
 
-- {"graphql.operationDescriptions"} - indicates syntax support for descriptions on operation and fragments
+- {"graphql.operationDescriptions"} - indicates support for descriptions on operations and fragments

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2446,7 +2446,7 @@ This version of the specification defines the following capabilities:
 
 ServiceExtension :
 
-- extend service Directives? { ServiceCapability+ }
+- extend service Directives? { ServiceCapability* }
 - extend service Directives [lookahead != `{`]
 
 Service extensions are used to represent a service which has been extended from

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2371,7 +2371,7 @@ both.
 
 A _service capability_ is identified by a _capability name_ (a {QualifiedName}),
 and may optionally have a string value. All capabilities within a service must
-have unique identifiers.
+have unique names.
 
 ```graphql example
 service {

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -40,6 +40,7 @@ TypeSystemDefinitionOrExtension :
 TypeSystemExtension :
 
 - SchemaExtension
+- ServiceExtension
 - TypeExtension
 - DirectiveExtension
 
@@ -2435,3 +2436,33 @@ websockets are supported at the current endpoint).
 This version of the specification defines the following capabilities:
 
 - {"graphql.operationDescriptions"} - indicates support for descriptions on operations and fragments
+
+### Service Extension
+
+ServiceExtension :
+
+- extend service Directives? { ServiceCapability+ }
+- extend service Directives [lookahead != `{`]
+
+Service extensions are used to represent a service which has been extended from
+a previous service. For example, this might be used by a GraphQL service which
+adds additional capabilities to an existing service.
+
+Note: Service extensions without additional capability definitions must not be
+followed by a {`{`} (such as a query shorthand) to avoid parsing ambiguity.
+
+```graphql example
+extend service {
+  capability example.newCapability
+}
+```
+
+**Service Validation**
+
+Service extensions have the potential to be invalid if incorrectly defined.
+
+1. The Service must already be defined.
+2. Any non-repeatable directives provided must not already apply to the previous
+   Service.
+3. Any capabilities provided must not already be defined on the previous
+   Service.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2404,7 +2404,12 @@ Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
 proposals. Identifiers beginning with the prefix {"example."} are reserved for
-documentation purposes.
+documentation purposes, and should not be used in operations.
+
+Note: Since IANA RFC 2606 reserves the second-level domain names
+{example.com}, {example.net}, and {example.org} for documentation purposes, the
+corresponding reverse-domain prefixes {"com.example."}, {"net.example."}, and
+{"org.example."} are also reserved for documentation purposes.
 
 Any identifiers beginning with case-insensitive variants of {"graphql."},
 {"org.graphql."} and {"gql."} are also reserved.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -12,6 +12,7 @@ TypeSystemDefinition :
 - SchemaDefinition
 - TypeDefinition
 - DirectiveDefinition
+- ServiceDefinition
 
 The GraphQL language includes an
 [IDL](https://en.wikipedia.org/wiki/Interface_description_language) used to
@@ -2344,3 +2345,93 @@ Directive extensions have the potential to be invalid if incorrectly defined.
 4. Any directives provided must not contain the use of a Directive which
    references the previous directive indirectly by referencing a Type or
    Directive which transitively includes a reference to the previous Directive.
+
+## Service Definition
+
+ServiceDefinition : Description? service { ServiceAttribute\* }
+
+ServiceAttribute :
+
+- ServiceCapabilities
+
+A GraphQL service is defined in terms of the capabilities that it offers which
+are external to the schema.
+
+All capabilities within a service must have unique identifiers.
+
+### Service Capabilities
+
+ServiceCapabilities: capabilities { ServiceCapability\* }
+
+ServiceCapability:
+
+- Description? QualifiedName [lookahead != `(`]
+- Description? QualifiedName ( StringValue )
+
+:: A _service capability_ describes a feature supported by the GraphQL service
+but not directly expressible via the type system. This may include support for
+new or experimental GraphQL syntactic or behavioral features, protocol support
+(such as GraphQL over WebSockets or Server-Sent Events), or additional
+operational information (such as endpoints for related services). Service
+capabilities may be supplied by the GraphQL implementation, the service, or
+both.
+
+A _service capability_ is identified by a _capability identifier_ (a
+{QualifiedName}), and may optionally have a string value.
+
+**Capability Identifier**
+
+:: A _capability identifier_ is a {QualifiedName} (a case-sensitive string value
+composed of two or more {Name} separated by a period (`.`)) that uniquely
+identifies a capability. This structure is inspired by reverse domain notation
+to encourage global uniqueness and collision-resistance; it is recommended that
+identifiers defined by specific projects, vendors, or implementations begin with
+a prefix derived from a DNS name they control (e.g., {"com.example."}).
+
+Clients must compare capability identifiers using exact (case-sensitive) string
+equality.
+
+**Reserved Capability Identifiers**
+
+A _capability identifier_ must not start with an underscore {"\_"}; this is
+reserved for future usage.
+
+Capability identifiers beginning with the prefix {"graphql."} are reserved and
+must not be used outside of official GraphQL Foundation specifications.
+Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
+proposals.
+
+Any identifiers beginning with case-insensitive variants of {"graphql."},
+{"org.graphql."} and {"gql."} are also reserved.
+
+Implementers should not change the meaning of capability identifiers; instead, a
+new capability identifier should be used when the meaning changes. Implementers
+should ensure that capability identifiers remain stable and version-agnostic
+where possible.
+
+Note: Capability versioning, if needed, can be indicated using dot suffixes
+(e.g.{ "org.example.capability.v2"}).
+
+This system enables incremental feature adoption and richer tooling
+interoperability, while avoiding tight coupling to specific implementations.
+
+**Capability value**
+
+For capabilities that require more information than a simple indication of
+support, a string value may be specified.
+
+For example, the capability {"graphql.onError"} does not require additional
+information and thus does not specify a value; whereas
+{"graphql.defaultErrorBehavior"} uses the value to indicate which _error
+behavior_ is the default.
+
+**Specified capabilities**
+
+This version of the specification defines the following capabilities:
+
+- {"graphql.defaultErrorBehavior"} - indicates the _default error behavior_ of
+  the service via the {value}. If not present, assume the _default error
+  behavior_ is {"PROPAGATE"}.
+- {"graphql.onError"} - indicates that the service allows the client to specify
+  {onError} in a request to indicate the _error behavior_ the service should use
+  for the request. No {value} is provided.

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2421,18 +2421,14 @@ interoperability, while avoiding tight coupling to specific implementations.
 For capabilities that require more information than a simple indication of
 support, a string value may be specified.
 
-For example, the capability {"graphql.onError"} does not require additional
-information and thus does not specify a value; whereas
-{"graphql.defaultErrorBehavior"} uses the value to indicate which _error
-behavior_ is the default.
+For example, the capability {"graphql.operationDescriptions"} does not require
+additional information and thus does not specify a value; whereas a capability
+such as {"example.transport.ws"} might use the value to indicate the endpoint to
+use for websocket communications (or might omit a value to indicate that
+websockets are supported at the current endpoint).
 
 **Specified capabilities**
 
 This version of the specification defines the following capabilities:
 
-- {"graphql.defaultErrorBehavior"} - indicates the _default error behavior_ of
-  the service via the {value}. If not present, assume the _default error
-  behavior_ is {"PROPAGATE"}.
-- {"graphql.onError"} - indicates that the service allows the client to specify
-  {onError} in a request to indicate the _error behavior_ the service should use
-  for the request. No {value} is provided.
+- {"graphql.operationDescriptions"} - indicates syntax support for descriptions on operation and fragments

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2471,5 +2471,23 @@ Service extensions have the potential to be invalid if incorrectly defined.
 1. The Service must already be defined.
 2. Any non-repeatable directives provided must not already apply to the previous
    Service.
-3. Any capabilities provided must not already be defined on the previous
-   Service.
+3. Any capabilities provided must have unique names and must not already be
+   defined on the previous Service.
+
+The following service extension is invalid because the {"example.transport.ws"}
+capability is already defined in the previous Service:
+
+```graphql counter-example
+extend service {
+  capability example.transport.ws("wss://ws.api.example.com/graphql")
+}
+```
+
+This service extension is invalid because the capability names are not unique:
+
+```graphql counter-example
+extend service {
+  capability example.someCapability
+  capability example.someCapability
+}
+```

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2369,9 +2369,9 @@ operational information (such as endpoints for related services). Service
 capabilities may be supplied by the GraphQL implementation, the service, or
 both.
 
-A _service capability_ is identified by a _capability identifier_ (a
-{QualifiedName}), and may optionally have a string value. All capabilities
-within a service must have unique identifiers.
+A _service capability_ is identified by a _capability name_ (a {QualifiedName}),
+and may optionally have a string value. All capabilities within a service must
+have unique identifiers.
 
 ```graphql example
 service {
@@ -2383,33 +2383,32 @@ service {
 }
 ```
 
-**Capability Identifier**
+**Capability Name**
 
-:: A _capability identifier_ is a {QualifiedName} (a case-sensitive string value
+:: A _capability name_ is a {QualifiedName} (a case-sensitive string value
 composed of two or more {Name} separated by a period (`.`)) that uniquely
 identifies a capability. This structure is inspired by reverse domain notation
 to encourage global uniqueness and collision-resistance; it is recommended that
-identifiers defined by specific projects, vendors, or implementations begin with
-a prefix derived from a DNS name they control (e.g., {"com.example."}).
+capability names defined by specific projects, vendors, or implementations begin
+with a prefix derived from a DNS name they control (e.g., {"com.example."}).
 
-Clients must compare capability identifiers using exact (case-sensitive) string
+Clients must compare capability names using exact (case-sensitive) string
 equality.
 
-**Reserved Capability Identifiers**
+**Reserved Capability Names**
 
-A _capability identifier_ must not start with an underscore {"\_"}; this is
-reserved for future usage.
+A _capability name_ must not start with an underscore {"\_"}; this is reserved
+for future usage.
 
-Capability identifiers beginning with the prefix {"graphql."} are reserved and
-must not be used outside of official GraphQL Foundation specifications.
-Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals.
+Capability names beginning with the prefix {"graphql."} are reserved and must
+not be used outside of official GraphQL Foundation specifications. Capability
+names beginning with the prefix {"graphql.rfc."} are reserved for RFC proposals.
 
-Any identifiers beginning with case-insensitive variants of {"graphql."},
+Any capability names beginning with case-insensitive variants of {"graphql."},
 {"org.graphql."} and {"gql."} are also reserved.
 
-Identifiers beginning with the prefix {"example."} are reserved for usage in
-documentation and examples only.
+Capability names beginning with the prefix {"example."} are reserved for usage
+in documentation and examples only.
 
 Note: Since IANA RFC 2606 reserves the second-level domain names
 {"example.com"}, {"example.net"}, and {"example.org"} for documentation
@@ -2417,10 +2416,9 @@ purposes, the corresponding reverse-domain prefixes {"com.example."},
 {"net.example."}, and {"org.example."} are also reserved for documentation
 purposes.
 
-Implementers should not change the meaning of capability identifiers; instead, a
-new capability identifier should be used when the meaning changes. Implementers
-should ensure that capability identifiers remain stable and version-agnostic
-where possible.
+Implementers should not change the meaning of capability names; instead, a new
+capability name should be used when the meaning changes. Implementers should
+ensure that capability names remain stable and version-agnostic where possible.
 
 Note: Capability versioning, if needed, can be indicated using dot suffixes
 (e.g. {"example.capability.v2"}).

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2348,11 +2348,7 @@ Directive extensions have the potential to be invalid if incorrectly defined.
 
 ## Service Definition
 
-ServiceDefinition : Description? service { ServiceAttribute\* }
-
-ServiceAttribute :
-
-- ServiceCapabilities
+ServiceDefinition : Description? service Directives? { ServiceCapability* }
 
 A GraphQL service is defined in terms of the capabilities that it offers which
 are external to the schema.
@@ -2361,12 +2357,9 @@ All capabilities within a service must have unique identifiers.
 
 ### Service Capabilities
 
-ServiceCapabilities: capabilities { ServiceCapability\* }
+ServiceCapability : Description? capability QualifiedName ServiceCapabilityValue?
 
-ServiceCapability:
-
-- Description? QualifiedName [lookahead != `(`]
-- Description? QualifiedName ( StringValue )
+ServiceCapabilityValue : ( StringValue )
 
 :: A _service capability_ describes a feature supported by the GraphQL service
 but not directly expressible via the type system. This may include support for
@@ -2378,6 +2371,16 @@ both.
 
 A _service capability_ is identified by a _capability identifier_ (a
 {QualifiedName}), and may optionally have a string value.
+
+```graphql example
+service {
+  "Indicates syntax support for descriptions on operation and fragment definitions"
+  capability graphql.operationDescriptions
+
+  "Websocket transport is supported via the given endpoint"
+  capability example.transport.ws("wss://api.example.com/graphql")
+}
+```
 
 **Capability Identifier**
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -2354,8 +2354,6 @@ ServiceDefinition : Description? service Directives? { ServiceCapability\* }
 A GraphQL service is defined in terms of the capabilities that it offers which
 are external to the schema.
 
-All capabilities within a service must have unique identifiers.
-
 ### Service Capabilities
 
 ServiceCapability : Description? capability QualifiedName
@@ -2372,7 +2370,8 @@ capabilities may be supplied by the GraphQL implementation, the service, or
 both.
 
 A _service capability_ is identified by a _capability identifier_ (a
-{QualifiedName}), and may optionally have a string value.
+{QualifiedName}), and may optionally have a string value. All capabilities
+within a service must have unique identifiers.
 
 ```graphql example
 service {
@@ -2404,16 +2403,18 @@ reserved for future usage.
 Capability identifiers beginning with the prefix {"graphql."} are reserved and
 must not be used outside of official GraphQL Foundation specifications.
 Identifiers beginning with the prefix {"graphql.rfc."} are reserved for RFC
-proposals. Identifiers beginning with the prefix {"example."} are reserved and
-should only be used for documentation purposes.
+proposals.
+
+Any identifiers beginning with case-insensitive variants of {"graphql."},
+{"org.graphql."} and {"gql."} are also reserved.
+
+Identifiers beginning with the prefix {"example."} are reserved for usage in
+documentation and examples only.
 
 Note: Since IANA RFC 2606 reserves the second-level domain names {example.com},
 {example.net}, and {example.org} for documentation purposes, the corresponding
 reverse-domain prefixes {"com.example."}, {"net.example."}, and {"org.example."}
 are also reserved for documentation purposes.
-
-Any identifiers beginning with case-insensitive variants of {"graphql."},
-{"org.graphql."} and {"gql."} are also reserved.
 
 Implementers should not change the meaning of capability identifiers; instead, a
 new capability identifier should be used when the meaning changes. Implementers
@@ -2421,7 +2422,7 @@ should ensure that capability identifiers remain stable and version-agnostic
 where possible.
 
 Note: Capability versioning, if needed, can be indicated using dot suffixes
-(e.g. {"org.example.capability.v2"}).
+(e.g. {"example.capability.v2"}).
 
 This system enables incremental feature adoption and richer tooling
 interoperability, while avoiding tight coupling to specific implementations.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -85,13 +85,14 @@ operation.
 
 ## Schema Introspection
 
-The schema introspection system is accessible from the meta-fields `__schema`
-and `__type` which are accessible from the type of the root of a query
-operation.
+The schema introspection system is accessible from the meta-fields `__schema`,
+`__type` and `__service` which are accessible from the type of the root of a
+query operation.
 
 ```graphql
 __schema: __Schema!
 __type(name: String!): __Type
+__service: __Service!
 ```
 
 Like all meta-fields, these are implicit and do not appear in the fields list in
@@ -227,6 +228,16 @@ enum __DirectiveLocation {
   ENUM_VALUE
   INPUT_OBJECT
   INPUT_FIELD_DEFINITION
+}
+
+type __Service {
+  capabilities: [__Capability!]!
+}
+
+type __Capability {
+  identifier: String!
+  description: String
+  value: String
 }
 ```
 
@@ -512,3 +523,29 @@ Fields\:
     {true}, deprecated arguments are also returned.
 - `isRepeatable` must return a Boolean that indicates if the directive may be
   used repeatedly at a single location.
+
+### The \_\_Service Type
+
+The `__Service` type is returned from the `__service` meta-field and provides
+information about the GraphQL service, most notably about its capabilities.
+
+Note: Services implementing an older version of this specification may not
+support the `__service` meta-field or `__Service` type. Support may be probed
+using the introspection query: `{ __type(name: "__Service") { name } }`, a
+{null} result indicates lack of support.
+
+Fields\:
+
+- `capabilities` must return a list of `__Capability` detailing each _service
+  capability_ supported by the service.
+
+### The \_\_Capability Type
+
+A `__Capability` object describes a specific _service capability_, and has the
+following fields\:
+
+- `identifier` must return the string _capability identifier_ uniquely
+  identifying this service capability.
+- `description` may return a String or {null}.
+- `value` the String value of the service capability, or {null} if there is no
+  associated value.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -235,7 +235,7 @@ type __Service {
 }
 
 type __Capability {
-  identifier: String!
+  name: String!
   description: String
   value: String
 }
@@ -544,8 +544,8 @@ Fields\:
 A `__Capability` object describes a specific _service capability_, and has the
 following fields\:
 
-- `identifier` must return the string _capability identifier_ uniquely
-  identifying this service capability.
+- `name` must return the string _capability name_ uniquely identifying this
+  service capability.
 - `description` may return a String or {null}.
 - `value` the String value of the service capability, or {null} if there is no
   associated value.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -231,6 +231,7 @@ enum __DirectiveLocation {
 }
 
 type __Service {
+  description: String
   capabilities: [__Capability!]!
 }
 
@@ -536,6 +537,7 @@ using the introspection query: `{ __type(name: "__Service") { name } }`, a
 
 Fields\:
 
+- `description` may return a String or {null}.
 - `capabilities` must return a list of `__Capability` detailing each _service
   capability_ supported by the service.
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -238,7 +238,7 @@ type __Service {
 }
 
 type __Capability {
-  identifier: String!
+  name: String!
   description: String
   value: String
 }
@@ -554,8 +554,8 @@ Fields\:
 A `__Capability` object describes a specific _service capability_, and has the
 following fields\:
 
-- `identifier` must return the string _capability identifier_ uniquely
-  identifying this service capability.
+- `name` must return the string _capability name_ uniquely identifying this
+  service capability.
 - `description` may return a String or {null}.
 - `value` the String value of the service capability, or {null} if there is no
   associated value.

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -234,6 +234,7 @@ enum __DirectiveLocation {
 }
 
 type __Service {
+  description: String
   capabilities: [__Capability!]!
 }
 
@@ -546,6 +547,7 @@ using the introspection query: `{ __type(name: "__Service") { name } }`, a
 
 Fields\:
 
+- `description` may return a String or {null}.
 - `capabilities` must return a list of `__Capability` detailing each _service
   capability_ supported by the service.
 

--- a/spec/Section 4 -- Introspection.md
+++ b/spec/Section 4 -- Introspection.md
@@ -85,13 +85,14 @@ operation.
 
 ## Schema Introspection
 
-The schema introspection system is accessible from the meta-fields `__schema`
-and `__type` which are accessible from the type of the root of a query
-operation.
+The schema introspection system is accessible from the meta-fields `__schema`,
+`__type` and `__service` which are accessible from the type of the root of a
+query operation.
 
 ```graphql
 __schema: __Schema!
 __type(name: String!): __Type
+__service: __Service!
 ```
 
 Like all meta-fields, these are implicit and do not appear in the fields list in
@@ -230,6 +231,16 @@ enum __DirectiveLocation {
   INPUT_OBJECT
   INPUT_FIELD_DEFINITION
   DIRECTIVE_DEFINITION
+}
+
+type __Service {
+  capabilities: [__Capability!]!
+}
+
+type __Capability {
+  identifier: String!
+  description: String
+  value: String
 }
 ```
 
@@ -522,3 +533,29 @@ Fields\:
   otherwise {false}.
 - `deprecationReason` returns the reason why this directive is deprecated, or
   null if this directive is not deprecated.
+
+### The \_\_Service Type
+
+The `__Service` type is returned from the `__service` meta-field and provides
+information about the GraphQL service, most notably about its capabilities.
+
+Note: Services implementing an older version of this specification may not
+support the `__service` meta-field or `__Service` type. Support may be probed
+using the introspection query: `{ __type(name: "__Service") { name } }`, a
+{null} result indicates lack of support.
+
+Fields\:
+
+- `capabilities` must return a list of `__Capability` detailing each _service
+  capability_ supported by the service.
+
+### The \_\_Capability Type
+
+A `__Capability` object describes a specific _service capability_, and has the
+following fields\:
+
+- `identifier` must return the string _capability identifier_ uniquely
+  identifying this service capability.
+- `description` may return a String or {null}.
+- `value` the String value of the service capability, or {null} if there is no
+  associated value.


### PR DESCRIPTION
_(Extracted and reworked from the error behaviors PR (#1163) to stand alone, since it has broader utility and can progress faster alone.)_

This PR introduces "service capabilities" - a mechanism for GraphQL services to advertise features and configuration that exist outside the type system - for example support for syntax features (executable descriptions, fragment arguments, document directives, etc), details of transport support (websocket endpoint, SSE endpoint, how to be notified of new schema versions), and other details that can enable automated client configuration.

### Motivation

In addition to being a prerequisite of the [error behaviors](https://github.com/graphql/graphql-spec/pull/1163) proposal, this is a desired feature for composite schemas and a key component of [The GraphQL Golden Path Initiative](https://github.com/graphql/graphql-wg/issues/1887) (specifically enabling **client auto-configuration**).

The goal is that a user can point tooling at a GraphQL endpoint and much of the configuration can be implied based on the service's advertised capabilities - this massively reduces the amount of "out of band" communication required.

Example use cases:
- Does the service support fragment arguments, or must the client transpile them?
- Does it support customizing error propagation behavior?
- Are subscriptions available over WebSockets? If so, what endpoint and protocol?
- Does it support incremental delivery (`@defer`/`@stream`)? Which version?
- Does it support automated document persistence? Which protocol?

### Why "capabilities" not "metadata"?

Capabilities inform automated tooling/client decisions and actions. Metadata is ancillary and often intended for human consumption. The name "capabilities" is intentional - it signals the purpose and discourages using this system as a dumping ground for arbitrary metadata. Every capability should be actionable by clients or tooling.

### Design

**Introspection** via `__service: __Service` meta-field (similar to `__schema: __Schema`):

```graphql
type __Service {
  capabilities: [__Capability!]!
}

type __Capability {
  identifier: String!
  description: String
  value: String
}
```

Support can be probed via: `{ __type(name: "__Service") { name } }` - if no result, then the service does not support service capabilities.

### SDL syntax

Slightly changed from previous proposals, here's the syntax I now propose:

```graphql
service {
  "Descriptions on operations and fragments are supported"
  capability graphql.operationDescriptions

  "WebSocket transport is supported via the given endpoint"
  capability example.transport.ws("wss://api.example.com/graphql")
}

extend service {
  capability com.example.customFeature
}
```

Notes on this choice:

- Capabilities without "values" should look neat
- Capabilities with values followed by capabilities without descriptions should not introduce easy syntax clashes (`service { capability foo.bar "Value" capability foo.baz }` would apply `"Value"` as the description for `foo.baz` rather than the value for `foo.bar`)
- The `extend` syntax feels very natural
- Avoids double-nesting of curly braces
- Leaves space for additional `service` properties in future
- Inserting other keywords between capabilities is acceptable, in the same way that inserting different directives between repeatable directives is acceptable
- A directive-based syntax could be used (`service @capability(identifier: "...", value: "...")`), but the `service` keyword already introduces new syntax so it doesn't seem necessary to be constrained to using ugly directives when a neater and more palatable syntax is available; this also allows for descriptions for each capability.

### Capability identifiers

A `QualifiedName` syntax (`Name(.Name)+`) inspired by reverse-domain notation encourages global uniqueness. The `graphql.` prefix is reserved for official GraphQL Foundation specifications (not just the main spec; e.g. `graphql.http.*` could be used by the GraphQL-over-HTTP spec).

