### PR TITLE
Allow empty object types

### DIFF
--- a/spec/Appendix C -- Grammar Summary.md
+++ b/spec/Appendix C -- Grammar Summary.md
@@ -156,7 +156,7 @@ OperationDefinition :
 
 OperationType : one of `query` `mutation` `subscription`
 
-SelectionSet : { Selection+ }
+SelectionSet : { Selection\* }
 
 Selection :
 

--- a/spec/Section 2 -- Language.md
+++ b/spec/Section 2 -- Language.md
@@ -383,7 +383,7 @@ Note: many examples below will use the query shorthand syntax.
 
 ## Selection Sets
 
-SelectionSet : { Selection+ }
+SelectionSet : { Selection\* }
 
 Selection :
 

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -716,7 +716,7 @@ Where `name` is a field that will yield a {String} value, and `age` is a field
 that will yield an {Int} value, and `picture` is a field that will yield a `Url`
 value.
 
-A query of an object value must select at least one field. This selection of
+A query of an object value must be made via a selection set. This selection of
 fields will yield an ordered map containing exactly the subset of the object
 queried, which should be represented in the order in which they were queried.
 Only fields that are declared on the object type may validly be queried on that
@@ -1933,9 +1933,8 @@ to denote a field that uses a Non-Null type like this: `name: String!`.
 **Nullable vs. Optional**
 
 Fields are _always_ optional within the context of a _selection set_, a field
-may be omitted and the selection set is still valid (so long as the selection
-set does not become empty). However fields that return Non-Null types will never
-return the value {null} if queried.
+may be omitted and the selection set is still valid. However fields that return
+Non-Null types will never return the value {null} if queried.
 
 Inputs (such as field arguments), are always optional by default. However a
 non-null input type is required. In addition to not accepting the value {null},

--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -921,8 +921,7 @@ Objects are never valid inputs.
 Object types have the potential to be invalid if incorrectly defined. This set
 of rules must be adhered to by every Object type in a GraphQL schema.
 
-1. An Object type must define one or more fields.
-2. For each field of an Object type:
+1. For each field of an Object type:
    1. The field must have a unique name within that Object type; no two fields
       may share the same name.
    2. The field must not have a name which begins with the characters {"\_\_"}
@@ -940,8 +939,8 @@ of rules must be adhered to by every Object type in a GraphQL schema.
          1. The `@deprecated` directive must not be applied to this argument.
       5. If the argument has a default value it must be compatible with
          {argumentType} as per the coercion rules for that type.
-3. An object type may declare that it implements one or more unique interfaces.
-4. An object type must be a super-set of all interfaces it implements:
+2. An object type may declare that it implements one or more unique interfaces.
+3. An object type must be a super-set of all interfaces it implements:
    1. Let this object type be {objectType}.
    2. For each interface declared implemented as {interfaceType},
       {IsValidImplementation(objectType, interfaceType)} must be {true}.

--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -720,9 +720,9 @@ fragment conflictingDifferingResponses on Pet {
 - For each {selection} in the document:
   - Let {selectionType} be the unwrapped result type of {selection}.
   - If {selectionType} is a scalar or enum:
-    - The subselection set of that selection must be empty.
+    - The subselection set of that selection must not be present.
   - If {selectionType} is an interface, union, or object:
-    - The subselection set of that selection must not be empty.
+    - The subselection set of that selection must be present.
 
 **Explanatory Text**
 


### PR DESCRIPTION
**Merge first:**

- #1227 

---

Since 2015 we've always required an object type to define at least 1 field. As we continue to explore GraphQL's position in the new AI-world, we realise that we need schema subsets that represents part of a larger interface, in these cases it's sometimes useful to leave in type references without including full definitions of those types:

```graphql
type Query {
  topAuthors: [Author!]
}
type Author {
  name: String!
  salesVolume: Int
  averageRating: Float
  topBooks: [Book!]
  mediaCoverage: [Article!]
  recentPublishers: [Publisher!]
}
type Book {}
type Article {}
type Publisher {}
```

Here the AI can see a basic schema it can write queries against, but it can also ask to expand the parts of the schema that are relevant to its interests - e.g. books or articles or publishers - without wasting context on things it doesn't care about.

We can make a schema like this valid by including at least one field on each of these types, but it's hard for a tool to know which field(s) to include, and not including fields makes it much more obvious to the LLM that the schema is partial. Making this partial schema itself valid would be helpful for tooling.

AI aside:

- This is also very useful for mutation payloads where no obvious value exists to return yet but we may wish to expand in future. Currently `type MyMutationPayload { success: Boolean! }` is used as a workaround, but it's messy.
- This is also very useful for schema evolution - it allows you to create a type before you know what it will contain, and allows you to deprecate all fields of a type without the schema being invalid.
- This also enables mutation-only schemas whilst still supporting introspection #490 

Related:

- Fixes https://github.com/graphql/graphql-spec/issues/568