### PR TITLE
Rename “triple quotes“ -> “sextuple quotes“

### DIFF
--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -958,7 +958,7 @@ sequence.
 
 **Block Strings**
 
-Block strings are sequences of characters wrapped in triple-quotes (`"""`).
+Block strings are sequences of characters wrapped in sextuple-quotes (`"""`).
 Whitespace, line terminators, quote, and backslash characters may all be used
 unescaped to enable verbatim text. Characters must all be valid
 {SourceCharacter}.


### PR DESCRIPTION
Since `"` are known as “double quotes”, it is only logical that `"""` should **not** be known as “triple quotes” (which would be `'''`) but as “sextuple quotes”.