### PR TITLE
Fixes for incremenal delivery integration branch

### DIFF
--- a/spec/Section 5 -- Validation.md
+++ b/spec/Section 5 -- Validation.md
@@ -560,7 +560,7 @@ FieldsInSetCanMerge(set):
   {set} including visiting fragments and inline fragments.
 - Given each pair of distinct members {fieldA} and {fieldB} in {fieldsForName}:
   - {SameResponseShape(fieldA, fieldB)} must be true.
-  - {SameStreamDirective(fieldA, fieldB)} must be true.
+  - {HasNoOverlappingStreams(fieldA, fieldB)} must be true.
   - If the parent types of {fieldA} and {fieldB} are equal or if either is not
     an Object Type:
     - {fieldA} and {fieldB} must have identical field names.
@@ -596,14 +596,10 @@ SameResponseShape(fieldA, fieldB):
   - If {SameResponseShape(subfieldA, subfieldB)} is {false}, return {false}.
 - Return {true}.
 
-SameStreamDirective(fieldA, fieldB):
+HasNoOverlappingStreams(fieldA, fieldB):
 
 - If neither {fieldA} nor {fieldB} has a directive named `stream`.
   - Return {true}.
-- If both {fieldA} and {fieldB} have a directive named `stream`.
-  - Let {streamA} be the directive named `stream` on {fieldA}.
-  - Let {streamB} be the directive named `stream` on {fieldB}.
-  - If {streamA} and {streamB} have identical sets of arguments, return {true}.
 - Return {false}.
 
 Note: In prior versions of the spec the term "composite" was used to signal a

--- a/spec/Section 7 -- Response.md
+++ b/spec/Section 7 -- Response.md
@@ -433,10 +433,10 @@ An _incremental pending notice_ must contain entries with the keys {"id"} and
 {"path"}, and may contain an entry with key {"label"}.
 
 The value of {"id"} must be a string. This {"id"} should be used by clients to
-correlate incremental pending notices with _incremental result_ and _completed
-result_. The {"id"} value must be unique across the entire _incremental stream_
-response. There must not be any other incremental pending notice in the
-_incremental stream_ with the same {"id"}.
+correlate incremental pending notices with _incremental result_ and _incremental
+completion notice_. The {"id"} value must be unique across the entire
+_incremental stream_ response. There must not be any other incremental pending
+notice in the _incremental stream_ with the same {"id"}.
 
 The value of {"path"} must be a _response position_. When the incremental
 pending notice is associated with a `@stream` directive, it indicates the list
@@ -574,8 +574,8 @@ and may contain an entry with the key {"errors"}.
 The value of {"id"} must be a string referencing its _associated incremental
 pending notice_. The associated incremental pending notice must appear either in
 the _initial incremental stream result_, in a prior _incremental stream update
-result_, or in the same _incremental stream update result_ as the _completed
-result_ that references it.
+result_, or in the same _incremental stream update result_ as the _incremental
+completion notice_ that references it.
 
 The value of {"errors"}, if present, informs clients that the delivery of the
 data from the _associated incremental pending notice_ has failed, due to an


### PR DESCRIPTION
In a previous discussion we had decided to validation agains any overlapping stream fields. This has already been implemented in graphql-js for some time
See https://github.com/graphql/defer-stream-wg/discussions/100 and https://github.com/graphql/graphql-js/pull/4342

Additionally there were two instances of _completed result_ that was not missed and not renamed to _incremental
completion notice_