### PR TITLE
fix: field selection set final values

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -419,8 +419,7 @@ discrete piece of information available to request within a selection set.
 Some fields describe complex data or relationships to other data. In order to
 further explore this data, a field may itself contain a selection set, allowing
 for deeply nested requests. All GraphQL operations must specify their selections
-down to fields which return scalar or enum values to ensure an unambiguously
-shaped response.
+down to _leaf fields_ to ensure an unambiguously shaped response.
 
 For example, this operation selects fields of complex data and relationships
 down to scalar values.

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -419,8 +419,8 @@ discrete piece of information available to request within a selection set.
 Some fields describe complex data or relationships to other data. In order to
 further explore this data, a field may itself contain a selection set, allowing
 for deeply nested requests. All GraphQL operations must specify their selections
-down to fields which return scalar values to ensure an unambiguously shaped
-response.
+down to fields which return scalar or enum values to ensure an unambiguously
+shaped response.
 
 For example, this operation selects fields of complex data and relationships
 down to scalar values.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -726,7 +726,7 @@ fragment conflictingDifferingResponses on Pet {
 
 **Explanatory Text**
 
-A field subselection is not allowed on leaf fields. A leaf field is any field
+:: A field subselection is not allowed on leaf fields. A _leaf field_ is any field
 with a scalar or enum unwrapped type.
 
 The following is valid.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -726,8 +726,8 @@ fragment conflictingDifferingResponses on Pet {
 
 **Explanatory Text**
 
-:: A field subselection is not allowed on leaf fields. A _leaf field_ is any field
-with a scalar or enum unwrapped type.
+:: A field subselection is not allowed on leaf fields. A _leaf field_ is any
+field with a scalar or enum unwrapped type.
 
 The following is valid.
 


### PR DESCRIPTION
AFAIK scalar and enum values are considered to be distinct throughout the specification so I think this would be more correct description of field selection.

I didn't change the sentence below the modified one because it doesn't contain any enum values, but I may add some if that'd be beneficial.

It really is a nitpick, but I stopped on it while reading the spec.