### PR TITLE
A schema with all deprecated elements removed must itself be valid

### DIFF
--- a/spec/Section 3 -- Type System.md
+++ b/spec/Section 3 -- Type System.md
@@ -136,6 +136,9 @@ All types and directives defined within a schema must not have a name which
 begins with {"\_\_"} (two underscores), as this is used exclusively by GraphQL's
 introspection system.
 
+If a GraphQL schema contains any deprecated _schema element_, a copy of the
+schema that omits all deprecated _schema element_ must itself be valid.
+
 ### Root Operation Types
 
 :: A schema defines the initial _root operation type_ for each kind of operation
@@ -968,7 +971,6 @@ IsValidImplementation(type, implementedType):
        2. Let {implementedFieldType} be the return type of {implementedField}.
        3. {IsValidImplementationFieldType(fieldType, implementedFieldType)} must
           be {true}.
-    6. If {field} is deprecated then {implementedField} must also be deprecated.
 
 IsValidImplementationFieldType(fieldType, implementedFieldType):
 


### PR DESCRIPTION
As a precursor to deprecating other schema elements (object types, etc), I figured it would be best to simplify the rule: the schema with all deprecated elements removed should itself be valid. This is a breaking change for servers currently (could mark a previously valid schema as invalid), but solvable in a non-breaking way by removing `@deprecated` directives, or (once they are supported) adding `@deprecated` to object types and other positions. It's non-breaking for clients.

This also aligns with #1230 wherein the schema with all deprecated elements removed is represented via `{ __schema(includeDeprecated: false) { ... } }`.