### PR TITLE
Editorial: consistent field ordering in Circular References examples

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -1622,8 +1622,8 @@ This example of a circularly-referenced input type is invalid as the field
 
 ```graphql counter-example
 input Example {
-  value: String
   self: Example!
+  value: String
 }
 ```
 


### PR DESCRIPTION
In the section on Input Object [Circular References](https://spec.graphql.org/draft/#sec-Input-Objects.Circular-References), there are a number of examples that use the format
```graphql
input Example {
  self: Example
  value: String
}
```

Specifically, the input objects define a `value: String` field that is the second field in the type definition.

One of the definitions reverses the order of the fields, putting the `value: String` definition first.

This is a pedantic edit to change the ordering so that it has the same field ordering as the other examples in this section.

Suggested by @benjie in https://github.com/graphql/graphql-spec/pull/1211#discussion_r2892768720.