### PR TITLE
Allow empty selection sets

### DIFF
--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -156,7 +156,7 @@ OperationDefinition :
 
 OperationType : one of `query` `mutation` `subscription`
 
-SelectionSet : { Selection+ }
+SelectionSet : { Selection\* }
 
 Selection :
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -383,7 +383,7 @@ Note: many examples below will use the query shorthand syntax.
 
 ## Selection Sets
 
-SelectionSet : { Selection+ }
+SelectionSet : { Selection\* }
 
 Selection :
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -716,7 +716,7 @@ Where `name` is a field that will yield a {String} value, and `age` is a field
 that will yield an {Int} value, and `picture` is a field that will yield a `Url`
 value.
 
-A query of an object value must select at least one field. This selection of
+A query of an object value must be made via a selection set. This selection of
 fields will yield an ordered map containing exactly the subset of the object
 queried, which should be represented in the order in which they were queried.
 Only fields that are declared on the object type may validly be queried on that
@@ -1933,9 +1933,8 @@ to denote a field that uses a Non-Null type like this: `name: String!`.
 **Nullable vs. Optional**
 
 Fields are _always_ optional within the context of a _selection set_, a field
-may be omitted and the selection set is still valid (so long as the selection
-set does not become empty). However fields that return Non-Null types will never
-return the value {null} if queried.
+may be omitted and the selection set is still valid. However fields that return
+Non-Null types will never return the value {null} if queried.
 
 Inputs (such as field arguments), are always optional by default. However a
 non-null input type is required. In addition to not accepting the value {null},

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -747,7 +747,7 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 }
 ```
 
-An empty selection is still a selection, so the following is also invalid.
+An empty selection is a selection, so the following is also invalid.
 
 ```graphql counter-example
 fragment scalarEmptySelectionsNotAllowedOnInt on Dog {

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -747,6 +747,14 @@ fragment scalarSelectionsNotAllowedOnInt on Dog {
 }
 ```
 
+An empty selection is still a selection, so the following is also invalid.
+
+```graphql counter-example
+fragment scalarEmptySelectionsNotAllowedOnInt on Dog {
+  barkVolume {}
+}
+```
+
 Conversely, non-leaf fields must have a field subselection. A non-leaf field is
 any field with an object, interface, or union unwrapped type.
 
@@ -785,6 +793,14 @@ query directQueryOnObjectWithSubFields {
   human {
     name
   }
+}
+```
+
+The subselection is permitted to be empty, so the following is also valid.
+
+```graphql example
+query directQueryOnObjectWithEmptySelection {
+  human {}
 }
 ```
 

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -720,9 +720,9 @@ fragment conflictingDifferingResponses on Pet {
 - For each {selection} in the document:
   - Let {selectionType} be the unwrapped result type of {selection}.
   - If {selectionType} is a scalar or enum:
-    - The subselection set of that selection must be empty.
+    - The subselection set of that selection must not be present.
   - If {selectionType} is an interface, union, or object:
-    - The subselection set of that selection must not be empty.
+    - The subselection set of that selection must be present.
 
 **Explanatory Text**
 


### PR DESCRIPTION
Since 2015 we've required selection sets to contain at least one field; however it's always been possible to have an empty object returned:

```graphql
type A { a: Int }
type B { b: Int }
union U = A | B
type Query { u: U }

query {
  u {
    ... on A { __typename }
  }
}
```

Here, if `u` returns type `B` the result will be `{"data":{"u":{}}}` - i.e. an empty object.

GraphQL clients are getting smarter and smarter, and it's common to have client-side extensions such as [Apollo's @client](https://www.apollographql.com/docs/react/local-state/local-resolvers), [Relay Resolvers](https://relay.dev/docs/v15.0.0/guides/relay-resolvers/) or [`@mock`'d fields](https://gaps.graphql.org/GAP-10/draft/). In all of these cases, any selections of these fields need to be removed before the document is sent to the server. But what happens when all the fields in the selection set are to be removed?

```graphql
  query LaunchDetails($launchId: ID!) {
    launch(id: $launchId) {
      isInCart @client
      site @client
    }
  }
```

There are many options (add `__typename`, remove `launch`, throw error, ...), but the safest solution is to allow the selection set to be empty. Hence, this PR.

- Fixes #674